### PR TITLE
Added a ADE20K and COCO2017 data conversion scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,8 @@ dmypy.json
 
 *.swo
 *.swp
+
+# Spacemacs
+._#*
+.#*
+.vscode/

--- a/streaming/vision/convert/ade20k.py
+++ b/streaming/vision/convert/ade20k.py
@@ -1,0 +1,120 @@
+# Copyright 2022 MosaicML Composer authors
+
+"""ADE20K streaming dataset conversion scripts."""
+
+import os
+import random
+from argparse import ArgumentParser, Namespace
+from glob import glob
+from tqdm import tqdm
+from typing import Any, Dict, Iterable, List, Tuple
+
+from streaming.base import MDSWriter
+from streaming.vision.convert.base import get_list_arg
+
+
+def parse_args() -> Namespace:
+    """Parse command line arguments.
+
+    Args:
+        Namespace: Command line arguments.
+    """
+    args = ArgumentParser()
+    args.add_argument('--in', type=str, default='./datasets/ade20k/', help='Location of Input dataset. Default: ./datasets/ade20k/')
+    args.add_argument('--out', type=str, default='./datasets/mds/ade20k/', help='Location to store the compressed dataset. Default: ./datasets/mds/ade20k/')
+    args.add_argument('--splits', type=str, default='train,val', help='Split to use. Default: train,val')
+    args.add_argument('--compression', type=str, default='zstd:7', help='Compression algorithm to use. Default: zstd:7')
+    args.add_argument('--hashes', type=str, default='sha1,xxh64', help='Hashing algorithms to apply to shard files. Default: sha1,xxh64')
+    args.add_argument('--limit', type=int, default=1 << 25, help='Shard size limit, after which point to start a new shard. Default: 33554432')
+    args.add_argument('--progbar', type=bool, default=True, help='tqdm progress bar. Default: True')
+    args.add_argument('--leave', type=bool, default=False, help='Keeps all traces of the progressbar upon termination of iteration. Default: False')
+    return args.parse_args()
+
+
+def get(in_root: str, split: str, shuffle: bool) -> List[Tuple[str, str, str]]:
+    """Collect the samples for this dataset split.
+
+    Args:
+        in_root (str): Input dataset directory.
+        split (str): Split name.
+        shuffle (bool): Whether to shuffle the samples before writing.
+
+    Returns:
+        List of samples of (uid, image_filename, annotation_filename).
+    """
+    # Get uids
+    split_images_in_dir = os.path.join(in_root, 'images', split)
+    split_annotations_in_dir = os.path.join(in_root, 'annotations', split)
+    image_glob_pattern = os.path.join(split_images_in_dir, f'ADE_{split}_*.jpg')
+    images = sorted(glob(image_glob_pattern))
+    uids = [s.strip('.jpg')[-8:] for s in images]
+
+    # Remove some known corrupted uids from 'train' split
+    if split == 'train':
+        corrupted_uids = ['00003020', '00001701', '00013508', '00008455']
+        uids = [uid for uid in uids if uid not in corrupted_uids]
+
+    # Create samples
+    samples = [(uid, os.path.join(split_images_in_dir, f'ADE_{split}_{uid}.jpg'),
+                os.path.join(split_annotations_in_dir, f'ADE_{split}_{uid}.png')) for uid in uids]
+
+    # Optionally shuffle samples at dataset creation for extra randomness
+    if shuffle:
+        random.shuffle(samples)
+
+    return samples
+
+
+def each(samples: List[Tuple[str, str, str]]) -> Iterable[Dict[str, Any]]:
+    """Generator over each dataset sample.
+
+    Args:
+        samples (list): List of samples of (uid, image_filename, annotation_filename).
+
+    Yields:
+        Sample dicts.
+    """
+    for (uid, image_file, annotation_file) in samples:
+        uid = uid.encode('utf-8')
+        image = open(image_file, 'rb').read()
+        annotation = open(annotation_file, 'rb').read()
+        yield {
+            'uid': uid,
+            'image': image,
+            'annotation': annotation,
+        }
+
+
+def main(args: Namespace) -> None:
+    """Main: create streaming ADE20K dataset.
+
+    Args:
+        args (Namespace): Command line arguments.
+    """
+    fields = {
+        'uid': 'bytes',
+        'image': 'bytes',
+        'annotation': 'bytes'
+    }
+
+    for (split, expected_num_samples, shuffle) in [
+        ('train', 20206, True),
+        ('val', 2000, False),
+    ]:
+        # Get samples
+        samples = get(in_root=getattr(args, 'in'), split=split, shuffle=shuffle)
+        if len(samples) != expected_num_samples:
+            raise ValueError(f'Number of samples in a dataset doesn\'t match. Expected {expected_num_samples}, but got {len(samples)}')
+
+        split_images_out_dir = os.path.join(args.out, split)
+        hashes = get_list_arg(args.hashes)
+
+        if args.progbar:
+            samples = tqdm(samples, leave=args.leave)
+
+        with MDSWriter(split_images_out_dir, fields, args.compression, hashes, args.limit) as out:
+            for sample in each(samples):
+                out.write(sample)
+
+if __name__ == '__main__':
+    main(parse_args())

--- a/streaming/vision/convert/ade20k.py
+++ b/streaming/vision/convert/ade20k.py
@@ -21,42 +21,54 @@ def parse_args() -> Namespace:
         Namespace: Command line arguments.
     """
     args = ArgumentParser()
-    args.add_argument('--in',
-                      type=str,
-                      default='./datasets/ade20k/',
-                      help='Location of Input dataset. Default: ./datasets/ade20k/')
     args.add_argument(
-        '--out',
+        '--in_root',
+        type=str,
+        default='./datasets/ade20k/',
+        help='Location of Input dataset. Default: ./datasets/ade20k/',
+    )
+    args.add_argument(
+        '--out_root',
         type=str,
         default='./datasets/mds/ade20k/',
-        help='Location to store the compressed dataset. Default: ./datasets/mds/ade20k/')
-    args.add_argument('--splits',
-                      type=str,
-                      default='train,val',
-                      help='Split to use. Default: train,val')
-    args.add_argument('--compression',
-                      type=str,
-                      default='zstd:7',
-                      help='Compression algorithm to use. Default: zstd:7')
-    args.add_argument('--hashes',
-                      type=str,
-                      default='sha1,xxh64',
-                      help='Hashing algorithms to apply to shard files. Default: sha1,xxh64')
+        help='Location to store the compressed dataset. Default: ./datasets/mds/ade20k/',
+    )
+    args.add_argument(
+        '--splits',
+        type=str,
+        default='train,val',
+        help='Split to use. Default: train,val',
+    )
+    args.add_argument(
+        '--compression',
+        type=str,
+        default='',
+        help='Compression algorithm to use. Default: None',
+    )
+    args.add_argument(
+        '--hashes',
+        type=str,
+        default='sha1,xxh64',
+        help='Hashing algorithms to apply to shard files. Default: sha1,xxh64',
+    )
     args.add_argument(
         '--limit',
         type=int,
-        default=1 << 25,
-        help='Shard size limit, after which point to start a new shard. Default: 33554432')
-    args.add_argument('--progbar',
-                      type=int,
-                      default=1,
-                      help='tqdm progress bar. Default: 1 (Act as True)')
+        default=1 << 22,
+        help='Shard size limit, after which point to start a new shard. Default: 4194304',
+    )
+    args.add_argument(
+        '--progbar',
+        type=int,
+        default=1,
+        help='tqdm progress bar. Default: 1 (Act as True)',
+    )
     args.add_argument(
         '--leave',
         type=int,
         default=0,
         help=
-        'Keeps all traces of the progressbar upon termination of iteration. Default: 0 (Act as False)'
+        'Keeps all traces of the progressbar upon termination of iteration. Default: 0 (Act as False)',
     )
     return args.parse_args()
 
@@ -132,13 +144,13 @@ def main(args: Namespace) -> None:
         ('val', 2000, False),
     ]:
         # Get samples
-        samples = get(in_root=getattr(args, 'in'), split=split, shuffle=shuffle)
+        samples = get(in_root=args.in_root, split=split, shuffle=shuffle)
         if len(samples) != expected_num_samples:
             raise ValueError(
                 f'Number of samples in a dataset doesn\'t match. Expected {expected_num_samples}, but got {len(samples)}'
             )
 
-        split_images_out_dir = os.path.join(args.out, split)
+        split_images_out_dir = os.path.join(args.out_root, split)
         hashes = get_list_arg(args.hashes)
 
         if args.progbar:

--- a/streaming/vision/convert/base.py
+++ b/streaming/vision/convert/base.py
@@ -5,7 +5,7 @@ import numpy as np
 from torch.utils.data import Dataset
 from tqdm import tqdm
 
-from ...base import MDSWriter
+from streaming.base import MDSWriter
 
 
 def get_list_arg(text: str) -> List[str]:

--- a/streaming/vision/convert/cifar10.py
+++ b/streaming/vision/convert/cifar10.py
@@ -2,7 +2,7 @@ from argparse import ArgumentParser, Namespace
 
 from torchvision.datasets import CIFAR10
 
-from .base import convert_image_class_dataset, get_list_arg
+from streaming.vision.convert.base import convert_image_class_dataset, get_list_arg
 
 
 def parse_args() -> Namespace:
@@ -15,7 +15,7 @@ def parse_args() -> Namespace:
     args.add_argument('--in', type=str, default='/datasets/cifar10/')
     args.add_argument('--out', type=str, default='/datasets/mds/cifar10/')
     args.add_argument('--splits', type=str, default='train,val')
-    args.add_argument('--compression', type=str, default='zstd:7')
+    args.add_argument('--compression', type=str, default='')
     args.add_argument('--hashes', type=str, default='sha1,xxh64')
     args.add_argument('--limit', type=int, default=1 << 20)
     args.add_argument('--progbar', type=int, default=1)

--- a/streaming/vision/convert/coco.py
+++ b/streaming/vision/convert/coco.py
@@ -1,0 +1,188 @@
+# Copyright 2022 MosaicML Composer authors
+
+"""COCO 2017 streaming dataset conversion scripts."""
+
+import os
+import json
+from tqdm import tqdm
+import torch
+import numpy as np
+from PIL import Image
+from torch.utils.data import Dataset
+from argparse import ArgumentParser, Namespace
+from typing import Dict, Iterable
+
+from streaming.vision.convert.base import get_list_arg
+from streaming.base import MDSWriter
+
+class _COCODetection(Dataset):
+    """PyTorch Dataset for the COCO dataset.
+
+    Args:
+        img_folder (str): Path to a COCO folder.
+        annotate_file (str): Path to a file that contains image id, annotations (e.g., bounding boxes and object
+            classes) etc.
+    """
+
+    def __init__(self, img_folder: str, annotate_file: str):
+        self.img_folder = img_folder
+        self.annotate_file = annotate_file
+
+        # Start processing annotation
+        with open(annotate_file) as fin:
+            self.data = json.load(fin)
+
+        self.images = {}
+
+        self.label_map = {}
+        self.label_info = {}
+        # 0 stands for the background
+        cnt = 0
+        self.label_info[cnt] = 'background'
+        for cat in self.data['categories']:
+            cnt += 1
+            self.label_map[cat['id']] = cnt
+            self.label_info[cnt] = cat['name']
+
+        # build inference for images
+        for img in self.data['images']:
+            img_id = img['id']
+            img_name = img['file_name']
+            img_size = (img['height'], img['width'])
+            if img_id in self.images:
+                raise Exception('dulpicated image record')
+            self.images[img_id] = (img_name, img_size, [])
+
+        # read bboxes
+        for bboxes in self.data['annotations']:
+            img_id = bboxes['image_id']
+            bbox = bboxes['bbox']
+            bbox_label = self.label_map[bboxes['category_id']]
+            self.images[img_id][2].append((bbox, bbox_label))
+
+        for k, v in list(self.images.items()):
+            if len(v[2]) == 0:
+                self.images.pop(k)
+
+        self.img_keys = list(self.images.keys())
+
+    #@property
+    def labelnum(self):
+        return len(self.label_info)
+
+    def __len__(self):
+        return len(self.images)
+
+    def __getitem__(self, idx: int):
+        img_id = self.img_keys[idx]
+        img_data = self.images[img_id]
+        fn = img_data[0]
+        img_path = os.path.join(self.img_folder, fn)
+
+        img = Image.open(img_path).convert('RGB')
+
+        htot, wtot = img_data[1]
+        bbox_sizes = []
+        bbox_labels = []
+
+        for (l, t, w, h), bbox_label in img_data[2]:
+            r = l + w
+            b = t + h
+            bbox_size = (l / wtot, t / htot, r / wtot, b / htot)
+            bbox_sizes.append(bbox_size)
+            bbox_labels.append(bbox_label)
+
+        bbox_sizes = torch.tensor(bbox_sizes)
+        bbox_labels = torch.tensor(bbox_labels)
+
+        return img, img_id, (htot, wtot), bbox_sizes, bbox_labels
+
+
+def parse_args() -> Namespace:
+    """Parse command line arguments.
+
+    Args:
+        Namespace: Command line arguments.
+    """
+    args = ArgumentParser()
+    args.add_argument('--in', type=str, default='./datasets/coco2017/', help='Location of Input dataset. Default: ./datasets/coco2017/')
+    args.add_argument('--out', type=str, default='./datasets/mds/coco2017/', help='Location to store the compressed dataset. Default: ./datasets/mds/coco2017/')
+    args.add_argument('--splits', type=str, default='train,val', help='Split to use. Default: train,val')
+    args.add_argument('--compression', type=str, default='zstd:7', help='Compression algorithm to use. Default: zstd:7')
+    args.add_argument('--hashes', type=str, default='sha1,xxh64', help='Hashing algorithms to apply to shard files. Default: sha1,xxh64')
+    args.add_argument('--limit', type=int, default=1 << 25, help='Shard size limit, after which point to start a new shard. Default: 33554432')
+    args.add_argument('--progbar', type=bool, default=True, help='tqdm progress bar. Default: True')
+    args.add_argument('--leave', type=bool, default=False, help='Keeps all traces of the progressbar upon termination of iteration. Default: False')
+    return args.parse_args()
+
+
+def each(dataset: _COCODetection, shuffle: bool) -> Iterable[Dict[str, bytes]]:
+    """Generator over each dataset sample.
+
+    Args:
+        dataset (COCODetection): COCO detection dataset.
+        shuffle (bool): Whether to shuffle the samples.
+
+    Yields:
+        Sample dicts.
+    """
+    if shuffle:
+        indices = np.random.permutation(len(dataset))
+    else:
+        indices = list(range(len(dataset)))
+    for idx in indices:
+        _, img_id, (htot, wtot), bbox_sizes, bbox_labels = dataset[idx]
+
+        img_id = dataset.img_keys[idx]
+        img_data = dataset.images[img_id]
+        img_basename = img_data[0]
+        img_filename = os.path.join(dataset.img_folder, img_basename)
+        img_bytes = open(img_filename, 'rb').read()
+
+        yield {
+            'img': img_bytes,
+            'img_id': np.int64(img_id).tobytes(),
+            'htot': np.int64(htot).tobytes(),
+            'wtot': np.int64(wtot).tobytes(),
+            'bbox_sizes': bbox_sizes.numpy().tobytes(),  # (_, 4) float32.
+            'bbox_labels': bbox_labels.numpy().tobytes(),  # int64.
+        }
+
+
+def main(args: Namespace) -> None:
+    """Main: create COCO streaming dataset.
+
+    Args:
+        args (Namespace): Command line arguments.
+    """
+    fields = {
+        'img': 'bytes',
+        'img_id': 'bytes',
+        'htot': 'bytes',
+        'wtot': 'bytes',
+        'bbox_sizes': 'bytes',
+        'bbox_labels': 'bytes'
+    }
+
+    for (split, expected_num_samples, shuffle) in [
+        ('train', 117266, True),
+        ('val', 4952, False),
+    ]:
+        split_out_dir = os.path.join(args.out_root, split)
+
+        split_images_in_dir = os.path.join(args.in_root, f'{split}2017')
+        split_annotations_in_file = os.path.join(args.in_root, 'annotations', f'instances_{split}2017.json')
+        dataset = _COCODetection(split_images_in_dir, split_annotations_in_file)
+
+        hashes = get_list_arg(args.hashes)
+
+        if args.progbar:
+            dataset = tqdm(dataset, leave=args.leave)
+
+        with MDSWriter(split_out_dir, fields, args.compression, hashes, args.limit) as out:
+            for sample in each(dataset, shuffle):
+                out.write(sample)
+
+
+if __name__ == '__main__':
+    main(parse_args())


### PR DESCRIPTION
## Description
- Added a ADE20K and COCO2017 data conversion scripts
- Currently, it converts into `mds` format.
- User can run the script as a standalone script to convert their RAW dataset into `mds` format.

## Linting
```
$ isort <file_name>
$ yapf -i -vv -p <file_name>
$ pyright
```

## Testing
- Downloaded the raw  ADE20K dataset locally and ran the `ade20k.py` script locally to generate the sharded `mds` file. The snapshot of structure is as shown below
```
.
├── train
│   ├── index.json
│   ├── shard.00000.mds
│   ├── shard.00001.mds
│   ├── shard.00002.mds
│   ├── shard.00003.mds
│   ├── shard.00004.mds
│   ├── shard.00005.mds
│   ├── shard.00006.mds
|    ............
│   ├── shard.00208.mds
│   ├── shard.00209.mds
│   └── shard.00210.mds
└── val
    ├── index.json
    ├── shard.00000.mds
    ├── shard.00001.mds
    ├── shard.00002.mds
     ............
    ├── shard.00018.mds
    ├── shard.00019.mds
    ├── shard.00020.mds
    └── shard.00021.mds

2 directories, 235 files
```
- Downloaded the raw MSCOCO-2017 dataset locally and ran the `coco.py` script locally to generate the sharded `mds` file. The curtailed snapshot of structure is as shown below
```
.
├── train
│   ├── index.json
│   ├── shard.00000.mds
│   ├── shard.00001.mds
│   ├── shard.00002.mds
│   ├── shard.00003.mds
│   ├── shard.00004.mds
│   ├── shard.00005.mds
│   ├── shard.00006.mds
│   ├── shard.00007.mds.
│   ├── shard.00008.mds
│   ├── shard.00009.mds
│   ├── shard.00010.mds
|    .........
│   ├── shard.00572.mds
│   └── shard.00573.mds
└── val
    ├── index.json
    ├── shard.00000.mds
    ├── shard.00001.mds
    ├── shard.00002.mds
    ├── shard.00003.mds
     .........
    ├── shard.00022.mds
    ├── shard.00023.mds
    └── shard.00024.mds

2 directories, 601 files
```