### PR TITLE
Added pre-commit config for a License Header

### DIFF
--- a/.ci/FILE_HEADER
+++ b/.ci/FILE_HEADER
@@ -1,0 +1,2 @@
+Copyright 2022 MosaicML Composer authors
+SPDX-License-Identifier: Apache-2.0

--- a/.ci/FILE_HEADER
+++ b/.ci/FILE_HEADER
@@ -1,2 +1,2 @@
-Copyright 2022 MosaicML Composer authors
+Copyright 2022 MosaicML Streaming authors
 SPDX-License-Identifier: Apache-2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,16 @@ repos:
       - id: fix-byte-order-marker
       - id: mixed-line-ending
       - id: trailing-whitespace
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.3.1
+    hooks:
+      - id: insert-license
+        args:
+          - --license-filepath
+          - .ci/FILE_HEADER
+          - --comment-style
+          - "#"
+        types: [python]
   - repo: local
     hooks:
       - id: pyright
@@ -58,4 +68,3 @@ repos:
         pass_filenames: false
         args: [--warnings]
         additional_dependencies: ["pyright@1.1.256"]
-

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Streaming authors
+# Copyright 2022 MosaicML Composer authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Configuration file for the Sphinx documentation builder.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Configuration file for the Sphinx documentation builder.

--- a/docs/source/doctest_cleanup.py
+++ b/docs/source/doctest_cleanup.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 """Cleanup script that is executed at the end of each doctest."""

--- a/docs/source/doctest_fixtures.py
+++ b/docs/source/doctest_fixtures.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 # disabling general type issues because of monkeypatching

--- a/streaming/__init__.py
+++ b/streaming/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from .base import CSVWriter, Dataset, JSONWriter, LocalDataset, MDSWriter, TSVWriter, XSVWriter
 
 __all__ = [

--- a/streaming/__init__.py
+++ b/streaming/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from .base import CSVWriter, Dataset, JSONWriter, LocalDataset, MDSWriter, TSVWriter, XSVWriter

--- a/streaming/base/__init__.py
+++ b/streaming/base/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from .dataset import Dataset

--- a/streaming/base/__init__.py
+++ b/streaming/base/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from .dataset import Dataset
 from .format import CSVWriter, JSONWriter, MDSWriter, TSVWriter, XSVWriter
 from .local import LocalDataset

--- a/streaming/base/compression/__init__.py
+++ b/streaming/base/compression/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from .compression import (compress, decompress, get_compression_extension, get_compressions,

--- a/streaming/base/compression/__init__.py
+++ b/streaming/base/compression/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from .compression import (compress, decompress, get_compression_extension, get_compressions,
                           is_compression)
 

--- a/streaming/base/compression/bench.py
+++ b/streaming/base/compression/bench.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from argparse import ArgumentParser, Namespace
 from time import time
 from typing import Iterator

--- a/streaming/base/compression/bench.py
+++ b/streaming/base/compression/bench.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from argparse import ArgumentParser, Namespace

--- a/streaming/base/compression/compression.py
+++ b/streaming/base/compression/compression.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 import bz2

--- a/streaming/base/compression/compression.py
+++ b/streaming/base/compression/compression.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 import bz2
 import gzip
 from abc import ABC, abstractmethod

--- a/streaming/base/compression/plot.py
+++ b/streaming/base/compression/plot.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from argparse import ArgumentParser, Namespace
 from collections import defaultdict
 from dataclasses import dataclass

--- a/streaming/base/compression/plot.py
+++ b/streaming/base/compression/plot.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from argparse import ArgumentParser, Namespace

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import os
 from enum import IntEnum

--- a/streaming/base/distributed.py
+++ b/streaming/base/distributed.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/streaming/base/distributed.py
+++ b/streaming/base/distributed.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 
 __all__ = ['get_global_rank', 'get_local_rank', 'get_local_world_size', 'get_world_size']

--- a/streaming/base/download.py
+++ b/streaming/base/download.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import shutil
 import urllib.parse

--- a/streaming/base/download.py
+++ b/streaming/base/download.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/streaming/base/format/__init__.py
+++ b/streaming/base/format/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any, Dict, Optional
 
 from .base.reader import Reader

--- a/streaming/base/format/__init__.py
+++ b/streaming/base/format/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, Optional

--- a/streaming/base/format/base/__init__.py
+++ b/streaming/base/format/base/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0

--- a/streaming/base/format/base/__init__.py
+++ b/streaming/base/format/base/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0

--- a/streaming/base/format/base/reader.py
+++ b/streaming/base/format/base/reader.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABC, abstractmethod

--- a/streaming/base/format/base/reader.py
+++ b/streaming/base/format/base/reader.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, Iterator, List, Optional

--- a/streaming/base/format/base/writer.py
+++ b/streaming/base/format/base/writer.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/streaming/base/format/base/writer.py
+++ b/streaming/base/format/base/writer.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import os
 from abc import ABC, abstractmethod

--- a/streaming/base/format/json/__init__.py
+++ b/streaming/base/format/json/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from .reader import JSONReader
 from .writer import JSONWriter
 

--- a/streaming/base/format/json/__init__.py
+++ b/streaming/base/format/json/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from .reader import JSONReader

--- a/streaming/base/format/json/encodings.py
+++ b/streaming/base/format/json/encodings.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABC, abstractmethod

--- a/streaming/base/format/json/encodings.py
+++ b/streaming/base/format/json/encodings.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC, abstractmethod
 from typing import Any
 

--- a/streaming/base/format/json/reader.py
+++ b/streaming/base/format/json/reader.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import os
 from copy import deepcopy

--- a/streaming/base/format/json/reader.py
+++ b/streaming/base/format/json/reader.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/streaming/base/format/json/writer.py
+++ b/streaming/base/format/json/writer.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/streaming/base/format/json/writer.py
+++ b/streaming/base/format/json/writer.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 from typing import Any, Dict, List, Optional, Tuple
 

--- a/streaming/base/format/mds/__init__.py
+++ b/streaming/base/format/mds/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from .reader import MDSReader
 from .writer import MDSWriter
 

--- a/streaming/base/format/mds/__init__.py
+++ b/streaming/base/format/mds/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from .reader import MDSReader

--- a/streaming/base/format/mds/encodings.py
+++ b/streaming/base/format/mds/encodings.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/streaming/base/format/mds/encodings.py
+++ b/streaming/base/format/mds/encodings.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import pickle
 from abc import ABC, abstractmethod

--- a/streaming/base/format/mds/reader.py
+++ b/streaming/base/format/mds/reader.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/streaming/base/format/mds/reader.py
+++ b/streaming/base/format/mds/reader.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 from copy import deepcopy
 from typing import Any, Dict, List, Optional

--- a/streaming/base/format/mds/writer.py
+++ b/streaming/base/format/mds/writer.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/streaming/base/format/mds/writer.py
+++ b/streaming/base/format/mds/writer.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 from typing import Any, Dict, List, Optional
 

--- a/streaming/base/format/xsv/__init__.py
+++ b/streaming/base/format/xsv/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from .reader import CSVReader, TSVReader, XSVReader
 from .writer import CSVWriter, TSVWriter, XSVWriter
 

--- a/streaming/base/format/xsv/__init__.py
+++ b/streaming/base/format/xsv/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from .reader import CSVReader, TSVReader, XSVReader

--- a/streaming/base/format/xsv/encodings.py
+++ b/streaming/base/format/xsv/encodings.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABC, abstractmethod

--- a/streaming/base/format/xsv/encodings.py
+++ b/streaming/base/format/xsv/encodings.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABC, abstractmethod
 from typing import Any
 

--- a/streaming/base/format/xsv/reader.py
+++ b/streaming/base/format/xsv/reader.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/streaming/base/format/xsv/reader.py
+++ b/streaming/base/format/xsv/reader.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 from copy import deepcopy
 from typing import Any, Dict, List, Optional

--- a/streaming/base/format/xsv/writer.py
+++ b/streaming/base/format/xsv/writer.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/streaming/base/format/xsv/writer.py
+++ b/streaming/base/format/xsv/writer.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 from typing import Any, Dict, List, Optional, Tuple
 

--- a/streaming/base/hashing/__init__.py
+++ b/streaming/base/hashing/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from .hashing import get_hash, get_hashes, is_hash
 
 __all__ = ['get_hash', 'get_hashes', 'is_hash']

--- a/streaming/base/hashing/__init__.py
+++ b/streaming/base/hashing/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from .hashing import get_hash, get_hashes, is_hash

--- a/streaming/base/hashing/bench.py
+++ b/streaming/base/hashing/bench.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from argparse import ArgumentParser, Namespace
 from time import time
 from typing import Iterator

--- a/streaming/base/hashing/bench.py
+++ b/streaming/base/hashing/bench.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from argparse import ArgumentParser, Namespace

--- a/streaming/base/hashing/hashing.py
+++ b/streaming/base/hashing/hashing.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 import hashlib
 from typing import Any, Callable, Dict, Set
 

--- a/streaming/base/hashing/hashing.py
+++ b/streaming/base/hashing/hashing.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 import hashlib

--- a/streaming/base/hashing/plot.py
+++ b/streaming/base/hashing/plot.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from argparse import ArgumentParser, Namespace
 from collections import defaultdict
 from typing import Dict, List, Optional, Tuple

--- a/streaming/base/hashing/plot.py
+++ b/streaming/base/hashing/plot.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from argparse import ArgumentParser, Namespace

--- a/streaming/base/index.py
+++ b/streaming/base/index.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from math import ceil
 from typing import List, Optional, Tuple
 

--- a/streaming/base/index.py
+++ b/streaming/base/index.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from math import ceil

--- a/streaming/base/local.py
+++ b/streaming/base/local.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/streaming/base/local.py
+++ b/streaming/base/local.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import os
 from typing import Any, Dict, Optional

--- a/streaming/vision/__init__.py
+++ b/streaming/vision/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0

--- a/streaming/vision/__init__.py
+++ b/streaming/vision/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0

--- a/streaming/vision/base.py
+++ b/streaming/vision/base.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any, Callable, Optional, Tuple
 
 from torchvision.transforms.functional import to_tensor

--- a/streaming/vision/base.py
+++ b/streaming/vision/base.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Callable, Optional, Tuple

--- a/streaming/vision/cifar10.py
+++ b/streaming/vision/cifar10.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from .base import ImageClassDataset
 
 

--- a/streaming/vision/cifar10.py
+++ b/streaming/vision/cifar10.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from .base import ImageClassDataset

--- a/streaming/vision/convert/__init__.py
+++ b/streaming/vision/convert/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0

--- a/streaming/vision/convert/__init__.py
+++ b/streaming/vision/convert/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0

--- a/streaming/vision/convert/ade20k.py
+++ b/streaming/vision/convert/ade20k.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 """ADE20K streaming dataset conversion scripts."""

--- a/streaming/vision/convert/ade20k.py
+++ b/streaming/vision/convert/ade20k.py
@@ -1,4 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
 
 """ADE20K streaming dataset conversion scripts."""
 

--- a/streaming/vision/convert/base.py
+++ b/streaming/vision/convert/base.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/streaming/vision/convert/base.py
+++ b/streaming/vision/convert/base.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 from typing import List, Optional
 

--- a/streaming/vision/convert/cifar10.py
+++ b/streaming/vision/convert/cifar10.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from argparse import ArgumentParser, Namespace
 
 from torchvision.datasets import CIFAR10

--- a/streaming/vision/convert/cifar10.py
+++ b/streaming/vision/convert/cifar10.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from argparse import ArgumentParser, Namespace

--- a/streaming/vision/convert/coco.py
+++ b/streaming/vision/convert/coco.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 """COCO 2017 streaming dataset conversion scripts."""

--- a/streaming/vision/convert/coco.py
+++ b/streaming/vision/convert/coco.py
@@ -1,4 +1,5 @@
 # Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
 
 """COCO 2017 streaming dataset conversion scripts."""
 

--- a/streaming/vision/convert/image_folder.py
+++ b/streaming/vision/convert/image_folder.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/streaming/vision/convert/image_folder.py
+++ b/streaming/vision/convert/image_folder.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 from argparse import ArgumentParser, Namespace
 from glob import glob

--- a/streaming/vision/imagenet.py
+++ b/streaming/vision/imagenet.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from .base import ImageClassDataset
 
 

--- a/streaming/vision/imagenet.py
+++ b/streaming/vision/imagenet.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from .base import ImageClassDataset

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,2 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,4 +1,4 @@
-# Copyright 2022 MosaicML Composer authors
+# Copyright 2022 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
 from shutil import rmtree

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Composer authors
+# SPDX-License-Identifier: Apache-2.0
+
 from shutil import rmtree
 from typing import Any, Dict, List
 


### PR DESCRIPTION
## Description
- Added pre-commit config for a License Header
- The License Header will get added automatically for a new file as part of pre-commit
- Took a reference from [mosaicml/composer](https://github.com/mosaicml/composer/blob/dev/.pre-commit-config.yaml#L71)