### PR TITLE
Disable local shard deletion

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -230,8 +230,8 @@ class Dataset(IterableDataset):
                     data = decompress(info.compression, data)  # pyright: ignore
                     with open(raw_filename, 'wb') as out:
                         out.write(data)
-                    if not self.keep_zip:
-                        os.remove(zip_filename)
+                    # if not self.keep_zip:
+                    #     os.remove(zip_filename)
                 else:
                     return False
         return True
@@ -329,8 +329,8 @@ class Dataset(IterableDataset):
                     data = decompress(info.compression, data)  # pyright: ignore
                     with open(raw_filename, 'wb') as out:
                         out.write(data)
-                    if not self.keep_zip:
-                        os.remove(zip_filename)
+                    # if not self.keep_zip:
+                    #     os.remove(zip_filename)
             else:
                 raw_filename = os.path.join(self.local, self.split, raw_info.basename)
                 if not os.path.isfile(raw_filename):

--- a/streaming/text/c4.py
+++ b/streaming/text/c4.py
@@ -1,3 +1,6 @@
+# Copyright 2022 MosaicML Streaming authors
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any, Dict, Optional
 
 from transformers.models.auto.tokenization_auto import AutoTokenizer


### PR DESCRIPTION
Temporarily disable deleting local copies of shards in case where multiple workers own the same shard