### PR TITLE
Added unittest for Writer and Reader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,18 @@ reportIncompleteStub = "error"
 reportUnsupportedDunderAll = "error"
 reportUnusedCoroutine = "error"
 
+# Pytest
+[tool.pytest.ini_options]
+# By default, do not run remote tests
+addopts = "--codeblocks --strict-markers -m 'not daily and not remote' -ra --tb=native"
+
+markers = [
+    # Should be run during daily regression
+    "daily",
+    # Whether the test will be reading data from a remote source, and may require credentials
+    "remote",
+]
+
 filterwarnings = [
     # "error",  # warnings should be treated like errors, but still need to fix some warnings
     'ignore:ExtraArgumentWarning',  # extra arguments originate from pytest-specific CLI args

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ extra_deps['dev'] = [
     'toml==0.10.2',
     'yamllint==1.26.3',
     'pre-commit>=2.18.1,<3',
+    'pytest_codeblocks==0.16.1',
 ]
 
 extra_deps['docs'] = [

--- a/streaming/text/convert/c4.py
+++ b/streaming/text/convert/c4.py
@@ -5,11 +5,11 @@ import os
 from argparse import ArgumentParser, Namespace
 from typing import Any, Dict, Iterator
 
-import datasets
 from datasets.arrow_dataset import Dataset
 from torch.utils.data import DataLoader, IterableDataset, get_worker_info
 from tqdm import tqdm
 
+import datasets
 from streaming.base import MDSWriter
 from streaming.base.util import get_list_arg
 

--- a/streaming/text/convert/c4.py
+++ b/streaming/text/convert/c4.py
@@ -5,7 +5,7 @@ import os
 from argparse import ArgumentParser, Namespace
 from typing import Any, Dict, Iterator
 
-import datasets as datasets
+import datasets
 from datasets.arrow_dataset import Dataset
 from torch.utils.data import DataLoader, IterableDataset, get_worker_info
 from tqdm import tqdm

--- a/streaming/text/convert/c4.py
+++ b/streaming/text/convert/c4.py
@@ -5,11 +5,11 @@ import os
 from argparse import ArgumentParser, Namespace
 from typing import Any, Dict, Iterator
 
+import datasets as datasets
 from datasets.arrow_dataset import Dataset
 from torch.utils.data import DataLoader, IterableDataset, get_worker_info
 from tqdm import tqdm
 
-import datasets
 from streaming.base import MDSWriter
 from streaming.base.util import get_list_arg
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,385 @@
+# Copyright 2022 MosaicML Streaming authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import math
+import os
+import pathlib
+import shutil
+import time
+from filecmp import dircmp
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+import numpy as np
+import pytest
+from torch.utils.data import DataLoader
+
+from streaming.base import Dataset, MDSWriter
+
+
+@pytest.fixture
+def remote_local(tmp_path: pathlib.Path) -> Tuple[str, str]:
+    remote = tmp_path.joinpath('remote')
+    local = tmp_path.joinpath('local')
+    return str(remote), str(local)
+
+
+@pytest.fixture
+def compressed_remote_local(tmp_path: pathlib.Path) -> Tuple[str, str, str]:
+    compressed = tmp_path.joinpath('compressed')
+    remote = tmp_path.joinpath('remote')
+    local = tmp_path.joinpath('local')
+    return tuple(str(x) for x in [compressed, remote, local])
+
+
+def get_fake_samples_and_columns_metadata(
+        num_samples: int) -> Tuple[List[Dict[str, bytes]], List[str], List[str], List[Any]]:
+    samples = [{
+        'uid': f'{ix:06}'.encode('utf-8'),
+        'data': np.int64(3 * ix).tobytes()
+    } for ix in range(num_samples)]
+    column_encodings = ['str', 'int']
+    column_names = ['uid', 'data']
+    column_sizes = [None, 8]
+    return samples, column_encodings, column_names, column_sizes
+
+
+def get_config_in_bytes(format: str,
+                        size_limit: int,
+                        column_names: List[str],
+                        column_encodings: List[str],
+                        column_sizes: List[str],
+                        compression: Optional[str] = None,
+                        hashes: Optional[List[str]] = []):
+    config = {
+        'version': 2,
+        'format': format,
+        'compression': compression,
+        'hashes': hashes,
+        'size_limit': size_limit,
+        'column_names': column_names,
+        'column_encodings': column_encodings,
+        'column_sizes': column_sizes
+    }
+    return json.dumps(config, sort_keys=True).encode('utf-8')
+
+
+def write_synthetic_streaming_dataset(
+    dirname: str,
+    columns: Dict[str, str],
+    samples: List[Dict[str, Any]],
+    shard_size_limit: int,
+    compression: Optional[str] = None,
+    hashes: Optional[List[str]] = None,
+) -> None:
+    with MDSWriter(dirname=dirname,
+                   columns=columns,
+                   compression=compression,
+                   hashes=hashes,
+                   size_limit=shard_size_limit) as out:
+        for sample in samples:
+            out.write(sample)
+
+
+@pytest.mark.parametrize('num_samples', [1000, 10000])
+@pytest.mark.parametrize('shard_size_limit', [1 << 8, 1 << 12, 1 << 24])
+def test_writer(remote_local: Tuple[str, str], num_samples: int, shard_size_limit: int) -> None:
+    dirname, _ = remote_local
+    samples, column_encodings, column_names, column_sizes = get_fake_samples_and_columns_metadata(
+        num_samples)
+    columns = dict(zip(column_names, column_encodings))
+
+    config_data_bytes = get_config_in_bytes('mds', shard_size_limit, column_names,
+                                            column_encodings, column_sizes)
+    extra_bytes_per_shard = 4 + 4 + len(config_data_bytes)
+    extra_bytes_per_sample = 4
+
+    first_sample_body = list(samples[0].values())
+    first_sample_head = np.array(
+        [len(data) for data, size in zip(first_sample_body, column_sizes) if size is None],
+        dtype=np.uint32)
+    first_sample_bytes = len(first_sample_head.tobytes() +
+                             b''.join(first_sample_body)) + extra_bytes_per_sample
+
+    expected_samples_per_shard = (shard_size_limit - extra_bytes_per_shard) // first_sample_bytes
+    expected_num_shards = math.ceil(num_samples / expected_samples_per_shard)
+    expected_num_files = expected_num_shards + 1  # the index file and compression metadata file
+
+    write_synthetic_streaming_dataset(dirname=dirname,
+                                      columns=columns,
+                                      samples=samples,
+                                      shard_size_limit=shard_size_limit)
+    files = os.listdir(dirname)
+    print(f'Number of files: {len(files)}')
+
+    assert len(
+        files
+    ) == expected_num_files, f'Files written ({len(files)}) != expected ({expected_num_files}).'
+
+
+@pytest.mark.parametrize('batch_size', [None, 1, 2])
+@pytest.mark.parametrize('remote_arg', ['none', 'same', 'different'])
+@pytest.mark.parametrize('shuffle', [False, True])
+def test_reader(remote_local: Tuple[str, str], batch_size: int, remote_arg: str, shuffle: bool):
+    num_samples = 117
+    shard_size_limit = 1 << 8
+    samples, column_encodings, column_names, _ = get_fake_samples_and_columns_metadata(num_samples)
+    columns = dict(zip(column_names, column_encodings))
+    if remote_arg == 'none':
+        remote, local = remote_local
+        dirname = local
+        remote = None
+    elif remote_arg == 'same':
+        remote, local = remote_local
+        dirname = local
+        remote = local
+    elif remote_arg == 'different':
+        remote, local = remote_local
+        dirname = remote
+    else:
+        assert False, f'Unknown value of remote_arg: {remote_arg}'
+
+    write_synthetic_streaming_dataset(dirname=dirname,
+                                      columns=columns,
+                                      samples=samples,
+                                      shard_size_limit=shard_size_limit)
+
+    # Build Dataset
+    dataset = Dataset(local=local, remote=remote, shuffle=shuffle, batch_size=batch_size)
+
+    # Test basic sample order
+    rcvd_samples = 0
+    shuffle_matches = 0
+    for ix, sample in enumerate(dataset):
+        rcvd_samples += 1
+        uid = sample['uid']
+        data = sample['data']
+        expected_uid = f'{ix:06}'
+        expected_data = 3 * ix
+        if shuffle:
+            shuffle_matches += (expected_uid == uid)
+        else:
+            assert uid == expected_uid, f'sample ix={ix} has uid={uid}, expected {expected_uid}'
+            assert data == expected_data, f'sample ix={ix} has data={data}, expected {expected_data}'
+
+    # If shuffling, there should be few matches
+    # The probability of k matches in a random permutation is ~1/(e*(k!))
+    if shuffle:
+        assert shuffle_matches < 10
+
+    # Test length
+    assert rcvd_samples == num_samples, f'Only received {rcvd_samples} samples, expected {num_samples}'
+    assert len(
+        dataset
+    ) == num_samples, f'Got dataset length={len(dataset)} samples, expected {num_samples}'
+
+
+@pytest.mark.parametrize(
+    'missing_file',
+    [
+        'index',
+        'shard',
+    ],
+)
+def test_reader_download_fail(remote_local: Tuple[str, str], missing_file: str):
+    num_samples = 117
+    shard_size_limit = 1 << 8
+    samples, column_encodings, column_names, _ = get_fake_samples_and_columns_metadata(num_samples)
+    columns = dict(zip(column_names, column_encodings))
+    remote, local = remote_local
+    write_synthetic_streaming_dataset(dirname=remote,
+                                      columns=columns,
+                                      samples=samples,
+                                      shard_size_limit=shard_size_limit)
+
+    if missing_file == 'index':
+        os.remove(os.path.join(remote, 'index.json'))
+    elif missing_file == 'shard':
+        os.remove(os.path.join(remote, 'shard.00000.mds'))
+
+    # Build and iterate over StreamingDataset
+    try:
+        dataset = Dataset(local=local, remote=remote, shuffle=False, timeout=1)
+        for _ in dataset:
+            pass
+    except FileNotFoundError as e:
+        print(f'Successfully raised error: {e}')
+
+
+@pytest.mark.parametrize('created_ago', [0.5, 3])
+@pytest.mark.parametrize('timeout', [1])
+@pytest.mark.parametrize('compression', [None])
+def test_reader_after_crash(remote_local: Tuple[str, str], created_ago: float, timeout: float,
+                            compression: str) -> None:
+    compression_ext = f'.{compression.split(":")[0]}' if compression is not None else ''
+    num_samples = 117
+    shard_size_limit = 1 << 8
+    samples, column_encodings, column_names, _ = get_fake_samples_and_columns_metadata(num_samples)
+    columns = dict(zip(column_names, column_encodings))
+    remote, local = remote_local
+    write_synthetic_streaming_dataset(dirname=remote,
+                                      columns=columns,
+                                      samples=samples,
+                                      shard_size_limit=shard_size_limit,
+                                      compression=compression)
+
+    if not os.path.exists(local):
+        os.mkdir(local)
+
+    shutil.copy(os.path.join(remote, f'index.json{compression_ext}'),
+                os.path.join(local, f'index.json.tmp{compression_ext}'))
+    shutil.copy(os.path.join(remote, f'shard.00003.mds{compression_ext}'),
+                os.path.join(local, f'shard.00003.mds.tmp{compression_ext}'))
+    time.sleep(created_ago)
+
+    dataset = Dataset(local=local, remote=remote, shuffle=False, timeout=timeout)
+
+    # Iterate over dataset and make sure there are no TimeoutErrors
+    for _ in dataset:
+        pass
+
+
+@pytest.mark.parametrize(
+    'share_remote_local',
+    [
+        True,
+        False,
+    ],
+)
+def test_reader_getitem(remote_local: Tuple[str, str], share_remote_local: bool) -> None:
+    num_samples = 117
+    shard_size_limit = 1 << 8
+    samples, column_encodings, column_names, _ = get_fake_samples_and_columns_metadata(num_samples)
+    columns = dict(zip(column_names, column_encodings))
+    remote, local = remote_local
+    if share_remote_local:
+        local = remote
+    write_synthetic_streaming_dataset(dirname=remote,
+                                      columns=columns,
+                                      samples=samples,
+                                      shard_size_limit=shard_size_limit)
+
+    # Build StreamingDataset
+    dataset = Dataset(local=local, remote=remote, shuffle=False)
+
+    # Test retrieving random sample
+    _ = dataset[17]
+
+
+@pytest.mark.daily
+@pytest.mark.parametrize('batch_size', [1, 2, 5])
+@pytest.mark.parametrize('drop_last', [False, True])
+@pytest.mark.parametrize('num_workers', [1])
+@pytest.mark.parametrize('persistent_workers', [
+    False,
+    True,
+])
+@pytest.mark.parametrize('shuffle', [False, True])
+def test_dataloader_single_device(remote_local: Tuple[str, str], batch_size: int, drop_last: bool,
+                                  num_workers: int, persistent_workers: bool, shuffle: bool):
+    num_samples = 31
+    shard_size_limit = 1 << 6
+    samples, column_encodings, column_names, _ = get_fake_samples_and_columns_metadata(num_samples)
+    columns = dict(zip(column_names, column_encodings))
+    remote, local = remote_local
+    write_synthetic_streaming_dataset(dirname=remote,
+                                      columns=columns,
+                                      samples=samples,
+                                      shard_size_limit=shard_size_limit)
+
+    # Build StreamingDataset
+    dataset = Dataset(local=local, remote=remote, shuffle=shuffle, batch_size=batch_size)
+
+    # Build DataLoader
+    dataloader = DataLoader(dataset=dataset,
+                            batch_size=batch_size,
+                            num_workers=num_workers,
+                            drop_last=drop_last,
+                            persistent_workers=persistent_workers)
+
+    # Expected number of batches based on batch_size and drop_last
+    expected_num_batches = (num_samples // batch_size) if drop_last else math.ceil(num_samples /
+                                                                                   batch_size)
+    expected_num_samples = expected_num_batches * batch_size if drop_last else num_samples
+
+    # Iterate over DataLoader
+    rcvd_batches = 0
+    sample_order = []
+
+    for batch_ix, batch in enumerate(dataloader):
+        rcvd_batches += 1
+
+        # Every batch should be complete except (maybe) final one
+        if batch_ix + 1 < expected_num_batches:
+            assert len(batch['uid']) == batch_size
+        else:
+            if drop_last:
+                assert len(batch['uid']) == batch_size
+            else:
+                assert len(batch['uid']) <= batch_size
+
+        for uid in batch['uid']:
+            sample_order.append(int(uid))
+
+    # Test dataloader length
+    assert len(dataloader) == expected_num_batches
+    assert rcvd_batches == expected_num_batches
+
+    # Test that all samples arrived
+    assert len(sample_order) == expected_num_samples
+    if not drop_last:
+        assert len(set(sample_order)) == num_samples
+
+    # Iterate over the dataloader again to check shuffle behavior
+    second_sample_order = []
+    for batch_ix, batch in enumerate(dataloader):
+        for uid in batch['uid']:
+            second_sample_order.append(int(uid))
+
+    assert len(sample_order) == len(second_sample_order)
+    if shuffle:
+        assert sample_order != second_sample_order
+    else:
+        assert sample_order == second_sample_order
+
+
+def check_for_diff_files(dir: dircmp, compression_ext: Union[None, str]):
+    """Check recursively for different files in a dircmp object.
+    Local directory also has the uncompressed files, ignore it during file comparison."""
+    if compression_ext:
+        for file in dir.diff_files:
+            assert not file.endswith(compression_ext)
+    else:
+        assert len(dir.diff_files) == 0
+    for subdir in dir.subdirs:
+        check_for_diff_files(subdir, compression_ext)
+
+
+@pytest.mark.parametrize('compression', [None, 'gz', 'gz:5'])
+def test_compression(compressed_remote_local: Tuple[str, str, str], compression: Optional[str]):
+    num_samples = 31
+    shard_size_limit = 1 << 6
+    shuffle = True
+    compressed, remote, local = compressed_remote_local
+    samples, column_encodings, column_names, _ = get_fake_samples_and_columns_metadata(num_samples)
+    columns = dict(zip(column_names, column_encodings))
+    compression_ext = compression.split(':')[0] if compression else None
+
+    write_synthetic_streaming_dataset(dirname=compressed,
+                                      columns=columns,
+                                      samples=samples,
+                                      shard_size_limit=shard_size_limit,
+                                      compression=compression)
+    write_synthetic_streaming_dataset(dirname=remote,
+                                      columns=columns,
+                                      samples=samples,
+                                      shard_size_limit=shard_size_limit,
+                                      compression=None)
+
+    dataset = Dataset(local=local, remote=compressed, shuffle=shuffle)
+
+    for _ in dataset:
+        pass  # download sample
+
+    dcmp = dircmp(remote, local)
+    check_for_diff_files(dcmp, compression_ext)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -197,7 +197,7 @@ def test_reader_download_fail(remote_local: Tuple[str, str], missing_file: str):
     elif missing_file == 'shard':
         os.remove(os.path.join(remote, 'shard.00000.mds'))
 
-    # Build and iterate over StreamingDataset
+    # Build and iterate over a streaming Dataset
     try:
         dataset = Dataset(local=local, remote=remote, shuffle=False, timeout=1)
         for _ in dataset:
@@ -226,8 +226,7 @@ def test_reader_after_crash(remote_local: Tuple[str, str], created_ago: float, t
     if not os.path.exists(local):
         os.mkdir(local)
 
-    shutil.copy(os.path.join(remote, f'index.json{compression_ext}'),
-                os.path.join(local, f'index.json.tmp{compression_ext}'))
+    shutil.copy(os.path.join(remote, f'index.json'), os.path.join(local, f'index.json.tmp'))
     shutil.copy(os.path.join(remote, f'shard.00003.mds{compression_ext}'),
                 os.path.join(local, f'shard.00003.mds.tmp{compression_ext}'))
     time.sleep(created_ago)
@@ -259,7 +258,7 @@ def test_reader_getitem(remote_local: Tuple[str, str], share_remote_local: bool)
                                       samples=samples,
                                       shard_size_limit=shard_size_limit)
 
-    # Build StreamingDataset
+    # Build a streaming Dataset
     dataset = Dataset(local=local, remote=remote, shuffle=False)
 
     # Test retrieving random sample
@@ -287,7 +286,7 @@ def test_dataloader_single_device(remote_local: Tuple[str, str], batch_size: int
                                       samples=samples,
                                       shard_size_limit=shard_size_limit)
 
-    # Build StreamingDataset
+    # Build a streaming Dataset
     dataset = Dataset(local=local, remote=remote, shuffle=shuffle, batch_size=batch_size)
 
     # Build DataLoader

--- a/tests/test_streaming_remote.py
+++ b/tests/test_streaming_remote.py
@@ -1,0 +1,138 @@
+# Copyright 2022 MosaicML Streaming authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pathlib
+import time
+from typing import Any, Dict, Optional, Tuple
+
+import pytest
+
+from streaming.base import Dataset
+from streaming.text import C4
+from streaming.vision import ADE20K, CIFAR10, COCO, ImageNet
+
+
+def get_dataset(name: str,
+                local: str,
+                split: str,
+                shuffle: bool,
+                batch_size: Optional[int],
+                other_kwargs: Optional[Dict[str, Any]] = None) -> Tuple[int, Dataset]:
+    other_kwargs = {} if other_kwargs is None else other_kwargs
+    dataset_map = {
+        'ade20k': {
+            'remote': 's3://mosaicml-internal-dataset-ade20k/mds/2/',
+            'num_samples': {
+                'train': 20206,
+                'val': 2000,
+            },
+            'class': ADE20K,
+            'kwargs': {},
+        },
+        'imagenet1k': {
+            'remote': 's3://mosaicml-internal-dataset-imagenet1k/mds/2/',
+            'num_samples': {
+                'train': 1281167,
+                'val': 50000,
+            },
+            'class': ImageNet,
+            'kwargs': {},
+        },
+        'coco': {
+            'remote': 's3://mosaicml-internal-dataset-coco/mds/2/',
+            'num_samples': {
+                'train': 117266,
+                'val': 4952,
+            },
+            'class': COCO,
+            'kwargs': {},
+        },
+        'c4': {
+            'remote': 's3://mosaicml-internal-dataset-c4/mds/2/',
+            'num_samples': {
+                'train': 364868892,
+                'val': 364608,
+            },
+            'class': C4,
+            'kwargs': {
+                'tokenizer_name': 'bert-base-uncased',
+                'max_seq_len': 512,
+                'group_method': 'truncate'
+            },
+        },
+        'cifar10': {
+            'remote': 's3://mosaicml-internal-dataset-cifar10/mds/2/',
+            'num_samples': {
+                'train': 50000,
+                'val': 10000,
+            },
+            'class': CIFAR10,
+            'kwargs': {},
+        },
+        'test_streaming_upload': {
+            'remote': 's3://streaming-upload-test-bucket/',
+            'num_samples': {
+                'all': 0,
+            },
+            'class': Dataset,
+            'kwargs': {},
+        }
+    }
+    if name not in dataset_map and split not in dataset_map[name]['num_samples'][split]:
+        raise ValueError('Could not load dataset with name={name} and split={split}')
+
+    d = dataset_map[name]
+    expected_samples = d['num_samples'][split]
+    remote = d['remote']
+    kwargs = {**d['kwargs'], **other_kwargs}
+    dataset = d['class'](local=local,
+                         remote=remote,
+                         split=split,
+                         shuffle=shuffle,
+                         batch_size=batch_size,
+                         **kwargs)
+    return (expected_samples, dataset)
+
+
+@pytest.mark.remote
+@pytest.mark.parametrize('name', [
+    'ade20k',
+    'imagenet1k',
+    'coco',
+    'cifar10',
+    'c4',
+])
+@pytest.mark.parametrize('split', ['val'])
+def test_streaming_remote_dataset(tmp_path: pathlib.Path, name: str, split: str) -> None:
+
+    # Build StreamingDataset
+    build_start = time.time()
+    expected_samples, dataset = get_dataset(name=name,
+                                            local=str(tmp_path),
+                                            split=split,
+                                            shuffle=False,
+                                            batch_size=None)
+    build_end = time.time()
+    build_dur = build_end - build_start
+    print('Built dataset')
+
+    # Test basic iteration
+    rcvd_samples = 0
+    iter_start = time.time()
+    for _ in dataset:
+        rcvd_samples += 1
+
+        if (rcvd_samples % 1000 == 0):
+            print(f'samples read: {rcvd_samples}')
+
+    iter_end = time.time()
+    iter_dur = iter_end - iter_start
+    samples_per_sec = rcvd_samples / iter_dur
+
+    # Print debug info
+    print(
+        f'build_dur={build_dur:.2f}s, iter_dur={iter_dur:.2f}, samples_per_sec={samples_per_sec:.2f}'
+    )
+
+    # Test all samples arrived
+    assert rcvd_samples == expected_samples


### PR DESCRIPTION
## Description
- Port unittest from composer repo
  - [test_streaming.py](https://github.com/mosaicml/composer/blob/release/v0.9.0/tests/datasets/test_streaming.py)
  - [test_streaming_remote.py](https://github.com/mosaicml/composer/blob/release/v0.9.0/tests/datasets/test_streaming_remote.py)
- Make it compatible with streaming repository
- Few of the tests are missing which will be added in upcoming PR such as 
  - More than one workers for [ test_dataloader_single_device()](https://github.com/mosaicml/composer/blob/release/v0.9.0/tests/datasets/test_streaming.py#L230)
  - Add [test_dataloader_multi_device()](https://github.com/mosaicml/composer/blob/release/v0.9.0/tests/datasets/test_streaming.py#L301)
  - Add [test_streaming_remote_dataloader()](https://github.com/mosaicml/composer/blob/release/v0.9.0/tests/datasets/test_streaming_remote.py#L177)