### PR TITLE
Fix wait-for-unzip race

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -211,7 +211,7 @@ class Dataset(IterableDataset):
                             partition: Partition,
                             raw_info: FileInfo,
                             zip_info: Optional[FileInfo] = None,
-                            compression: Optional[str] = None) -> None:
+                            compression: Optional[str] = None) -> bool:
         """Decompress and validate shard data given raw/zip version metadata.
 
         MDS format uses joint shards (ie, one file per shard). Other formats supported by streaming


### PR DESCRIPTION
Fix two identical race conditions in shard preload and download respectively.

The problem: some workers were thinking they were all clear to go ahead before that was actually the case, and encountering momentarily missing, empty, or truncated shards as a result in scenarios involving enough GPUs, large enough shards, and compression. Streaming V2 handles compression differently than V1 and adds hash (and ideally file size) validation, but the "wait" path was not updated to include the added steps in prepping shards for use.