### PR TITLE
Improve algorithmic complexity of sample-to-shard lookup from O(log N) to O(1)

### DIFF
--- a/streaming/base/index.py
+++ b/streaming/base/index.py
@@ -60,7 +60,7 @@ class Index(object):
             self.slot_size = min(samples_per_shard[:-1])
         else:
             self.slot_size = samples_per_shard[-1]
-        self.slot_size = self.slot_size or 1
+        self.slot_size = self.slot_size or 1  # For the edge case of empty shards.
         self.num_slots = (self.total_samples + self.slot_size - 1) // self.slot_size
         shard_ends = np.array(samples_per_shard).cumsum()
         shard = 0

--- a/streaming/base/index.py
+++ b/streaming/base/index.py
@@ -56,7 +56,10 @@ class Index(object):
 
         # Make a lookup table of sample to shard, stored in the form of equal-sized spans of sample
         # IDs that map to at most two adjacent shards, keeping the dividing sample ID.
-        self.slot_size = min(samples_per_shard[:-1])
+        if samples_per_shard[:-1]:
+            self.slot_size = min(samples_per_shard[:-1]) or 1
+        else:
+            self.slot_size = samples_per_shard[-1]
         self.num_slots = (self.total_samples + self.slot_size - 1) // self.slot_size
         shard_ends = np.array(samples_per_shard).cumsum()
         shard = 0

--- a/streaming/base/index.py
+++ b/streaming/base/index.py
@@ -57,9 +57,10 @@ class Index(object):
         # Make a lookup table of sample to shard, stored in the form of equal-sized spans of sample
         # IDs that map to at most two adjacent shards, keeping the dividing sample ID.
         if samples_per_shard[:-1]:
-            self.slot_size = min(samples_per_shard[:-1]) or 1
+            self.slot_size = min(samples_per_shard[:-1])
         else:
             self.slot_size = samples_per_shard[-1]
+        self.slot_size = self.slot_size or 1
         self.num_slots = (self.total_samples + self.slot_size - 1) // self.slot_size
         shard_ends = np.array(samples_per_shard).cumsum()
         shard = 0
@@ -84,7 +85,8 @@ class Index(object):
         Returns:
             Tuple[int, int]: Shard and sample index within that shard.
         """
-        shard, div = self.slots[idx // self.slot_size]
+        slot_idx = min(idx // self.slot_size, len(self.slots) - 1)
+        shard, div = self.slots[slot_idx]
         if div <= idx:
             shard += 1
         offset = idx - self.shard_offsets[shard]


### PR DESCRIPTION
Improve algorithmic complexity of sample-to-shard lookup from O(log N) to O(1) by means of a lookup table followed by a comparison whose entries, corresponding to sample ID ranges, overlap at most two shards. Previously this was done by bisection.