### PR TITLE
Skip pre-commit check for enwiki convert skip to have code parity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
 default_language_version:
   python: python3
+# Skip the pre-commit check for below directories to have
+# a consistency with the official tfrecord preprocessing scripts
+exclude: '^(streaming/text/convert/enwiki/)'
 repos:
   - repo: https://github.com/google/yapf
     rev: v0.32.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ include = [
 exclude = [
     "build/**",
     "node_modules/**",
+    "streaming/text/convert/enwiki/**"
 ]
 
 reportUnnecessaryIsInstance = "warning"

--- a/streaming/text/enwiki.py
+++ b/streaming/text/enwiki.py
@@ -3,10 +3,9 @@
 
 """English Wikipedia 2020-01-01 streaming dataset."""
 
-import numpy as np
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
-from transformers.models.auto.tokenization_auto import AutoTokenizer
+import numpy as np
 
 from streaming.base import Dataset
 


### PR DESCRIPTION
## Description
- PR https://github.com/mosaicml/streaming/pull/28 added a Enwiki dataset conversion scripts for streaming.
- As part of the code parity with the official tfrecord preprocessing, pre-commit fails with multiple linting problem. Hence, this PR exclude the enwiki convert directory pre-commit checks.
- As part of a long term vision, we should move all those scripts to a common sub-folders.