### PR TITLE
Create and push release branch as part of workflow

### DIFF
--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -47,6 +47,11 @@ jobs:
       #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
       #     repository_url: https://test.pypi.org/legacy/
 
+      - name: Create release branch
+        run: git checkout -b release/${{ github.ref_name }}
+      - name: Push release branch
+        run: git push origin release/${{ github.ref_name }}
+
       - name: Create GitHub Release
         id: create_release
         uses: actions/create-release@v1


### PR DESCRIPTION
## Description of changes:
- Create and push release branch as part of the release workflow
- New branch `release/<tag_name>` would be created automatically.