### PR TITLE
Fixed stale URL references

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 
 <h4><p align='center'>
 <a href="https://www.mosaicml.com">[Website]</a>
-- <a href="https://docs.mosaicml.com/projects/streaming/en/latest/getting_started/user_guide.html">[Getting Started]</a>
-- <a href="https://docs.mosaicml.com/projects/streaming/">[Docs]
+- <a href="https://streaming.docs.mosaicml.com/en/latest/getting_started/user_guide.html">[Getting Started]</a>
+- <a href="https://streaming.docs.mosaicml.com/">[Docs]
 - <a href="https://www.mosaicml.com/team">[We're Hiring!]</a>
 </p></h4>
 
@@ -34,7 +34,7 @@
     <a href="https://pypi.org/project/mosaicml-streaming/">
         <img alt="PyPi Downloads" src="https://img.shields.io/pypi/dm/mosaicml-streaming">
     </a>
-    <a href="https://docs.mosaicml.com/projects/streaming">
+    <a href="https://streaming.docs.mosaicml.com">
         <img alt="Documentation" src="https://readthedocs.org/projects/streaming/badge/?version=stable">
     </a>
     <a href="https://join.slack.com/t/mosaicml-community/shared_invite/zt-w0tiddn9-WGTlRpfjcO9J5jyrMub1dg">
@@ -54,7 +54,7 @@ Streaming is a PyTorch compatible dataset that enables users to stream training 
 dataloader = torch.utils.data.DataLoader(dataset=ImageStreamingDataset(remote='s3://...'))
 ```
 
-Please check the [quick start guide](https://docs.mosaicml.com/projects/streaming/en/latest/getting_started/quick_start.html) and [user guide](https://docs.mosaicml.com/projects/streaming/en/latest/getting_started/user_guide.html) on how to use the Streaming Dataset.
+Please check the [quick start guide](https://streaming.docs.mosaicml.com/en/latest/getting_started/quick_start.html) and [user guide](https://streaming.docs.mosaicml.com/en/latest/getting_started/user_guide.html) on how to use the Streaming Dataset.
 
 # Key Benefits
 
@@ -75,10 +75,10 @@ pip install mosaicml-streaming
 ```
 
 # Examples
-Please check our [Examples](https://docs.mosaicml.com/projects/streaming/) section for the end-to-end model training workflow using Streaming datasets.
+Please check our [Examples](https://streaming.docs.mosaicml.com/) section for the end-to-end model training workflow using Streaming datasets.
 
 # 📚 Documentation
-Getting started guides, examples, API reference, and other useful information can be found in our [docs](https://docs.mosaicml.com/projects/streaming).
+Getting started guides, examples, API reference, and other useful information can be found in our [docs](https://streaming.docs.mosaicml.com).
 
 # 💫 Contributors
 We welcome any contributions, pull requests, or issues!

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -521,7 +521,7 @@ class PatchedHTMLTranslator(HTML5Translator):
             if 'refid' not in node and (
                     not any(node['refuri'].startswith(x)
                             for x in ('/', 'https://docs.mosaicml.com', '#')) or
-                    node['refuri'].startswith('https://docs.mosaicml.com/projects/streaming') or
+                    node['refuri'].startswith('https://streaming.docs.mosaicml.com') or
                     node['refuri'].startswith('https://docs.mosaicml.com/projects/yahp')):
                 # If there's a refid, or the refuri starts with a non-external uri scheme, then it's an internal
                 # (hardcoded) link, so don't open that in a new tab

--- a/examples/cifar10.ipynb
+++ b/examples/cifar10.ipynb
@@ -25,8 +25,8 @@
     "\n",
     "Let's get started!\n",
     "\n",
-    "[streaming_dataset]: https://docs.mosaicml.com/projects/streaming/en/latest/api_reference/generated/streaming.Dataset.html\n",
-    "[streaming_dataset_mds_writer]: https://docs.mosaicml.com/projects/streaming/en/latest/api_reference/generated/streaming.MDSWriter.html"
+    "[streaming_dataset]: https://streaming.docs.mosaicml.com/en/latest/api_reference/generated/streaming.Dataset.html\n",
+    "[streaming_dataset_mds_writer]: https://streaming.docs.mosaicml.com/en/latest/api_reference/generated/streaming.MDSWriter.html"
    ]
   },
   {
@@ -190,7 +190,7 @@
     "\n",
     "For more information on the `MDSWriter` check out the [API reference][api].\n",
     "\n",
-    "[api]: https://docs.mosaicml.com/projects/streaming/en/latest/api_reference/generated/streaming.MDSWriter.html"
+    "[api]: https://streaming.docs.mosaicml.com/en/latest/api_reference/generated/streaming.MDSWriter.html"
    ]
   },
   {
@@ -240,7 +240,7 @@
     "\n",
     "We extend Streaming's `Dataset` to deserialize the data.\n",
     "\n",
-    "For more information on the Streaming `Dataset` parent class check out the [API reference](https://docs.mosaicml.com/projects/streaming/en/latest/api_reference/generated/streaming.Dataset.html)."
+    "For more information on the Streaming `Dataset` parent class check out the [API reference](https://streaming.docs.mosaicml.com/en/latest/api_reference/generated/streaming.Dataset.html)."
    ]
   },
   {

--- a/examples/facesynthetics.ipynb
+++ b/examples/facesynthetics.ipynb
@@ -28,8 +28,8 @@
     "\n",
     "Let's get started!\n",
     "\n",
-    "[streaming_dataset]: https://docs.mosaicml.com/projects/streaming/en/latest/api_reference/generated/streaming.Dataset.html\n",
-    "[streaming_dataset_mds_writer]: https://docs.mosaicml.com/projects/streaming/en/latest/api_reference/generated/streaming.MDSWriter.html"
+    "[streaming_dataset]: https://streaming.docs.mosaicml.com/en/latest/api_reference/generated/streaming.Dataset.html\n",
+    "[streaming_dataset_mds_writer]: https://streaming.docs.mosaicml.com/en/latest/api_reference/generated/streaming.MDSWriter.html"
    ]
   },
   {
@@ -278,7 +278,7 @@
     "\n",
     "For more information on the `MDSWriter` check out the [API reference][api].\n",
     "\n",
-    "[api]: https://docs.mosaicml.com/projects/streaming/en/latest/api_reference/generated/streaming.MDSWriter.html"
+    "[api]: https://streaming.docs.mosaicml.com/en/latest/api_reference/generated/streaming.MDSWriter.html"
    ]
   },
   {
@@ -331,7 +331,7 @@
     "\n",
     "We extend Streaming's `Dataset` to deserialize the binary data and convert the labels to one-hot encoding.\n",
     "\n",
-    "For more information on the Streaming `Dataset` parent class check out the [API reference](https://docs.mosaicml.com/projects/streaming/en/latest/api_reference/generated/streaming.Dataset.html)."
+    "For more information on the Streaming `Dataset` parent class check out the [API reference](https://streaming.docs.mosaicml.com/en/latest/api_reference/generated/streaming.Dataset.html)."
    ]
   },
   {

--- a/examples/synthetic_nlp.ipynb
+++ b/examples/synthetic_nlp.ipynb
@@ -25,8 +25,8 @@
     "\n",
     "Let's get started!\n",
     "\n",
-    "[streaming_dataset]: https://docs.mosaicml.com/projects/streaming/en/latest/api_reference/generated/streaming.Dataset.html\n",
-    "[streaming_dataset_mds_writer]: https://docs.mosaicml.com/projects/streaming/en/latest/api_reference/generated/streaming.MDSWriter.html"
+    "[streaming_dataset]: https://streaming.docs.mosaicml.com/en/latest/api_reference/generated/streaming.Dataset.html\n",
+    "[streaming_dataset_mds_writer]: https://streaming.docs.mosaicml.com/en/latest/api_reference/generated/streaming.MDSWriter.html"
    ]
   },
   {
@@ -318,7 +318,7 @@
     "\n",
     "We are going to use the `MDSWriter` to convert the raw synthetic NLP dataset into a `.mds` file format.\n",
     "\n",
-    "For more information on the Streaming `MDSWriter` class check out the [API reference](https://docs.mosaicml.com/projects/streaming/en/latest/api_reference/generated/streaming.MDSWriter.html)."
+    "For more information on the Streaming `MDSWriter` class check out the [API reference](https://streaming.docs.mosaicml.com/en/latest/api_reference/generated/streaming.MDSWriter.html)."
    ]
   },
   {
@@ -396,7 +396,7 @@
     "\n",
     "We extend Streaming's `Dataset` to deserialize the data. Let's verify the dataloading samples from Streaming's `Dataset` class with the raw samples for content validity and deterministic sample ordering.\n",
     "\n",
-    "For more information on the Streaming `Dataset` parent class check out the [API reference](https://docs.mosaicml.com/projects/streaming/en/latest/api_reference/generated/streaming.Dataset.html)."
+    "For more information on the Streaming `Dataset` parent class check out the [API reference](https://streaming.docs.mosaicml.com/en/latest/api_reference/generated/streaming.Dataset.html)."
    ]
   },
   {
@@ -437,7 +437,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below are some utility methods about the dataset which would be highly useful for debugging and model training. For more information on the Streaming `Dataset` parameters, check out the [API reference](https://docs.mosaicml.com/projects/streaming/en/latest/api_reference/generated/streaming.Dataset.html)."
+    "Below are some utility methods about the dataset which would be highly useful for debugging and model training. For more information on the Streaming `Dataset` parameters, check out the [API reference](https://streaming.docs.mosaicml.com/en/latest/api_reference/generated/streaming.Dataset.html)."
    ]
   },
   {


### PR DESCRIPTION
## Description of changes:

When we changed the docs URL from `docs.mosaicml.com/projects/streaming` to `streaming.docs.mosaicml.com`, this broke several hard coded links.  This PR fixes those dead links and updates them to point to the updated URL.

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [x] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
