### PR TITLE
Add OCI Cloud Storage support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ install_requires = [
     'transformers>=4.21.3,<5',
     'xxhash>=3.0.0,<4',
     'zstd>=1.5.2.5,<2',
+    'oci>=2.88,<3',
 ]
 
 extra_deps = {}

--- a/streaming/base/storage.py
+++ b/streaming/base/storage.py
@@ -124,7 +124,7 @@ def download_from_oci(remote: str, local: str) -> None:
     """Download a file from remote OCI to local.
 
     Args:
-        remote (str): Remote path (S3).
+        remote (str): Remote path (OCI).
         local (str): Local path (local filesystem).
     """
     import oci

--- a/streaming/base/storage.py
+++ b/streaming/base/storage.py
@@ -137,7 +137,9 @@ def download_from_oci(remote: str, local: str) -> None:
         raise ValueError(f'Expected obj.scheme to be "oci", got {obj.scheme} for remote={remote}')
 
     bucket_name = obj.netloc.split('@' + namespace)[0]
-    object_details = client.get_object(namespace, bucket_name, obj.path)
+    # Remove leading and trailing forward slash from string
+    object_path = obj.path.strip('/')
+    object_details = client.get_object(namespace, bucket_name, object_path)
     with open(local, 'wb') as f:
         for chunk in object_details.data.raw.stream(2048**2, decode_content=False):
             f.write(chunk)

--- a/streaming/vision/convert/base.py
+++ b/streaming/vision/convert/base.py
@@ -45,7 +45,7 @@ def convert_image_class_dataset(dataset: Dataset,
         'y': 'int',
     }
     hashes = hashes or []
-    indices = np.random.permutation(len(dataset))  # pyright: ignore
+    indices = np.random.permutation(len(dataset)).tolist()  # pyright: ignore
     if progbar:
         indices = tqdm(indices, leave=leave)
     split_dir = os.path.join(root, split)


### PR DESCRIPTION
## Description of changes:
- Add OCI Cloud Storage support

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] Tested the functionality locally
- [x] Tested the CIFAR10 model training on a remote instance

- Able to run the model training on CIFAR10 dataset on OCI

```
/workdisk/karan/composer_venv/lib/python3.9/site-packages/torch/distributed/launch.py:178: FutureWarning: The module torch.distributed.launch is deprecated
and will be removed in future. Use torchrun.
Note that --use_env is set by default in torchrun.
If your script expects `--local_rank` argument to be set, please
change it to read from `os.environ['LOCAL_RANK']` instead. See
https://pytorch.org/docs/stable/distributed.html#launch-utility for
further instructions

  warnings.warn(
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1563/1563 [00:15<00:00, 97.94batch/s]
epoch: 1/10 Train Loss: 0.0652, Train Acc: 23.34
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1563/1563 [00:04<00:00, 376.93batch/s]
epoch: 2/10 Train Loss: 0.0505, Train Acc: 41.15
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1563/1563 [00:04<00:00, 383.69batch/s]
epoch: 3/10 Train Loss: 0.0453, Train Acc: 47.82
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1563/1563 [00:03<00:00, 391.00batch/s]
epoch: 4/10 Train Loss: 0.0420, Train Acc: 51.94
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1563/1563 [00:04<00:00, 380.38batch/s]
epoch: 5/10 Train Loss: 0.0393, Train Acc: 55.17
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1563/1563 [00:04<00:00, 389.59batch/s]
epoch: 6/10 Train Loss: 0.0371, Train Acc: 58.00
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1563/1563 [00:04<00:00, 387.94batch/s]
epoch: 7/10 Train Loss: 0.0352, Train Acc: 60.25
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1563/1563 [00:04<00:00, 388.32batch/s]
epoch: 8/10 Train Loss: 0.0336, Train Acc: 62.14
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1563/1563 [00:03<00:00, 394.60batch/s]
epoch: 9/10 Train Loss: 0.0322, Train Acc: 63.72
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1563/1563 [00:04<00:00, 386.42batch/s]
epoch: 10/10 Train Loss: 0.0310, Train Acc: 64.99
```

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
