### PR TITLE
Support for S3 public bucket

### DIFF
--- a/streaming/base/storage.py
+++ b/streaming/base/storage.py
@@ -22,6 +22,22 @@ def download_from_s3(remote: str, local: str, timeout: float) -> None:
         local (str): Local path (local filesystem).
         timeout (float): How long to wait for shard to download before raising an exception.
     """
+
+    def _download_file(unsigned: bool = False) -> None:
+        """Download the file from AWS S3 bucket. The bucket can be either public or private.
+
+        Args:
+            unsigned (bool, optional): Set to True if it is a public bucket. Defaults to False.
+        """
+        if unsigned:
+            # Client will be using unsigned mode in which public
+            # resources can be accessed without credentials
+            config = Config(read_timeout=timeout, signature_version=UNSIGNED)
+        else:
+            config = Config(read_timeout=timeout)
+        s3 = boto3.client('s3', config=config)
+        s3.download_file(obj.netloc, obj.path.lstrip('/'), local)
+
     import boto3
     from botocore import UNSIGNED
     from botocore.config import Config
@@ -32,15 +48,16 @@ def download_from_s3(remote: str, local: str, timeout: float) -> None:
         raise ValueError(f'Expected obj.scheme to be "s3", got {obj.scheme} for remote={remote}')
 
     try:
-        s3 = boto3.client('s3', config=Config(read_timeout=timeout))
-        s3.download_file(obj.netloc, obj.path.lstrip('/'), local)
+        _download_file()
     except NoCredentialsError:
         # Public S3 buckets without credentials
-        s3 = boto3.client('s3', config=Config(read_timeout=timeout, signature_version=UNSIGNED))
-        s3.download_file(obj.netloc, obj.path.lstrip('/'), local)
+        _download_file(unsigned=True)
     except ClientError as e:
         if e.response['Error']['Code'] in S3_NOT_FOUND_CODES:
             raise FileNotFoundError(f'Object {remote} not found.') from e
+        elif e.response['Error']['Code'] == '400':
+            # Public S3 buckets without credentials
+            _download_file(unsigned=True)
 
 
 def download_from_sftp(remote: str, local: str) -> None:


### PR DESCRIPTION
## Description of changes:
- Support for S3 public bucket
- User can now use Streaming for the public S3 bucket

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [x] Test the feature locally without any credentials
- [x] Test the feature on the remote instance without any credentials

- Able to run the BERT base model on C4 dataset using public bucket

```
train                           5%|█▎                       | 1/20 [00:06<01:57,  6.20s/ba, loss/train/total=10.4969]
train                          80%|████████████████████     | 16/20 [00:14<00:02,  1.86ba/s, loss/train/total=7.6183]   Inside try block
train                          95%|███████████████████████▊ | 19/20 [00:15<00:00,  1.88ba/s, loss/train/total=7.6474]   Inside NoCredentialsError block
bert_pre_trainingBatch     20:    1%|▏                        | 4/712 [00:01<03:29,  3.37ba/s]
bert_pre_trainingBatch     20:   15%|███▊                     | 106/712 [00:22<02:07,  4.77ba/s]
bert_pre_trainingBatch     20:   32%|███████▉                 | 225/712 [00:47<01:42,  4.77ba/s]
bert_pre_trainingBatch     20:   47%|███████████▊             | 338/712 [01:11<01:18,  4.76ba/s]
bert_pre_trainingBatch     20:   62%|███████████████▋         | 445/712 [01:34<00:56,  4.76ba/s]
bert_pre_trainingBatch     20:   77%|███████████████████▏     | 547/712 [01:55<00:34,  4.77ba/s]
bert_pre_trainingBatch     20:   91%|██████████████████████▋  | 645/712 [02:16<00:14,  4.77ba/s]
bert_pre_trainingBatch     20:  100%|█████████████████████████| 712/712 [02:30<00:00,  4.74ba/s]

train                         100%|█████████████████████████| 20/20 [02:46<00:00,  8.32s/ba, loss/train/total=7.6344]
```

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
