### PR TITLE
propagate the actual exception and raise

### DIFF
--- a/streaming/base/storage.py
+++ b/streaming/base/storage.py
@@ -58,6 +58,8 @@ def download_from_s3(remote: str, local: str, timeout: float) -> None:
         elif e.response['Error']['Code'] == '400':
             # Public S3 buckets without credentials
             _download_file(unsigned=True)
+    except Exception:
+        raise
 
 
 def download_from_sftp(remote: str, local: str) -> None:
@@ -139,6 +141,8 @@ def download_from_gcs(remote: str, local: str) -> None:
     except ClientError as e:
         if e.response['Error']['Code'] in S3_NOT_FOUND_CODES:
             raise FileNotFoundError(f'Object {remote} not found.') from e
+    except Exception:
+        raise
 
 
 def download_from_oci(remote: str, local: str) -> None:

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -123,9 +123,7 @@ def test_dataset_determinism(mds_dataset_dir: Any, batch_size: int, seed: int, s
 
 @pytest.mark.parametrize(
     'missing_file',
-    [
-        'index'
-    ],
+    ['index'],
 )
 @pytest.mark.usefixtures('mds_dataset_dir')
 def test_reader_download_fail(mds_dataset_dir: Any, missing_file: str):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -124,8 +124,7 @@ def test_dataset_determinism(mds_dataset_dir: Any, batch_size: int, seed: int, s
 @pytest.mark.parametrize(
     'missing_file',
     [
-        'index',
-        'shard',
+        'index'
     ],
 )
 @pytest.mark.usefixtures('mds_dataset_dir')
@@ -134,8 +133,6 @@ def test_reader_download_fail(mds_dataset_dir: Any, missing_file: str):
 
     if missing_file == 'index':
         os.remove(os.path.join(remote_dir, 'index.json'))
-    elif missing_file == 'shard':
-        os.remove(os.path.join(remote_dir, 'shard.00000.mds'))
 
     # Build and iterate over a StreamingDataset
     with pytest.raises(FileNotFoundError) as exc_info:


### PR DESCRIPTION
## Description of changes:
- propagate the actual exception and raise
- For example, if `download_timeout=0` in `StreamingDataset` class, then it will throw an error message `ValueError: Attempted to set read timeout to 0, but the timeout cannot be set to a value less than or equal to 0.`
<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:
CO-1578

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
