### PR TITLE
Set multiprocessing method as fork for Mac OS

### DIFF
--- a/streaming/__init__.py
+++ b/streaming/__init__.py
@@ -3,9 +3,6 @@
 
 """MosaicML Streaming Datasets for cloud-native model training."""
 
-import multiprocessing as mp
-import sys
-
 import streaming.text as text
 import streaming.vision as vision
 from streaming._version import __version__
@@ -16,11 +13,3 @@ __all__ = [
     'StreamingDataLoader', 'StreamingDataset', 'CSVWriter', 'JSONWriter', 'MDSWriter', 'TSVWriter',
     'XSVWriter', 'LocalDataset', 'vision', 'text'
 ]
-
-IS_MACOS = sys.platform == 'darwin'
-
-# Set the multiprocessing start method to `fork` for MAC OS since
-# streaming uses a FileLock for sharing the resources between ranks
-# and workers which is Unpickleable except method `fork`.
-if IS_MACOS:
-    mp.set_start_method('fork', force=True)

--- a/streaming/__init__.py
+++ b/streaming/__init__.py
@@ -3,6 +3,9 @@
 
 """MosaicML Streaming Datasets for cloud-native model training."""
 
+import multiprocessing as mp
+import sys
+
 import streaming.text as text
 import streaming.vision as vision
 from streaming._version import __version__
@@ -13,3 +16,11 @@ __all__ = [
     'StreamingDataLoader', 'StreamingDataset', 'CSVWriter', 'JSONWriter', 'MDSWriter', 'TSVWriter',
     'XSVWriter', 'LocalDataset', 'vision', 'text'
 ]
+
+IS_MACOS = sys.platform == 'darwin'
+
+# Set the multiprocessing start method to `fork` for MAC OS since
+# streaming uses a FileLock for sharing the resources between ranks
+# and workers which is Unpickleable except method `fork`.
+if IS_MACOS:
+    mp.set_start_method('fork', force=True)

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -5,6 +5,7 @@
 
 import json
 import os
+import sys
 from enum import IntEnum
 from multiprocessing.shared_memory import SharedMemory
 from threading import Thread
@@ -28,6 +29,7 @@ from streaming.base.partitioning import get_partitions
 from streaming.base.shared import SharedBarrier
 from streaming.base.shuffle import get_shuffle
 from streaming.base.storage import download
+from streaming.base.util import set_mp_start_method
 from streaming.base.world import World
 
 # Time to wait, in seconds.
@@ -151,6 +153,7 @@ class StreamingDataset(IterableDataset):
         self.download_retry = download_retry
         self.download_timeout = download_timeout
         self.validate_hash = validate_hash or None
+        set_mp_start_method(sys.platform)
 
         if tdist.is_available() and not tdist.is_initialized() and torch.cuda.is_available() and \
                 'RANK' in os.environ:

--- a/streaming/base/local.py
+++ b/streaming/base/local.py
@@ -5,6 +5,7 @@
 
 import json
 import os
+import sys
 from typing import Any, Dict, Optional
 
 import numpy as np
@@ -12,6 +13,7 @@ from torch.utils.data import Dataset
 
 from streaming.base.format import reader_from_json
 from streaming.base.index import Index, get_index_basename
+from streaming.base.util import set_mp_start_method
 
 __all__ = ['LocalDataset']
 
@@ -29,6 +31,7 @@ class LocalDataset(Dataset):
 
         self.local = local
         self.split = split
+        set_mp_start_method(sys.platform)
 
         filename = os.path.join(local, split, get_index_basename())  # pyright: ignore
         obj = json.load(open(filename))

--- a/streaming/base/util.py
+++ b/streaming/base/util.py
@@ -3,6 +3,7 @@
 
 """Utility and helper functions for datasets."""
 
+import multiprocessing as mp
 from typing import List
 
 __all__ = ['get_list_arg']
@@ -18,3 +19,18 @@ def get_list_arg(text: str) -> List[str]:
         List[str]: Splits, if any.
     """
     return text.split(',') if text else []
+
+
+def set_mp_start_method(platform: str) -> None:
+    """Set the multiprocessing start method.
+
+    Args:
+        platform (str): Machine platform name
+    """
+    IS_MACOS = platform == 'darwin'
+
+    # Set the multiprocessing start method to `fork` for MAC OS since
+    # streaming uses a FileLock for sharing the resources between ranks
+    # and workers and this works because fork doesn't pickle.
+    if IS_MACOS:
+        mp.set_start_method('fork', force=True)


### PR DESCRIPTION
## Description of changes:
- Set multiprocessing method as fork for Mac OS instead of `spawn` which is a default method.
- Streaming uses a FileLock for sharing the resources between ranks and workers which is Unpickleable except method `fork`.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:
CO-1589

If the multiprocessing method is `spawn` or `forkserver`, then running streaming application on Mac OS results in below error

```
File "/Users/sh/.pyenv/versions/3.10.6/lib/python3.10/multiprocessing/context.py", line 288, in _Popen
    return Popen(process_obj)
  File "/Users/sh/.pyenv/versions/3.10.6/lib/python3.10/multiprocessing/popen_spawn_posix.py", line 32, in __init__
    super().__init__(process_obj)
  File "/Users/sh/.pyenv/versions/3.10.6/lib/python3.10/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "/Users/sh/.pyenv/versions/3.10.6/lib/python3.10/multiprocessing/popen_spawn_posix.py", line 47, in _launch
    reduction.dump(process_obj, fp)
  File "/Users/sh/.pyenv/versions/3.10.6/lib/python3.10/multiprocessing/reduction.py", line 60, in dump
    ForkingPickler(file, protocol).dump(obj)
TypeError: cannot pickle '_thread.lock' object
```

This PR fixed this issue by using multiprocessing method as `fork`.

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
