### PR TITLE
Removed cuda memory allocation which was causing CUDA OOM

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -119,8 +119,7 @@ class StreamingDataset(IterableDataset):
             an exception. Defaults to ``60``.
         validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
             shards. Defaults to ``None``.
-        shuffle_seed (int, optional): Seed for Deterministic data shuffling. Defaults to
-            ``9176``.
+        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with resumption.
             Defaults to ``None``, which is interpreted as the number of nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
@@ -137,7 +136,7 @@ class StreamingDataset(IterableDataset):
                  download_retry: int = 2,
                  download_timeout: float = 60,
                  validate_hash: Optional[str] = None,
-                 shuffle_seed: Optional[int] = 9176,
+                 shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None):
         self.local = local

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -8,17 +8,14 @@ import os
 from enum import IntEnum
 from multiprocessing.shared_memory import SharedMemory
 from threading import Thread
-from time import sleep, time
+from time import sleep
 from typing import Any, Dict, Iterator, Optional, Tuple
 
 import numpy as np
-import torch
 from filelock import FileLock
 from numpy.typing import NDArray
-from torch import distributed as tdist
 from torch.utils.data import IterableDataset
 
-from streaming.base import distributed as dist
 from streaming.base.compression import decompress
 from streaming.base.format import reader_from_json
 from streaming.base.format.base.reader import FileInfo
@@ -28,6 +25,7 @@ from streaming.base.partitioning import get_partitions
 from streaming.base.shared import SharedBarrier
 from streaming.base.shuffle import get_shuffle
 from streaming.base.storage import download
+from streaming.base.util import is_file_exist
 from streaming.base.world import World
 
 # Time to wait, in seconds.
@@ -152,9 +150,10 @@ class StreamingDataset(IterableDataset):
         self.download_timeout = download_timeout
         self.validate_hash = validate_hash or None
 
-        if tdist.is_available() and not tdist.is_initialized() and torch.cuda.is_available() and \
-                'RANK' in os.environ:
-            tdist.init_process_group('nccl')
+        if self.download_retry < 0:
+            raise ValueError('parameter `download_retry` can never be negative.')
+        if self.download_timeout < 0:
+            raise ValueError('parameter `download_timeout` can never be negative.')
 
         # Seed is set below.
         world = World()
@@ -168,7 +167,12 @@ class StreamingDataset(IterableDataset):
             filename = self._download_file(basename)
         else:
             filename = os.path.join(local, self.split, basename)  # pyright: ignore
-        dist.barrier()
+
+        # Everyone waits for the file to become populated.
+        is_file_exist(filename, TICK, self.download_timeout,
+                      f'{filename} file took too long to download')
+
+        # dist.barrier()
         obj = json.load(open(filename))
         if obj['version'] != 2:
             raise ValueError('Unsupported version')
@@ -187,23 +191,6 @@ class StreamingDataset(IterableDataset):
         if shuffle_seed is None:
             shuffle_seed = np.random.randint(1 << 60)
         prefix_int = np.random.randint(1 << 24)
-        if world.num_ranks > 1:
-            # Setup for coordinating.
-            device_prefix = 'cuda' if torch.cuda.is_available() else 'cpu'
-            device = torch.device(f'{device_prefix}:{world.rank_of_node}')
-            tensor = torch.zeros(1, dtype=torch.int64, device=device)
-
-            # Coordinate the shuffle seed across ranks.
-            if world.is_leader:
-                tensor[0] = shuffle_seed
-            dist.broadcast(tensor, 0)
-            shuffle_seed = int(tensor)
-
-            # Add a coordinated random prefix to all shm names for uniqueness.
-            if world.is_leader:
-                tensor[0] = prefix_int
-            dist.broadcast(tensor, 0)
-            prefix_int = int(tensor)
         self.shuffle_seed = shuffle_seed
         self._prefix = f'{prefix_int:06x}'
 
@@ -352,7 +339,7 @@ class StreamingDataset(IterableDataset):
                        world: World,
                        epoch: int,
                        sample_in_epoch: int,
-                       timeout: Optional[float] = 60) -> NDArray[np.int64]:
+                       timeout: float = 60) -> NDArray[np.int64]:
         """Get this worker's partition of this epoch's sample space.
 
         Args:
@@ -391,17 +378,7 @@ class StreamingDataset(IterableDataset):
             os.rename(tmp_filename, filename)
 
         # Everyone waits for the file to become populated.
-        t0 = time()
-        while True:
-            sleep(TICK)
-            if os.path.exists(filename):
-                sleep(TICK)
-                break
-            if timeout is not None:
-                dt = time() - t0
-                if timeout < dt:
-                    raise RuntimeError('Partitioning and shuffling took too long, bailing out: ' +
-                                       f'{timeout:.3f} < {dt:.3f} sec.')
+        is_file_exist(filename, TICK, timeout, 'Partitioning and shuffling took too long')
 
         # Each worker loads its slice of the sample ID tensor to iterate through.
         # Tensor shape: (num nodes, ranks per node, workers per rank, samples per worker).

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -119,8 +119,8 @@ class StreamingDataset(IterableDataset):
             an exception. Defaults to ``60``.
         validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
             shards. Defaults to ``None``.
-        shuffle_seed (int, optional): Seed for shuffling, or ``None`` for random seed. Defaults to
-            ``None``.
+        shuffle_seed (int, optional): Seed for Deterministic data shuffling. Defaults to
+            ``9176``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with resumption.
             Defaults to ``None``, which is interpreted as the number of nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
@@ -137,7 +137,7 @@ class StreamingDataset(IterableDataset):
                  download_retry: int = 2,
                  download_timeout: float = 60,
                  validate_hash: Optional[str] = None,
-                 shuffle_seed: Optional[int] = None,
+                 shuffle_seed: Optional[int] = 9176,
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None):
         self.local = local
@@ -188,8 +188,6 @@ class StreamingDataset(IterableDataset):
         self.index = Index(self.shard_sizes)
 
         # Determine and distribute shuffle seed and shm prefix.
-        if shuffle_seed is None:
-            shuffle_seed = np.random.randint(1 << 24)
         seed_rng = np.random.default_rng(shuffle_seed)
         self.shuffle_seed = int(seed_rng.integers(1 << 60))
         prefix_int = np.random.randint(1 << 24)

--- a/streaming/base/util.py
+++ b/streaming/base/util.py
@@ -3,6 +3,8 @@
 
 """Utility and helper functions for datasets."""
 
+import os
+from time import sleep, time
 from typing import List
 
 __all__ = ['get_list_arg']
@@ -18,3 +20,26 @@ def get_list_arg(text: str) -> List[str]:
         List[str]: Splits, if any.
     """
     return text.split(',') if text else []
+
+
+def is_file_exist(filename: str, sleep_time: float, timeout: float, err_msg: str) -> None:
+    """Wait for the file to exist till timeout seconds. Raise an Exception after that.
+
+    Args:
+        filename (str): A file name
+        sleep_time (float): Number of seconds to wait before next polling
+        timeout (float): Number of seconds to wait for a file to exist before raising an exception
+        err_msg (str): Error message description for an exception
+
+    Raises:
+        RuntimeError: Raise an Exception if file does not exist after timeout
+    """
+    start_time = time()
+    while True:
+        sleep(sleep_time)
+        if os.path.exists(filename):
+            sleep(sleep_time)
+            break
+        dt = time() - start_time
+        if dt > timeout:
+            raise RuntimeError(f'{err_msg}, bailing out: ' + f'{timeout:.3f} < {dt:.3f} sec.')

--- a/streaming/base/util.py
+++ b/streaming/base/util.py
@@ -22,12 +22,13 @@ def get_list_arg(text: str) -> List[str]:
     return text.split(',') if text else []
 
 
-def is_file_exist(filename: str, sleep_time: float, timeout: float, err_msg: str) -> None:
+def wait_for_file_to_exist(filename: str, poll_interval: float, timeout: float,
+                           err_msg: str) -> None:
     """Wait for the file to exist till timeout seconds. Raise an Exception after that.
 
     Args:
         filename (str): A file name
-        sleep_time (float): Number of seconds to wait before next polling
+        poll_interval (float): Number of seconds to wait before next polling
         timeout (float): Number of seconds to wait for a file to exist before raising an exception
         err_msg (str): Error message description for an exception
 
@@ -36,9 +37,9 @@ def is_file_exist(filename: str, sleep_time: float, timeout: float, err_msg: str
     """
     start_time = time()
     while True:
-        sleep(sleep_time)
+        sleep(poll_interval)
         if os.path.exists(filename):
-            sleep(sleep_time)
+            sleep(poll_interval)
             break
         dt = time() - start_time
         if dt > timeout:

--- a/streaming/text/c4.py
+++ b/streaming/text/c4.py
@@ -41,8 +41,7 @@ class StreamingC4(StreamingDataset):
             an exception. Defaults to ``60``.
         validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
             shards. Defaults to ``None``.
-        shuffle_seed (int, optional): Seed for shuffling, or ``None`` for random seed. Defaults to
-            ``None``.
+        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with resumption.
             Defaults to ``None``, which is interpreted as the number of nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
@@ -62,7 +61,7 @@ class StreamingC4(StreamingDataset):
                  download_retry: int = 2,
                  download_timeout: float = 60,
                  validate_hash: Optional[str] = None,
-                 shuffle_seed: Optional[int] = None,
+                 shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None):
         if group_method not in {'truncate', 'concat'}:

--- a/streaming/text/enwiki.py
+++ b/streaming/text/enwiki.py
@@ -33,8 +33,7 @@ class StreamingEnWiki(StreamingDataset):
             an exception. Defaults to ``60``.
         validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
             shards. Defaults to ``None``.
-        shuffle_seed (int, optional): Seed for shuffling, or ``None`` for random seed. Defaults to
-            ``None``.
+        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with resumption.
             Defaults to ``None``, which is interpreted as the number of nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
@@ -51,7 +50,7 @@ class StreamingEnWiki(StreamingDataset):
                  download_retry: int = 2,
                  download_timeout: float = 60,
                  validate_hash: Optional[str] = None,
-                 shuffle_seed: Optional[int] = None,
+                 shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None):
         super().__init__(local, remote, split, shuffle, predownload, keep_zip, download_retry,

--- a/streaming/text/pile.py
+++ b/streaming/text/pile.py
@@ -41,8 +41,7 @@ class StreamingPile(StreamingDataset):
             an exception. Defaults to ``60``.
         validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
             shards. Defaults to ``None``.
-        shuffle_seed (int, optional): Seed for shuffling, or ``None`` for random seed. Defaults to
-            ``None``.
+        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with resumption.
             Defaults to ``None``, which is interpreted as the number of nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
@@ -62,7 +61,7 @@ class StreamingPile(StreamingDataset):
                  download_retry: int = 2,
                  download_timeout: float = 60,
                  validate_hash: Optional[str] = None,
-                 shuffle_seed: Optional[int] = None,
+                 shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None) -> None:
         if group_method not in ['truncate']:

--- a/streaming/vision/ade20k.py
+++ b/streaming/vision/ade20k.py
@@ -41,8 +41,7 @@ class StreamingADE20K(StreamingDataset):
             an exception. Defaults to ``60``.
         validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
             shards. Defaults to ``None``.
-        shuffle_seed (int, optional): Seed for shuffling, or ``None`` for random seed. Defaults to
-            ``None``.
+        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with resumption.
             Defaults to ``None``, which is interpreted as the number of nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
@@ -62,7 +61,7 @@ class StreamingADE20K(StreamingDataset):
                  download_retry: int = 2,
                  download_timeout: float = 60,
                  validate_hash: Optional[str] = None,
-                 shuffle_seed: Optional[int] = None,
+                 shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None):
         super().__init__(local, remote, split, shuffle, predownload, keep_zip, download_retry,

--- a/streaming/vision/base.py
+++ b/streaming/vision/base.py
@@ -73,8 +73,7 @@ class StreamingVisionDataset(StreamingDataset, VisionDataset):
             an exception. Defaults to ``60``.
         validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
             shards. Defaults to ``None``.
-        shuffle_seed (int, optional): Seed for shuffling, or ``None`` for random seed. Defaults to
-            ``None``.
+        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with resumption.
             Defaults to ``None``, which is interpreted as the number of nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
@@ -94,7 +93,7 @@ class StreamingVisionDataset(StreamingDataset, VisionDataset):
                  download_retry: int = 2,
                  download_timeout: float = 60,
                  validate_hash: Optional[str] = None,
-                 shuffle_seed: Optional[int] = None,
+                 shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None):
         super().__init__(local, remote, split, shuffle, predownload, keep_zip, download_retry,
@@ -153,8 +152,7 @@ class StreamingImageClassDataset(StreamingVisionDataset):
             an exception. Defaults to ``60``.
         validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
             shards. Defaults to ``None``.
-        shuffle_seed (int, optional): Seed for shuffling, or ``None`` for random seed. Defaults to
-            ``None``.
+        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with resumption.
             Defaults to ``None``, which is interpreted as the number of nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
@@ -173,7 +171,7 @@ class StreamingImageClassDataset(StreamingVisionDataset):
                  download_retry: int = 2,
                  download_timeout: float = 60,
                  validate_hash: Optional[str] = None,
-                 shuffle_seed: Optional[int] = None,
+                 shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None):
         transforms = None

--- a/streaming/vision/cifar10.py
+++ b/streaming/vision/cifar10.py
@@ -37,8 +37,7 @@ class StreamingCIFAR10(StreamingImageClassDataset):
             an exception. Defaults to ``60``.
         validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
             shards. Defaults to ``None``.
-        shuffle_seed (int, optional): Seed for shuffling, or ``None`` for random seed. Defaults to
-            ``None``.
+        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with resumption.
             Defaults to ``None``, which is interpreted as the number of nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is

--- a/streaming/vision/coco.py
+++ b/streaming/vision/coco.py
@@ -37,8 +37,7 @@ class StreamingCOCO(StreamingDataset):
             an exception. Defaults to ``60``.
         validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
             shards. Defaults to ``None``.
-        shuffle_seed (int, optional): Seed for shuffling, or ``None`` for random seed. Defaults to
-            ``None``.
+        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with resumption.
             Defaults to ``None``, which is interpreted as the number of nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
@@ -56,7 +55,7 @@ class StreamingCOCO(StreamingDataset):
                  download_retry: int = 2,
                  download_timeout: float = 60,
                  validate_hash: Optional[str] = None,
-                 shuffle_seed: Optional[int] = None,
+                 shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None):
         super().__init__(local, remote, split, shuffle, predownload, keep_zip, download_retry,

--- a/streaming/vision/imagenet.py
+++ b/streaming/vision/imagenet.py
@@ -37,8 +37,7 @@ class StreamingImageNet(StreamingImageClassDataset):
             an exception. Defaults to ``60``.
         validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
             shards. Defaults to ``None``.
-        shuffle_seed (int, optional): Seed for shuffling, or ``None`` for random seed. Defaults to
-            ``None``.
+        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with resumption.
             Defaults to ``None``, which is interpreted as the number of nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is


### PR DESCRIPTION
## Description of changes:
- Removed the CUDA memory allocation which was used to synchronize the `shuffle_seed` and `prefix_int` across ranks.
- Based on how randomness works, the initial value `shuffle_seed` or `prefix_int` would be same across all the ranks, hence, there is no need for `dist.broadcast` operation.
- User needs to set the seed for getting the deterministic behavior on single node and multi-node training which is the same behavior as before.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:
CO-1591

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
