### PR TITLE
Reference the shared memory object in a worker process when using spawn multiprocessing method

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -320,6 +320,9 @@ class StreamingDataset(IterableDataset):
         Returns:
             Tuple[int, int]: What epoch this is, and sample offset in that epoch.
         """
+        # Reference the same shared memory object in a worker process
+        self._next_epoch_arr = np.ndarray(1, buffer=self._next_epoch_shm.buf, dtype=np.int64)
+
         # Either resume from checkpoint, or start from scratch.
         presumed_epoch = self.next_epoch
         epoch, sample_in_epoch = self._resume(world, presumed_epoch)


### PR DESCRIPTION
## Description of changes:
- Torch DataLoader uses multiprocessing to spin up `num_workers` processes. 
  - The Linux system by default start method is `fork` and when a process is forked the child process inherits all the same variables in the same state as they were in the parent. 
  - The Mac system by default start method is `spawn` and when a process is spawned, it begins by starting a new Python interpreter. The current module is reimported and new versions of all the variables are created.
- For the `spawn` processes, since the resources are not shared, any changes made in `next_epoch` variable by the `num_workers` will not be reflected in the main process and this results in the `test_streamingdataloader_mid_epoch_resumption` test failures when `num_workers` > 0.
- The changes made in this PR would reference the same shared memory object in the `num_workers` processes which was created in the main process. This would ensure that the main process or a parent process would see the updated values when changes made by the `num_workers` processes.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
