### PR TITLE
Release all the StreamingDataset resources during job termination

### DIFF
--- a/streaming/base/shared.py
+++ b/streaming/base/shared.py
@@ -54,11 +54,11 @@ class SharedBarrier:
                 break
             except FileNotFoundError:
                 sleep(TICK)
-                dt = time() - start_time
-                if dt > TIMEOUT:
+                elapsed = time() - start_time
+                if elapsed > TIMEOUT:
                     raise RuntimeError(
                         f'Timed out waiting for creating a shared memory block, bailing out: ' +
-                        f'{TIMEOUT:.3f} < {dt:.3f} sec.')
+                        f'{TIMEOUT:.3f} < {elapsed:.3f} sec.')
                 continue
         self._arr = np.ndarray(3, buffer=self._shm.buf, dtype=np.int32)
         self._arr[0] = 0

--- a/streaming/base/shared.py
+++ b/streaming/base/shared.py
@@ -175,7 +175,7 @@ class SharedBarrier:
 
 
 def create_shared_memory(name: Optional[str] = None, size: int = 0) -> SharedMemory:
-    """Create a new Shared Memory block or attaches to an existing shared memory block.
+    """Create a new Shared Memory block or attach to an existing shared memory block.
 
     Args:
         name (str, optional): A unique shared memory block name. Defaults to None.

--- a/streaming/base/shared.py
+++ b/streaming/base/shared.py
@@ -70,13 +70,16 @@ class SharedBarrier:
 
     def __del__(self):
         """Destructor clears array that references shm."""
-        if self._shm is not None:
+        if hasattr(self, '_shm') and self._shm is not None:
             # Close each SharedMemory instance
             self._shm.close()
             if self.is_local_leader:
                 # Call unlink only once to release the shared memory
                 self._shm.unlink()
-        if self.is_local_leader:
+            else:
+                # Wait for local leader process to execute first
+                sleep(1)
+        if hasattr(self, 'dirname') and self.is_local_leader:
             if os.path.islink(self.dirname):
                 os.unlink(self.dirname)
             shutil.rmtree(self.dirname)

--- a/streaming/base/util.py
+++ b/streaming/base/util.py
@@ -4,8 +4,11 @@
 """Utility and helper functions for datasets."""
 
 import os
+import shutil
 from time import sleep, time
 from typing import List
+
+from streaming.base.world import World
 
 __all__ = ['get_list_arg']
 
@@ -44,3 +47,22 @@ def wait_for_file_to_exist(filename: str, poll_interval: float, timeout: float,
         dt = time() - start_time
         if dt > timeout:
             raise RuntimeError(f'{err_msg}, bailing out: ' + f'{timeout:.3f} < {dt:.3f} sec.')
+
+
+def wait_for_local_leader(world: World) -> None:
+    """Wait for local rank 0.
+
+    Args:
+        world (World): World state.
+    """
+    dir_path = os.path.join(os.path.sep, 'tmp', 'streaming', 'local_sync')
+    if world.is_local_leader:
+        os.makedirs(dir_path, exist_ok=True)
+    else:
+        wait_for_file_to_exist(dir_path,
+                               poll_interval=0.07,
+                               timeout=60,
+                               err_msg='Waiting for local rank 0')
+        if os.path.islink(dir_path):
+            os.unlink(dir_path)
+        shutil.rmtree(dir_path)

--- a/tests/test_barrier.py
+++ b/tests/test_barrier.py
@@ -16,10 +16,10 @@ from streaming.base.shared import SharedBarrier
 
 class TestSharedBarrier:
 
-    @pytest.mark.parametrize('filelock_path', ['/tmp/file_path'])
+    @pytest.mark.parametrize('filelock_path', ['/tmp/dir/file_path'])
     @pytest.mark.parametrize('shm_path', ['barrier_shm_path'])
     def test_params(self, filelock_path: str, shm_path: str):
-        barrier = SharedBarrier(filelock_path, shm_path)
+        barrier = SharedBarrier(filelock_path, shm_path, True)
         assert barrier.filelock_path == filelock_path
         assert barrier.shm_path == shm_path
         assert isinstance(barrier._arr, np.ndarray)
@@ -32,7 +32,7 @@ class TestSharedBarrier:
     @pytest.mark.parametrize('num_exit', [4, 9])
     @pytest.mark.parametrize('flag', [True, False])
     def test_setter_getter(self, num_enter: int, num_exit: int, flag: bool):
-        barrier = SharedBarrier('/tmp/file_path', 'barrier_shm_path')
+        barrier = SharedBarrier('/tmp/dir/file_path', 'barrier_shm_path', True)
         barrier.num_enter = num_enter
         assert barrier.num_enter == num_enter
         barrier.num_exit = num_exit
@@ -53,7 +53,7 @@ class TestSharedBarrier:
         mp.set_start_method('fork', force=True)
         manager = mp.Manager()
         shared_list = manager.list()
-        barrier = SharedBarrier('/tmp/file_path', 'barrier_shm_path')
+        barrier = SharedBarrier('/tmp/dir/file_path', 'barrier_shm_path', True)
         processes = [
             mp.Process(target=self.run, args=(num_process, barrier, shared_list))
             for _ in range(num_process)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -105,6 +105,8 @@ def test_dataset_determinism(mds_dataset_dir: Any, batch_size: int, seed: int, s
     for sample in dataset:
         sample_order.append(sample['id'])
 
+    del dataset
+
     # Build StreamingDataset again to test deterministic sample ID
     dataset = StreamingDataset(local=local_dir,
                                remote=remote_dir,

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -95,6 +95,8 @@ def test_dataloader_determinism(mds_dataset_dir: Any, batch_size: int, seed: int
     sample_order = []
     for batch in dataloader:
         sample_order.extend(batch['id'][:])
+    del dataloader
+    del dataset
 
     # Build StreamingDataset again to test deterministic sample ID
     dataset = StreamingDataset(local=local_dir,
@@ -184,6 +186,9 @@ def test_streamingdataloader_mid_epoch_resumption(mds_dataset_dir: Any, batch_si
             assert state_dict is not None
             break
         sample_order.extend(batch['id'][:])
+
+    del dataloader
+    del dataset
 
     dataset = StreamingDataset(local=local_dir,
                                remote=remote_dir,


### PR DESCRIPTION
## Description of changes:
- Release all the StreamingDataset resources during job termination and fixed all the memory leaks
- Before:
```
$ pytest tests/

========================================================================= short test summary info 
=========================================================================
SKIPPED [6] tests/test_distributed.py:66: Fails due to new shared Filelock. See https://mosaicml.atlassian.net/browse/CO- 
1403
=================================================== 488 passed, 6 skipped, 5 deselected, 1 warning in 
129.29s (0:02:09) ===================================================
/opt/homebrew/Cellar/python@3.10/3.10.7/Frameworks/Python.framework/Versions/3.10/lib/python3.10/multiprocessing/reso urce_tracker.py:224: UserWarning: resource_tracker: 
There appear to be 378 leaked shared_memory objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
```
  - After:
  ```
  $ pytest tests/


  ========================================================================= short test summary info 
  =========================================================================
  SKIPPED [6] tests/test_distributed.py:66: Fails due to new shared Filelock. See https://mosaicml.atlassian.net/browse/CO- 
  1403
  ================================================== 488 passed, 6 skipped, 5 deselected, 2 warnings in 
  121.43s (0:02:01) ===================================================
  ```

- Ran the gpt-125m LLM model training
- Before
```
/usr/lib/python3.10/multiprocessing/resource_tracker.py:224: UserWarning: resource_tracker: There appear to be 6 leaked shared_memory objects to clean up at shutdown
  warnings.warn('resource_tracker: There appear to be %d '
/usr/lib/python3.10/multiprocessing/resource_tracker.py:237: UserWarning: resource_tracker: '/88fcf1_next_epoch': [Errno 2] No such file or directory: '/88fcf1_next_epoch'
  warnings.warn('resource_tracker: %r: %s' % (name, e))
/usr/lib/python3.10/multiprocessing/resource_tracker.py:237: UserWarning: resource_tracker: '/6f2a6f_shard_states': [Errno 2] No such file or directory: '/6f2a6f_shard_states'
  warnings.warn('resource_tracker: %r: %s' % (name, e))
/usr/lib/python3.10/multiprocessing/resource_tracker.py:237: UserWarning: resource_tracker: '/6f2a6f_barrier': [Errno 2] No such file or directory: '/6f2a6f_barrier'
  warnings.warn('resource_tracker: %r: %s' % (name, e))
/usr/lib/python3.10/multiprocessing/resource_tracker.py:237: UserWarning: resource_tracker: '/88fcf1_barrier': [Errno 2] No such file or directory: '/88fcf1_barrier'
  warnings.warn('resource_tracker: %r: %s' % (name, e))
/usr/lib/python3.10/multiprocessing/resource_tracker.py:237: UserWarning: resource_tracker: '/6f2a6f_next_epoch': [Errno 2] No such file or directory: '/6f2a6f_next_epoch'
  warnings.warn('resource_tracker: %r: %s' % (name, e))
/usr/lib/python3.10/multiprocessing/resource_tracker.py:237: UserWarning: resource_tracker: '/88fcf1_shard_states': [Errno 2] No such file or directory: '/88fcf1_shard_states'
  warnings.warn('resource_tracker: %r: %s' % (name, e))
Waiting up to 30 seconds for all training processes to terminate. Press Ctrl-C to exit immediately.
```
- After
```
wandb: Synced 5 W&B file(s), 0 media file(s), 0 artifact file(s) and 0 other file(s)
wandb: Find logs at:
Waiting up to 30 seconds for all training processes to terminate. Press Ctrl-C to exit immediately.
```

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
