### PR TITLE
Fix ade20k conversion script

### DIFF
--- a/streaming/vision/convert/ade20k.py
+++ b/streaming/vision/convert/ade20k.py
@@ -86,10 +86,13 @@ def get(in_root: str, split: str, shuffle: bool) -> List[Tuple[str, str, str]]:
         List of samples of (uid, image_filename, annotation_filename).
     """
     # Get uids
-    split_images_in_dir = os.path.join(in_root, 'images', split)
+    if split not in ('train', 'val'):
+        raise ValueError(f"Split must be one of 'train', 'val', not {split}")
+    subdir = 'training' if split == 'train' else 'validation'
+    split_images_in_dir = os.path.join(in_root, 'images', subdir)
     if not os.path.exists(split_images_in_dir):
         raise FileNotFoundError(f'Images path does not exist: {split_images_in_dir}')
-    split_annotations_in_dir = os.path.join(in_root, 'annotations', split)
+    split_annotations_in_dir = os.path.join(in_root, 'annotations', subdir)
     if not os.path.exists(split_annotations_in_dir):
         raise FileNotFoundError(f'Annotations path does not exist: {split_annotations_in_dir}')
     image_glob_pattern = os.path.join(split_images_in_dir, f'ADE_{split}_*.jpg')


### PR DESCRIPTION
## Description of changes:

Fixes incorrect subdirectory paths for ade20k.

- 'train' -> 'training'
- 'val' -> 'validation'

## Issue #, if available:
Fixes [CO-1698](https://mosaicml.atlassian.net/browse/CO-1698).

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [X] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.