### PR TITLE
Fix Lossy JPEG reencoding for MDS format

### DIFF
--- a/streaming/base/format/mds/encodings.py
+++ b/streaming/base/format/mds/encodings.py
@@ -11,6 +11,7 @@ from typing import Any, Optional, Set
 
 import numpy as np
 from PIL import Image
+from PIL.JpegImagePlugin import JpegImageFile
 
 __all__ = [
     'get_mds_encoded_size', 'get_mds_encodings', 'is_mds_encoding', 'mds_decode', 'mds_encode'
@@ -208,9 +209,14 @@ class JPEG(Encoding):
 
     def encode(self, obj: Image.Image) -> bytes:
         self._validate(obj, Image.Image)
-        out = BytesIO()
-        obj.save(out, format='JPEG')
-        return out.getvalue()
+        if isinstance(obj, JpegImageFile) and hasattr(obj, 'filename'):
+            # read the source file to prevent lossy re-encoding
+            with open(obj.filename, 'rb') as f:
+                return f.read()
+        else:
+            out = BytesIO()
+            obj.save(out, format='JPEG')
+            return out.getvalue()
 
     def decode(self, data: bytes) -> Image.Image:
         inp = BytesIO(data)


### PR DESCRIPTION
## Description of changes:

I believe that currently MDSWriter performs lossy re-encoding on JPEG files, losing image information in the process. As many popular vision datasets are composed of JPEG files, it seems a relevant to preserve the original data whenever possible.

The way to address this is to identify JPEG files that have been opened via PIL and use the filename attribute to read the data on disk directly. The current examples seem to smartly bypass this (e.g. [ImageNet](https://github.com/mosaicml/streaming/blob/main/streaming/vision/convert/imagenet.py#L154)) by reading the file contents and relying that `mds_encode` won't encode bytes objects (see [here](https://github.com/mosaicml/streaming/blob/main/streaming/base/format/mds/encodings.py#L319)). However, this is not documented in the user guide at all and it is probably a footgun if PIL JpegFile objects are passed to the MDSWriter.

This [notebook gist](https://gist.github.com/JJGO/7dfc5bef956d622ee02fc82fd54af752) shows the behavior before and after the patch. A clear indication of data loss is the ~15% filesize reduction after reencoding. The jpeg artifacting is also displayed.

## Merge Checklist:

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).


### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

- I added a `test_jpegfile_encode_decode` that enforces data preservation as the current `test_jpeg_encode_decode` doesn't.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
