### PR TITLE
Synchronize prefix_int across all ranks to resolve hang issue

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -8,10 +8,11 @@ import os
 from enum import IntEnum
 from multiprocessing.shared_memory import SharedMemory
 from threading import Thread
-from time import sleep
+from time import sleep, time
 from typing import Any, Dict, Iterator, Optional, Tuple
 
 import numpy as np
+import torch.distributed as dist
 from filelock import FileLock
 from numpy.typing import NDArray
 from torch.utils.data import IterableDataset
@@ -30,6 +31,7 @@ from streaming.base.world import World
 
 # Time to wait, in seconds.
 TICK = 0.07
+TIMEOUT = 60
 
 
 class _ShardState(IntEnum):
@@ -202,12 +204,32 @@ class StreamingDataset(IterableDataset):
         # Determine and distribute shuffle seed and shm prefix.
         seed_rng = np.random.default_rng(shuffle_seed)
         self.shuffle_seed = int(seed_rng.integers(1 << 60))
-        prefix_int = np.random.randint(1 << 24)
+        prefix_int = int(seed_rng.integers(1 << 24))
         self._prefix = f'{prefix_int:06x}'
 
         # Should be a unique shared directory per each StreamingDataset instantiation to avoid a conflict
         # between a different StreamingDataset instance on a same machine.
-        self._shared_dir = os.path.join(os.path.sep, 'tmp', 'streaming', self._prefix)
+        start_time = time()
+        while True:
+            sleep(TICK)
+            self._shared_dir = os.path.join(os.path.sep, 'tmp', 'streaming', self._prefix)
+            if os.path.exists(self._shared_dir):
+                prefix_int = int(seed_rng.integers(1 << 24))
+                self._prefix = f'{prefix_int:06x}'
+            else:
+                break
+            dt = time() - start_time
+            if dt > TIMEOUT:
+                raise RuntimeError(
+                    f'Could not find the unique shared directory, bailing out. Please provide a different `shuffle_seed` value.'
+                )
+
+        # Initialize the distributed package and synchronize all the ranks
+        if dist.is_available() and not dist.is_initialized():
+            dist.init_process_group(backend='nccl' if dist.is_nccl_available() else 'gloo',
+                                    rank=world.rank,
+                                    world_size=world.num_ranks)
+        dist.barrier()
 
         # Create the shared memory-backed worker barrier, without its lock, which is unpickleable.
         worker_barrier_filelock_path = os.path.join(self._shared_dir, 'barrier_filelock')
@@ -235,6 +257,9 @@ class StreamingDataset(IterableDataset):
         # downloaded).
         self._shard_states = create_shared_memory(name=f'{self._prefix}_shard_states',
                                                   size=len(self.shard_sizes) * np.uint8(0).nbytes)
+
+        # Destroy process group, and de-initialize the distributed package
+        dist.destroy_process_group()
 
     @property
     def next_epoch(self) -> int:

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import socket
 import tempfile
 from typing import Any, List, Optional
 
@@ -53,3 +54,12 @@ def get_config_in_bytes(format: str,
         'column_sizes': column_sizes
     }
     return json.dumps(config, sort_keys=True).encode('utf-8')
+
+
+def get_free_tcp_port() -> int:
+    """Get a free socket port to listen on."""
+    tcp = socket.socket()
+    tcp.bind(('', 0))
+    _, port = tcp.getsockname()
+    tcp.close()
+    return port

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,17 @@ from typing import Any
 
 import pytest
 
-from tests.common.utils import compressed_remote_local, remote_local  # pyright: ignore
+from tests.common.utils import compressed_remote_local  # pyright: ignore
+from tests.common.utils import get_free_tcp_port  # pyright: ignore
+from tests.common.utils import remote_local  # pyright: ignore
 from tests.test_reader import mds_dataset_dir  # pyright: ignore
+
+
+@pytest.fixture(scope='session', autouse=True)
+def tests_setup_and_teardown():
+    # Will be executed before the first test
+    os.environ['MASTER_ADDR'] = 'localhost'
+    os.environ['MASTER_PORT'] = str(get_free_tcp_port())
 
 
 # Override of pytest "runtest" for DistributedTest class

--- a/tests/test_laziness.py
+++ b/tests/test_laziness.py
@@ -2,14 +2,17 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import shutil
+from typing import Tuple
+
+import pytest
 
 from streaming import MDSWriter, StreamingDataset
 
 
-def test_laziness():
+@pytest.mark.usefixtures('remote_local')
+def test_laziness(remote_local: Tuple[str, str]):
     num_samples = 100_000
-    local = 'my-local'
-    remote = 'my-remote'
+    remote, local = remote_local
     columns = {'value': 'int'}
     compression = None
     hashes = None
@@ -49,6 +52,3 @@ def test_laziness():
     for i in range(num_samples):
         sample = dataset[i]
         assert sample['value'] == i
-
-    shutil.rmtree(remote)
-    shutil.rmtree(local)


### PR DESCRIPTION
## Description of changes:
- Without setting the seed inside the main script, all the ranks generates a unique [prefix_int](https://github.com/mosaicml/streaming/blob/main/streaming/base/dataset.py#L205) which is not expected and this leads to [worker_barrier](https://github.com/mosaicml/streaming/blob/main/streaming/base/dataset.py#L215) being hanged since it expects all the ranks to generate the same `prefix_int`.
- The changes in this PR ensures all the ranks sees the same `prefix_int` which fixes the hang issue.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:
CO-1688

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

### Integration Testing

- Ran [Resnet50](https://github.com/mosaicml/examples/blob/main/examples/resnet/yamls/mcloud_run.yaml) model training and [gpt llm 125m](https://github.com/mosaicml/examples/blob/main/examples/llm/yamls/mosaic_gpt/125m.yaml) model training on below configurations and I didn't see a hang:
  - Single node: with and without `composer.utils.reproducibility.seed_all(seed)`
  - Multi-node (2 nodes): with and without `composer.utils.reproducibility.seed_all(seed)`

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
