### PR TITLE
Avoid common local folder when instantiating more than one StreamingDataset

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -164,10 +164,11 @@ class StreamingDataset(IterableDataset):
             raise ValueError(
                 'Parameter ``download_timeout`` (in seconds) must be greater than zero')
         local_split_path = os.path.join(self.local, self.split)
-        # Check if the directory exist and also not empty
-        if os.path.exists(local_split_path) and os.listdir(local_split_path):
+        # Check if the directory exist and is also not empty
+        if self.remote is not None and os.path.exists(local_split_path) and os.listdir(
+                local_split_path):
             raise ValueError(''.join([
-                f'Directory {local_split_path} already exist and not empty.',
+                f'Directory {local_split_path} already exist and is also not empty.',
                 'Either delete or empty the directory or provide a different `split` parameter.'
             ]))
 

--- a/tests/test_laziness.py
+++ b/tests/test_laziness.py
@@ -47,6 +47,8 @@ def test_laziness(remote_local: Tuple[str, str]):
     for i, sample in zip(range(num_samples), dataset):
         assert sample['value'] == i
 
+    shutil.rmtree(local)
+
     # Re-verify __getitem__ downloads/accesses.
     dataset = StreamingDataset(local, remote)
     for i in range(num_samples):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -191,3 +191,15 @@ def test_reader_getitem(mds_dataset_dir: Any, share_remote_local: bool, index: i
     sample = dataset[index]
     assert sample['id'] == f'{index:06}'
     assert sample['sample'] == 3 * index
+
+
+@pytest.mark.usefixtures('mds_dataset_dir')
+def test_same_local_dir_exception(mds_dataset_dir: Any):
+    remote_dir, local_dir = mds_dataset_dir
+    batch_size = 8
+
+    with pytest.raises(ValueError) as exc_info:
+        # Build StreamingDataset
+        _ = StreamingDataset(local=local_dir, remote=remote_dir, batch_size=batch_size)
+        _ = StreamingDataset(local=local_dir, remote=remote_dir, batch_size=batch_size)
+    assert exc_info.match(r'.*Either delete or empty the directory*')

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -98,6 +98,7 @@ def test_dataloader_determinism(mds_dataset_dir: Any, batch_size: int, seed: int
         sample_order.extend(batch['id'][:])
     del dataloader
     del dataset
+    shutil.rmtree(local_dir)
 
     # Build StreamingDataset again to test deterministic sample ID
     dataset = StreamingDataset(local=local_dir,
@@ -190,6 +191,7 @@ def test_streamingdataloader_mid_epoch_resumption(mds_dataset_dir: Any, batch_si
 
     del dataloader
     del dataset
+    shutil.rmtree(local_dir)
 
     dataset = StreamingDataset(local=local_dir,
                                remote=remote_dir,


### PR DESCRIPTION
## Description of changes:
- There is an issue where if the split is same for both `train` and `val` dataloader, which by default means using the same local folder for both `train` and `val` dataloader, the script non-deterministically fails with `FileNotFoundError: [Errno 2] No such file or directory: ‘/tmp/the-pile/val/shard.00000.mds'`. The issue doesn’t occur if using a separate local folder for `train` and `val` dataloader.
- The changes in this PR checks if the local split directory exists and empty or not and raise Exception if it exists and not empty.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:
CO-1667

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
