### PR TITLE
Fixed CPU crash

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -266,7 +266,7 @@ class StreamingDataset(IterableDataset):
                                                   size=len(self.shard_sizes) * np.uint8(0).nbytes)
 
         # Destroy process group, and de-initialize the distributed package
-        if is_dist_pg_initialized and self._rank_world.num_ranks > 1:
+        if is_dist_pg_initialized:
             dist.destroy_process_group()
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,13 +12,6 @@ from tests.common.utils import remote_local  # pyright: ignore
 from tests.test_reader import mds_dataset_dir  # pyright: ignore
 
 
-@pytest.fixture(scope='session', autouse=True)
-def tests_setup_and_teardown():
-    # Will be executed before the first test
-    os.environ['MASTER_ADDR'] = 'localhost'
-    os.environ['MASTER_PORT'] = str(get_free_tcp_port())
-
-
 # Override of pytest "runtest" for DistributedTest class
 # This hook is run before the default pytest_runtest_call
 @pytest.hookimpl(tryfirst=True)  # pyright: ignore


### PR DESCRIPTION
## Description of changes:
### What was the issue?
- When Instantiating and iterating a StreamingDataset or doing a model training on a CPU based Instance / Single GPU based instance, it crashes with `ValueError: Error initializing torch.distributed using env:// rendezvous: environment variable MASTER_ADDR expected, but not set`. 

### Why was it not caught before?
- The Streaming repository unit test was importing an environment variables `MASTER_ADDR` and a `MASTER_PORT` in the [conftest.py](https://github.com/mosaicml/streaming/blob/8d5d9818ce6972f1f82a529156abfd2f35612a7b/tests/conftest.py#L15) file. Hence, it was not caught during unit test.

### What have you done to resolve the issue?
This PR does 2 things to fix the issue:
- Check if it is a non-distributed environment and skip the distributed initialization if it is a non-distributed workload.
- Remove the `MASTER_ADDR` and `MASTER_PORT` environment variables from the unit test. 

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:
CO-1771

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

### Unit test

#### 1. Streaming Unit test
PASSED
```
=================================================== 
515 passed, 6 skipped, 5 deselected, 1 warning in 144.51s (0:02:24) 
===================================================
```
#### 2. MosaicML Examples repository Unit test
Ran the CI Unit test with this PR changes to ensure all the unit test passes.
Repo link: [mosaicml/streaming](https://github.com/mosaicml/streaming)
CI Test: [PASSED](https://github.com/karan6181/examples/actions/runs/4165071290)

#### 3. Integration Test

- [1 node / 1 GPUs] [[GPT LLM 125m on C4](https://github.com/mosaicml/examples/blob/main/examples/llm/yamls/mosaic_gpt/125m.yaml)] for 100 batches: PASSED
- [1 node / 1 GPUs] [[BERT](https://github.com/mosaicml/examples/blob/main/examples/bert/yamls/main/mosaic-bert-base-uncased.yaml)] on C4 for 200 batches : PASSED
- [1 node / 1 GPUs] [[Resnet50](https://github.com/mosaicml/examples/blob/main/examples/resnet/yamls/resnet50.yaml)] on ImageNet for 2 epochs: PASSED
- [1 node / 8 GPUs] [[GPT LLM 125m on C4](https://github.com/mosaicml/examples/blob/main/examples/llm/yamls/mosaic_gpt/125m.yaml)] for 4800 batches: PASSED
- [1 node / 8 GPUs] [[BERT](https://github.com/mosaicml/examples/blob/main/examples/bert/yamls/main/mosaic-bert-base-uncased.yaml)] on C4 for 200 batches : PASSED
- [1 node / 8 GPUs] [[Resnet50 on ImageNet](https://github.com/mosaicml/examples/blob/main/examples/resnet/yamls/mcloud_run.yaml)] for 36 epochs: PASSED
- [2 nodes / 16 GPUs] [[Resnet50 on ImageNet](https://github.com/mosaicml/examples/blob/main/examples/resnet/yamls/mcloud_run.yaml)] for 36 epochs: PASSED
- [2 node / 16 GPUs] [[GPT LLM 125m on C4](https://github.com/mosaicml/examples/blob/main/examples/llm/yamls/mosaic_gpt/125m.yaml)] for 4800 batches: PASSED

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.


<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
