### PR TITLE
Adjust StreamingDataset arguments

### DIFF
--- a/scripts/serialization/compare.py
+++ b/scripts/serialization/compare.py
@@ -174,7 +174,7 @@ def mds_read_seq(dirname: str) -> Iterator[Dict[str, Any]]:
     Returns:
         Iterator[Dict[str, Any]]: Iterator over samples.
     """
-    yield from StreamingDataset(dirname)
+    yield from StreamingDataset(local=dirname)
 
 
 def mds_read_shuf(dirname: str) -> Iterator[Dict[str, Any]]:
@@ -186,7 +186,7 @@ def mds_read_shuf(dirname: str) -> Iterator[Dict[str, Any]]:
     Returns:
         Iterator[Dict[str, Any]]: Iterator over samples.
     """
-    yield from StreamingDataset(dirname, shuffle=True)
+    yield from StreamingDataset(local=dirname, shuffle=True)
 
 
 def mds_read_rand(dirname: str) -> Iterator[Dict[str, Any]]:
@@ -198,7 +198,7 @@ def mds_read_rand(dirname: str) -> Iterator[Dict[str, Any]]:
     Returns:
         Iterator[Dict[str, Any]]: Iterator over samples.
     """
-    dataset = StreamingDataset(dirname)
+    dataset = StreamingDataset(local=dirname)
     indices = np.random.permutation(dataset.index.total_samples)
     for idx in indices:
         yield dataset[idx]

--- a/scripts/webvid/bench_inside.py
+++ b/scripts/webvid/bench_inside.py
@@ -30,7 +30,7 @@ def main(args: Namespace):
     Args:
         args (Namespace): Command-line arguments.
     """
-    dataset = StreamingInsideWebVid(args.local, args.remote)
+    dataset = StreamingInsideWebVid(local=args.local, remote=args.remote)
     tt = []
     t0 = time()
     for _ in dataset:

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -127,6 +127,8 @@ class StreamingDataset(IterableDataset):
             initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
+        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
+        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py2s``.
     """
 
     def __init__(self,
@@ -142,7 +144,9 @@ class StreamingDataset(IterableDataset):
                  validate_hash: Optional[str] = None,
                  shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
-                 batch_size: Optional[int] = None):
+                 batch_size: Optional[int] = None,
+                 partition_algo: str = 'orig',
+                 shuffle_algo: str = 'py2s'):
         self.local = local
         self.remote = remote
         self.split = split or ''  # Empty string for os.path.join().
@@ -152,6 +156,8 @@ class StreamingDataset(IterableDataset):
         self.download_retry = download_retry
         self.download_timeout = download_timeout
         self.validate_hash = validate_hash or None
+        self.partition_algo = partition_algo
+        self.shuffle_algo = shuffle_algo
 
         if self.download_retry < 0:
             raise ValueError('Parameter ``download_retry`` must be non-negative')

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -146,7 +146,7 @@ class StreamingDataset(IterableDataset):
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None,
                  partition_algo: str = 'orig',
-                 shuffle_algo: str = 'py2s'):
+                 shuffle_algo: str = 'py2s') -> None:
         self.local = local
         self.remote = remote
         self.split = split or ''  # Empty string for os.path.join().

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -130,6 +130,7 @@ class StreamingDataset(IterableDataset):
     """
 
     def __init__(self,
+                 *,
                  local: str,
                  remote: Optional[str] = None,
                  split: Optional[str] = None,

--- a/streaming/multimodal/convert/webvid/inside_to_outside.py
+++ b/streaming/multimodal/convert/webvid/inside_to_outside.py
@@ -44,7 +44,7 @@ def main(args: Namespace) -> None:
         args (Namespace): Command-line arguments.
     """
     hashes = args.hashes.split(',') if args.hashes else []
-    dataset = StreamingDataset(getattr(args, 'in'))
+    dataset = StreamingDataset(local=getattr(args, 'in'))
     with MDSWriter(local=args.out_mds,
                    columns=out_columns,
                    compression=args.compression,

--- a/streaming/multimodal/webvid.py
+++ b/streaming/multimodal/webvid.py
@@ -41,6 +41,8 @@ class StreamingInsideWebVid(StreamingDataset):
             initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
+        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
+        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py2s``.
     """
 
     def __getitem__(self, idx: int) -> Any:
@@ -87,6 +89,8 @@ class StreamingOutsideGIWebVid(StreamingDataset):
             initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
+        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
+        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py2s``.
         extra_local (str, optional): Base destination of extra local sample downloads.
         extra_remote (str, optional): Base source of extra remote sample downloads.
     """
@@ -105,6 +109,8 @@ class StreamingOutsideGIWebVid(StreamingDataset):
                  shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None,
+                 partition_algo: str = 'orig',
+                 shuffle_algo: str = 'py2s',
                  extra_local: Optional[str] = None,
                  extra_remote: Optional[str] = None):
         super().__init__(local=local,
@@ -118,7 +124,9 @@ class StreamingOutsideGIWebVid(StreamingDataset):
                          validate_hash=validate_hash,
                          shuffle_seed=shuffle_seed,
                          num_canonical_nodes=num_canonical_nodes,
-                         batch_size=batch_size)
+                         batch_size=batch_size,
+                         partition_algo=partition_algo,
+                         shuffle_algo=shuffle_algo)
 
         # Videos are stored outside of their shards here.
         self.extra_local = extra_local
@@ -180,6 +188,8 @@ class StreamingOutsideDTWebVid(StreamingDataset):
             initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
+        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
+        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py2s``.
         extra_local (str, optional): Base destination of extra local sample downloads.
         extra_remote (str, optional): Base source of extra remote sample downloads.
     """
@@ -198,6 +208,8 @@ class StreamingOutsideDTWebVid(StreamingDataset):
                  shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None,
+                 partition_algo: str = 'orig',
+                 shuffle_algo: str = 'py2s',
                  extra_local: Optional[str] = None,
                  extra_remote: Optional[str] = None):
         super().__init__(local=local,
@@ -211,7 +223,9 @@ class StreamingOutsideDTWebVid(StreamingDataset):
                          validate_hash=validate_hash,
                          shuffle_seed=shuffle_seed,
                          num_canonical_nodes=num_canonical_nodes,
-                         batch_size=batch_size)
+                         batch_size=batch_size,
+                         partition_algo=partition_algo,
+                         shuffle_algo=shuffle_algo)
 
         # Videos are stored outside of their shards here.
         self.extra_local = extra_local

--- a/streaming/multimodal/webvid.py
+++ b/streaming/multimodal/webvid.py
@@ -92,6 +92,7 @@ class StreamingOutsideGIWebVid(StreamingDataset):
     """
 
     def __init__(self,
+                 *,
                  local: str,
                  remote: Optional[str] = None,
                  split: Optional[str] = None,
@@ -106,9 +107,18 @@ class StreamingOutsideGIWebVid(StreamingDataset):
                  batch_size: Optional[int] = None,
                  extra_local: Optional[str] = None,
                  extra_remote: Optional[str] = None):
-        super().__init__(local, remote, split, shuffle, predownload, keep_zip, download_retry,
-                         download_timeout, validate_hash, shuffle_seed, num_canonical_nodes,
-                         batch_size)
+        super().__init__(local=local,
+                         remote=remote,
+                         split=split,
+                         shuffle=shuffle,
+                         predownload=predownload,
+                         keep_zip=keep_zip,
+                         download_retry=download_retry,
+                         download_timeout=download_timeout,
+                         validate_hash=validate_hash,
+                         shuffle_seed=shuffle_seed,
+                         num_canonical_nodes=num_canonical_nodes,
+                         batch_size=batch_size)
 
         # Videos are stored outside of their shards here.
         self.extra_local = extra_local
@@ -175,6 +185,7 @@ class StreamingOutsideDTWebVid(StreamingDataset):
     """
 
     def __init__(self,
+                 *,
                  local: str,
                  remote: Optional[str] = None,
                  split: Optional[str] = None,
@@ -189,9 +200,18 @@ class StreamingOutsideDTWebVid(StreamingDataset):
                  batch_size: Optional[int] = None,
                  extra_local: Optional[str] = None,
                  extra_remote: Optional[str] = None):
-        super().__init__(local, remote, split, shuffle, predownload, keep_zip, download_retry,
-                         download_timeout, validate_hash, shuffle_seed, num_canonical_nodes,
-                         batch_size)
+        super().__init__(local=local,
+                         remote=remote,
+                         split=split,
+                         shuffle=shuffle,
+                         predownload=predownload,
+                         keep_zip=keep_zip,
+                         download_retry=download_retry,
+                         download_timeout=download_timeout,
+                         validate_hash=validate_hash,
+                         shuffle_seed=shuffle_seed,
+                         num_canonical_nodes=num_canonical_nodes,
+                         batch_size=batch_size)
 
         # Videos are stored outside of their shards here.
         self.extra_local = extra_local

--- a/streaming/text/c4.py
+++ b/streaming/text/c4.py
@@ -50,6 +50,7 @@ class StreamingC4(StreamingDataset):
     """
 
     def __init__(self,
+                 *,
                  tokenizer_name: str,
                  max_seq_len: int,
                  group_method: str,
@@ -68,9 +69,18 @@ class StreamingC4(StreamingDataset):
         if group_method not in {'truncate'}:
             raise ValueError(f"group_method='{group_method}' must be one of {'truncate'}.")
 
-        super().__init__(local, remote, split, shuffle, predownload, keep_zip, download_retry,
-                         download_timeout, validate_hash, shuffle_seed, num_canonical_nodes,
-                         batch_size)
+        super().__init__(local=local,
+                         remote=remote,
+                         split=split,
+                         shuffle=shuffle,
+                         predownload=predownload,
+                         keep_zip=keep_zip,
+                         download_retry=download_retry,
+                         download_timeout=download_timeout,
+                         validate_hash=validate_hash,
+                         shuffle_seed=shuffle_seed,
+                         num_canonical_nodes=num_canonical_nodes,
+                         batch_size=batch_size)
         self.tokenizer_name = tokenizer_name
         self.max_seq_len = max_seq_len
         self.group_method = group_method

--- a/streaming/text/c4.py
+++ b/streaming/text/c4.py
@@ -47,6 +47,8 @@ class StreamingC4(StreamingDataset):
             initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
+        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
+        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py2s``.
     """
 
     def __init__(self,
@@ -65,7 +67,9 @@ class StreamingC4(StreamingDataset):
                  validate_hash: Optional[str] = None,
                  shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
-                 batch_size: Optional[int] = None):
+                 batch_size: Optional[int] = None,
+                 partition_algo: str = 'orig',
+                 shuffle_algo: str = 'py2s') -> None:
         if group_method not in {'truncate'}:
             raise ValueError(f"group_method='{group_method}' must be one of {'truncate'}.")
 
@@ -80,7 +84,9 @@ class StreamingC4(StreamingDataset):
                          validate_hash=validate_hash,
                          shuffle_seed=shuffle_seed,
                          num_canonical_nodes=num_canonical_nodes,
-                         batch_size=batch_size)
+                         batch_size=batch_size,
+                         partition_algo=partition_algo,
+                         shuffle_algo=shuffle_algo)
         self.tokenizer_name = tokenizer_name
         self.max_seq_len = max_seq_len
         self.group_method = group_method

--- a/streaming/text/enwiki.py
+++ b/streaming/text/enwiki.py
@@ -39,6 +39,8 @@ class StreamingEnWiki(StreamingDataset):
             initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
+        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
+        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py2s``.
     """
 
     def __init__(self,
@@ -54,7 +56,9 @@ class StreamingEnWiki(StreamingDataset):
                  validate_hash: Optional[str] = None,
                  shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
-                 batch_size: Optional[int] = None):
+                 batch_size: Optional[int] = None,
+                 partition_algo: str = 'orig',
+                 shuffle_algo: str = 'py2s') -> None:
         super().__init__(local=local,
                          remote=remote,
                          split=split,
@@ -66,7 +70,9 @@ class StreamingEnWiki(StreamingDataset):
                          validate_hash=validate_hash,
                          shuffle_seed=shuffle_seed,
                          num_canonical_nodes=num_canonical_nodes,
-                         batch_size=batch_size)
+                         batch_size=batch_size,
+                         partition_algo=partition_algo,
+                         shuffle_algo=shuffle_algo)
         self.field_dtypes = {
             'input_ids': np.int32,
             'input_mask': np.int32,

--- a/streaming/text/enwiki.py
+++ b/streaming/text/enwiki.py
@@ -42,6 +42,7 @@ class StreamingEnWiki(StreamingDataset):
     """
 
     def __init__(self,
+                 *,
                  local: str,
                  remote: Optional[str] = None,
                  split: Optional[str] = None,
@@ -54,9 +55,18 @@ class StreamingEnWiki(StreamingDataset):
                  shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None):
-        super().__init__(local, remote, split, shuffle, predownload, keep_zip, download_retry,
-                         download_timeout, validate_hash, shuffle_seed, num_canonical_nodes,
-                         batch_size)
+        super().__init__(local=local,
+                         remote=remote,
+                         split=split,
+                         shuffle=shuffle,
+                         predownload=predownload,
+                         keep_zip=keep_zip,
+                         download_retry=download_retry,
+                         download_timeout=download_timeout,
+                         validate_hash=validate_hash,
+                         shuffle_seed=shuffle_seed,
+                         num_canonical_nodes=num_canonical_nodes,
+                         batch_size=batch_size)
         self.field_dtypes = {
             'input_ids': np.int32,
             'input_mask': np.int32,

--- a/streaming/text/pile.py
+++ b/streaming/text/pile.py
@@ -50,6 +50,7 @@ class StreamingPile(StreamingDataset):
     """
 
     def __init__(self,
+                 *,
                  tokenizer_name: str,
                  max_seq_len: int,
                  group_method: str,
@@ -68,9 +69,18 @@ class StreamingPile(StreamingDataset):
         if group_method not in ['truncate']:
             raise ValueError(f'Only group_method="truncate" is supported at this time.')
 
-        super().__init__(local, remote, split, shuffle, predownload, keep_zip, download_retry,
-                         download_timeout, validate_hash, shuffle_seed, num_canonical_nodes,
-                         batch_size)
+        super().__init__(local=local,
+                         remote=remote,
+                         split=split,
+                         shuffle=shuffle,
+                         predownload=predownload,
+                         keep_zip=keep_zip,
+                         download_retry=download_retry,
+                         download_timeout=download_timeout,
+                         validate_hash=validate_hash,
+                         shuffle_seed=shuffle_seed,
+                         num_canonical_nodes=num_canonical_nodes,
+                         batch_size=batch_size)
         self.tokenizer_name = tokenizer_name
         self.max_seq_len = max_seq_len
         self.group_method = group_method

--- a/streaming/text/pile.py
+++ b/streaming/text/pile.py
@@ -47,6 +47,8 @@ class StreamingPile(StreamingDataset):
             initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
+        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
+        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py2s``.
     """
 
     def __init__(self,
@@ -65,7 +67,9 @@ class StreamingPile(StreamingDataset):
                  validate_hash: Optional[str] = None,
                  shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
-                 batch_size: Optional[int] = None) -> None:
+                 batch_size: Optional[int] = None,
+                 partition_algo: str = 'orig',
+                 shuffle_algo: str = 'py2s') -> None:
         if group_method not in ['truncate']:
             raise ValueError(f'Only group_method="truncate" is supported at this time.')
 
@@ -80,7 +84,9 @@ class StreamingPile(StreamingDataset):
                          validate_hash=validate_hash,
                          shuffle_seed=shuffle_seed,
                          num_canonical_nodes=num_canonical_nodes,
-                         batch_size=batch_size)
+                         batch_size=batch_size,
+                         partition_algo=partition_algo,
+                         shuffle_algo=shuffle_algo)
         self.tokenizer_name = tokenizer_name
         self.max_seq_len = max_seq_len
         self.group_method = group_method

--- a/streaming/vision/ade20k.py
+++ b/streaming/vision/ade20k.py
@@ -50,6 +50,7 @@ class StreamingADE20K(StreamingDataset):
     """
 
     def __init__(self,
+                 *,
                  local: str,
                  remote: Optional[str] = None,
                  split: Optional[str] = None,
@@ -65,9 +66,18 @@ class StreamingADE20K(StreamingDataset):
                  shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None):
-        super().__init__(local, remote, split, shuffle, predownload, keep_zip, download_retry,
-                         download_timeout, validate_hash, shuffle_seed, num_canonical_nodes,
-                         batch_size)
+        super().__init__(local=local,
+                         remote=remote,
+                         split=split,
+                         shuffle=shuffle,
+                         predownload=predownload,
+                         keep_zip=keep_zip,
+                         download_retry=download_retry,
+                         download_timeout=download_timeout,
+                         validate_hash=validate_hash,
+                         shuffle_seed=shuffle_seed,
+                         num_canonical_nodes=num_canonical_nodes,
+                         batch_size=batch_size)
         self.joint_transform = joint_transform
         self.transform = transform
         self.target_transform = target_transform

--- a/streaming/vision/ade20k.py
+++ b/streaming/vision/ade20k.py
@@ -47,6 +47,8 @@ class StreamingADE20K(StreamingDataset):
             initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
+        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
+        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py2s``.
     """
 
     def __init__(self,
@@ -65,7 +67,9 @@ class StreamingADE20K(StreamingDataset):
                  validate_hash: Optional[str] = None,
                  shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
-                 batch_size: Optional[int] = None):
+                 batch_size: Optional[int] = None,
+                 partition_algo: str = 'orig',
+                 shuffle_algo: str = 'py2s') -> None:
         super().__init__(local=local,
                          remote=remote,
                          split=split,
@@ -77,7 +81,9 @@ class StreamingADE20K(StreamingDataset):
                          validate_hash=validate_hash,
                          shuffle_seed=shuffle_seed,
                          num_canonical_nodes=num_canonical_nodes,
-                         batch_size=batch_size)
+                         batch_size=batch_size,
+                         partition_algo=partition_algo,
+                         shuffle_algo=shuffle_algo)
         self.joint_transform = joint_transform
         self.transform = transform
         self.target_transform = target_transform

--- a/streaming/vision/base.py
+++ b/streaming/vision/base.py
@@ -82,6 +82,7 @@ class StreamingVisionDataset(StreamingDataset, VisionDataset):
     """
 
     def __init__(self,
+                 *,
                  local: str,
                  remote: Optional[str] = None,
                  split: Optional[str] = None,
@@ -97,9 +98,18 @@ class StreamingVisionDataset(StreamingDataset, VisionDataset):
                  shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None):
-        super().__init__(local, remote, split, shuffle, predownload, keep_zip, download_retry,
-                         download_timeout, validate_hash, shuffle_seed, num_canonical_nodes,
-                         batch_size)
+        super().__init__(local=local,
+                         remote=remote,
+                         split=split,
+                         shuffle=shuffle,
+                         predownload=predownload,
+                         keep_zip=keep_zip,
+                         download_retry=download_retry,
+                         download_timeout=download_timeout,
+                         validate_hash=validate_hash,
+                         shuffle_seed=shuffle_seed,
+                         num_canonical_nodes=num_canonical_nodes,
+                         batch_size=batch_size)
 
         has_transforms = transforms is not None
         has_separate_transform = transform is not None or target_transform is not None
@@ -162,6 +172,7 @@ class StreamingImageClassDataset(StreamingVisionDataset):
     """
 
     def __init__(self,
+                 *,
                  local: str,
                  remote: Optional[str] = None,
                  split: Optional[str] = None,
@@ -176,7 +187,18 @@ class StreamingImageClassDataset(StreamingVisionDataset):
                  shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None):
-        transforms = None
-        super().__init__(local, remote, split, shuffle, transforms, transform, target_transform,
-                         predownload, keep_zip, download_retry, download_timeout, validate_hash,
-                         shuffle_seed, num_canonical_nodes, batch_size)
+        super().__init__(local=local,
+                         remote=remote,
+                         split=split,
+                         shuffle=shuffle,
+                         transforms=None,
+                         transform=transform,
+                         target_transform=target_transform,
+                         predownload=predownload,
+                         keep_zip=keep_zip,
+                         download_retry=download_retry,
+                         download_timeout=download_timeout,
+                         validate_hash=validate_hash,
+                         shuffle_seed=shuffle_seed,
+                         num_canonical_nodes=num_canonical_nodes,
+                         batch_size=batch_size)

--- a/streaming/vision/base.py
+++ b/streaming/vision/base.py
@@ -79,6 +79,8 @@ class StreamingVisionDataset(StreamingDataset, VisionDataset):
             initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
+        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
+        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py2s``.
     """
 
     def __init__(self,
@@ -97,7 +99,9 @@ class StreamingVisionDataset(StreamingDataset, VisionDataset):
                  validate_hash: Optional[str] = None,
                  shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
-                 batch_size: Optional[int] = None):
+                 batch_size: Optional[int] = None,
+                 partition_algo: str = 'orig',
+                 shuffle_algo: str = 'py2s'):
         super().__init__(local=local,
                          remote=remote,
                          split=split,
@@ -109,7 +113,9 @@ class StreamingVisionDataset(StreamingDataset, VisionDataset):
                          validate_hash=validate_hash,
                          shuffle_seed=shuffle_seed,
                          num_canonical_nodes=num_canonical_nodes,
-                         batch_size=batch_size)
+                         batch_size=batch_size,
+                         partition_algo=partition_algo,
+                         shuffle_algo=shuffle_algo)
 
         has_transforms = transforms is not None
         has_separate_transform = transform is not None or target_transform is not None
@@ -169,6 +175,8 @@ class StreamingImageClassDataset(StreamingVisionDataset):
             initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
+        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
+        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py2s``.
     """
 
     def __init__(self,
@@ -186,7 +194,9 @@ class StreamingImageClassDataset(StreamingVisionDataset):
                  validate_hash: Optional[str] = None,
                  shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
-                 batch_size: Optional[int] = None):
+                 batch_size: Optional[int] = None,
+                 partition_algo: str = 'orig',
+                 shuffle_algo: str = 'py2s'):
         super().__init__(local=local,
                          remote=remote,
                          split=split,
@@ -201,4 +211,6 @@ class StreamingImageClassDataset(StreamingVisionDataset):
                          validate_hash=validate_hash,
                          shuffle_seed=shuffle_seed,
                          num_canonical_nodes=num_canonical_nodes,
-                         batch_size=batch_size)
+                         batch_size=batch_size,
+                         partition_algo=partition_algo,
+                         shuffle_algo=shuffle_algo)

--- a/streaming/vision/base.py
+++ b/streaming/vision/base.py
@@ -101,7 +101,7 @@ class StreamingVisionDataset(StreamingDataset, VisionDataset):
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None,
                  partition_algo: str = 'orig',
-                 shuffle_algo: str = 'py2s'):
+                 shuffle_algo: str = 'py2s') -> None:
         super().__init__(local=local,
                          remote=remote,
                          split=split,
@@ -196,7 +196,7 @@ class StreamingImageClassDataset(StreamingVisionDataset):
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None,
                  partition_algo: str = 'orig',
-                 shuffle_algo: str = 'py2s'):
+                 shuffle_algo: str = 'py2s') -> None:
         super().__init__(local=local,
                          remote=remote,
                          split=split,

--- a/streaming/vision/cifar10.py
+++ b/streaming/vision/cifar10.py
@@ -43,4 +43,6 @@ class StreamingCIFAR10(StreamingImageClassDataset):
             initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
+        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
+        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py2s``.
     """

--- a/streaming/vision/coco.py
+++ b/streaming/vision/coco.py
@@ -43,6 +43,8 @@ class StreamingCOCO(StreamingDataset):
             initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
+        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
+        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py2s``.
     """
 
     def __init__(self,
@@ -59,7 +61,9 @@ class StreamingCOCO(StreamingDataset):
                  validate_hash: Optional[str] = None,
                  shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
-                 batch_size: Optional[int] = None):
+                 batch_size: Optional[int] = None,
+                 partition_algo: str = 'orig',
+                 shuffle_algo: str = 'py2s') -> None:
         super().__init__(local=local,
                          remote=remote,
                          split=split,
@@ -71,7 +75,9 @@ class StreamingCOCO(StreamingDataset):
                          validate_hash=validate_hash,
                          shuffle_seed=shuffle_seed,
                          num_canonical_nodes=num_canonical_nodes,
-                         batch_size=batch_size)
+                         batch_size=batch_size,
+                         partition_algo=partition_algo,
+                         shuffle_algo=shuffle_algo)
         self.transform = transform
 
     def __getitem__(self, idx: int) -> Any:

--- a/streaming/vision/coco.py
+++ b/streaming/vision/coco.py
@@ -46,6 +46,7 @@ class StreamingCOCO(StreamingDataset):
     """
 
     def __init__(self,
+                 *,
                  local: str,
                  remote: Optional[str] = None,
                  split: Optional[str] = None,
@@ -59,9 +60,18 @@ class StreamingCOCO(StreamingDataset):
                  shuffle_seed: int = 9176,
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None):
-        super().__init__(local, remote, split, shuffle, predownload, keep_zip, download_retry,
-                         download_timeout, validate_hash, shuffle_seed, num_canonical_nodes,
-                         batch_size)
+        super().__init__(local=local,
+                         remote=remote,
+                         split=split,
+                         shuffle=shuffle,
+                         predownload=predownload,
+                         keep_zip=keep_zip,
+                         download_retry=download_retry,
+                         download_timeout=download_timeout,
+                         validate_hash=validate_hash,
+                         shuffle_seed=shuffle_seed,
+                         num_canonical_nodes=num_canonical_nodes,
+                         batch_size=batch_size)
         self.transform = transform
 
     def __getitem__(self, idx: int) -> Any:

--- a/streaming/vision/imagenet.py
+++ b/streaming/vision/imagenet.py
@@ -43,4 +43,6 @@ class StreamingImageNet(StreamingImageClassDataset):
             initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
+        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
+        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py2s``.
     """

--- a/tests/test_laziness.py
+++ b/tests/test_laziness.py
@@ -28,18 +28,18 @@ def test_laziness(remote_local: Tuple[str, str]):
             out.write(sample)
 
     # Verify __getitem__ accesses.
-    dataset = StreamingDataset(remote)
+    dataset = StreamingDataset(local=remote)
     for i in range(num_samples):
         sample = dataset[i]
         assert sample['value'] == i
 
     # Verify __iter__ -> __getitem__ accesses.
-    dataset = StreamingDataset(remote)
+    dataset = StreamingDataset(local=remote)
     for i, sample in zip(range(num_samples), dataset):
         assert sample['value'] == i
 
     # Verify __getitem__ downloads/accesses.
-    dataset = StreamingDataset(local, remote)
+    dataset = StreamingDataset(local=local, remote=remote)
     for i in range(num_samples):
         sample = dataset[i]
         assert sample['value'] == i
@@ -47,12 +47,12 @@ def test_laziness(remote_local: Tuple[str, str]):
     shutil.rmtree(local)
 
     # Verify __iter__ -> __getitem__ downloads/accesses.
-    dataset = StreamingDataset(local, remote)
+    dataset = StreamingDataset(local=local, remote=remote)
     for i, sample in zip(range(num_samples), dataset):
         assert sample['value'] == i
 
     # Re-verify __getitem__ downloads/accesses.
-    dataset = StreamingDataset(local, remote)
+    dataset = StreamingDataset(local=local, remote=remote)
     for i in range(num_samples):
         sample = dataset[i]
         assert sample['value'] == i

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -106,7 +106,7 @@ class TestMDSWriter:
         # Apply the seed again for numpy determinism
         dataset.seed = seed
 
-        mds_dataset = StreamingDataset(local, shuffle=False)
+        mds_dataset = StreamingDataset(local=local, shuffle=False)
         # Ensure length of dataset is equal
         assert len(dataset) == len(mds_dataset) == num_samples
 
@@ -162,7 +162,7 @@ class TestJSONWriter:
         # Apply the seed again for numpy determinism
         dataset.seed = seed
 
-        mds_dataset = StreamingDataset(local, shuffle=False)
+        mds_dataset = StreamingDataset(local=local, shuffle=False)
         # Ensure length of dataset is equal
         assert len(dataset) == len(mds_dataset) == num_samples
 
@@ -242,7 +242,7 @@ class TestXSVWriter:
         # Apply the seed again for numpy determinism
         dataset.seed = seed
 
-        mds_dataset = StreamingDataset(local, shuffle=False)
+        mds_dataset = StreamingDataset(local=local, shuffle=False)
         # Ensure length of dataset is equal
         assert len(dataset) == len(mds_dataset) == num_samples
 


### PR DESCRIPTION
## Description of changes:

Adjust StreamingDataset arguments: require kwargs only, and add stubs for `paritition_algo` and `shuffle_algo` to be implemented in a following PR.

We require all kwargs to StreamingDataset in order to protect us and our users as we evolve its arguments over time.

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
