### PR TITLE
Download the shard files as tmp extension until it finishes for OCI

### DIFF
--- a/streaming/base/storage.py
+++ b/streaming/base/storage.py
@@ -165,9 +165,11 @@ def download_from_oci(remote: str, local: str) -> None:
     # Remove leading and trailing forward slash from string
     object_path = obj.path.strip('/')
     object_details = client.get_object(namespace, bucket_name, object_path)
-    with open(local, 'wb') as f:
+    local_tmp = local + '.tmp'
+    with open(local_tmp, 'wb') as f:
         for chunk in object_details.data.raw.stream(2048**2, decode_content=False):
             f.write(chunk)
+    os.rename(local_tmp, local)
 
 
 def download_from_local(remote: str, local: str) -> None:


### PR DESCRIPTION
## Description of changes:
- With OCI cloud storage, file downloading happens in chunks. So, the issue here was that once first chunks get downloaded by one of the rank, other ranks thinks that the file is fully downloaded and starts loading the file which is unexpected behavior. 
- The fix in this PR is to download the file as an `.tmp` extension by one of the rank and once downloaded fully, change it back to original file name. During all this time, other ranks wait for file to exist and once rename happens by the main rank, other ranks can start loading.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:
STR-7

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
