### PR TITLE
Remove unsupported ThreadPoolExecutor shutdown param in python38

### DIFF
--- a/streaming/base/format/base/writer.py
+++ b/streaming/base/format/base/writer.py
@@ -248,7 +248,7 @@ class Writer(ABC):
             self._reset_cache()
         self._write_index()
         logger.debug(f'Waiting for all shard files to get uploaded to {self.remote}')
-        self.executor.shutdown(wait=True, cancel_futures=False)
+        self.executor.shutdown(wait=True)
         if self.remote and not self.keep_local:
             shutil.rmtree(self.local)
 


### PR DESCRIPTION
## Description of changes:
- Remove unsupported ThreadPoolExecutor shutdown param `cancel_futures` in python38.
- Parameter `cancel_futures` is being added in Python 3.9 or later. Since, we are keeping `cancel_futures` as `False` anyhow which is also a default parameter in `shutdown()` method, we can remove the `cancel_futures` parameter from `self.executor.shutdown()` call.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:
https://github.com/mosaicml/streaming/issues/192

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
