### PR TITLE
Raise an exception if bucket does not exist during upload

### DIFF
--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -178,7 +178,7 @@ class S3Uploader(CloudUploader):
         from botocore.config import Config
         config = Config()
         self.s3 = boto3.client('s3', config=config)
-        self.bucket_exists(self.remote)  # pyright: ignore
+        self.check_bucket_exists(self.remote)  # pyright: ignore
 
     def upload_file(self, filename: str):
         """Upload file from local instance to AWS S3 bucket.
@@ -204,7 +204,7 @@ class S3Uploader(CloudUploader):
             )
         self.clear_local(local=local_filename)
 
-    def bucket_exists(self, remote: str):
+    def check_bucket_exists(self, remote: str):
         """Raise an exception if the bucket does not exist.
 
         Args:
@@ -256,7 +256,7 @@ class GCSUploader(CloudUploader):
                                        endpoint_url='https://storage.googleapis.com',
                                        aws_access_key_id=os.environ['GCS_KEY'],
                                        aws_secret_access_key=os.environ['GCS_SECRET'])
-        self.bucket_exists(self.remote)  # pyright: ignore
+        self.check_bucket_exists(self.remote)  # pyright: ignore
 
     def upload_file(self, filename: str):
         """Upload file from local instance to Google Cloud Storage bucket.
@@ -282,7 +282,7 @@ class GCSUploader(CloudUploader):
             )
         self.clear_local(local=local_filename)
 
-    def bucket_exists(self, remote: str):
+    def check_bucket_exists(self, remote: str):
         """Raise an exception if the bucket does not exist.
 
         Args:
@@ -333,7 +333,7 @@ class OCIUploader(CloudUploader):
             config=config, retry_strategy=oci.retry.DEFAULT_RETRY_STRATEGY)
         self.namespace = self.client.get_namespace().data
         self.upload_manager = oci.object_storage.UploadManager(self.client)
-        self.bucket_exists(self.remote)  # pyright: ignore
+        self.check_bucket_exists(self.remote)  # pyright: ignore
 
     def upload_file(self, filename: str):
         """Upload file from local instance to OCI Cloud Storage bucket.
@@ -363,7 +363,7 @@ class OCIUploader(CloudUploader):
             )
         self.clear_local(local=local_filename)
 
-    def bucket_exists(self, remote: str):
+    def check_bucket_exists(self, remote: str):
         """Raise an exception if the bucket does not exist.
 
         Args:

--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -178,6 +178,7 @@ class S3Uploader(CloudUploader):
         from botocore.config import Config
         config = Config()
         self.s3 = boto3.client('s3', config=config)
+        self.bucket_exists(self.remote)  # pyright: ignore
 
     def upload_file(self, filename: str):
         """Upload file from local instance to AWS S3 bucket.
@@ -202,6 +203,26 @@ class S3Uploader(CloudUploader):
                 Callback=lambda bytes_transferred: pbar.update(bytes_transferred),
             )
         self.clear_local(local=local_filename)
+
+    def bucket_exists(self, remote: str):
+        """Raise an exception if the bucket does not exist.
+
+        Args:
+            remote (str): S3 bucket path.
+
+        Raises:
+            error: Bucket does not exist.
+        """
+        from botocore.exceptions import ClientError
+
+        bucket_name = urllib.parse.urlparse(remote).netloc
+        try:
+            self.s3.head_bucket(Bucket=bucket_name)
+        except ClientError as error:
+            if error.response['Error']['Code'] == '404':
+                error.args = (f'Bucket `{bucket_name}` does not exist! ' +
+                              f'Check the bucket permission or create the bucket.',)
+            raise error
 
 
 class GCSUploader(CloudUploader):
@@ -235,6 +256,7 @@ class GCSUploader(CloudUploader):
                                        endpoint_url='https://storage.googleapis.com',
                                        aws_access_key_id=os.environ['GCS_KEY'],
                                        aws_secret_access_key=os.environ['GCS_SECRET'])
+        self.bucket_exists(self.remote)  # pyright: ignore
 
     def upload_file(self, filename: str):
         """Upload file from local instance to Google Cloud Storage bucket.
@@ -259,6 +281,26 @@ class GCSUploader(CloudUploader):
                 Callback=lambda bytes_transferred: pbar.update(bytes_transferred),
             )
         self.clear_local(local=local_filename)
+
+    def bucket_exists(self, remote: str):
+        """Raise an exception if the bucket does not exist.
+
+        Args:
+            remote (str): S3 bucket path.
+
+        Raises:
+            error: Bucket does not exist.
+        """
+        from botocore.exceptions import ClientError
+
+        bucket_name = urllib.parse.urlparse(remote).netloc
+        try:
+            self.gcs_client.head_bucket(Bucket=bucket_name)
+        except ClientError as error:
+            if error.response['Error']['Code'] == '404':
+                error.args = (f'Bucket `{bucket_name}` does not exist! ' +
+                              f'Check the bucket permission or create the bucket.',)
+            raise error
 
 
 class OCIUploader(CloudUploader):
@@ -287,10 +329,11 @@ class OCIUploader(CloudUploader):
 
         import oci
         config = oci.config.from_file()
-        client = oci.object_storage.ObjectStorageClient(
+        self.client = oci.object_storage.ObjectStorageClient(
             config=config, retry_strategy=oci.retry.DEFAULT_RETRY_STRATEGY)
-        self.namespace = client.get_namespace().data
-        self.upload_manager = oci.object_storage.UploadManager(client)
+        self.namespace = self.client.get_namespace().data
+        self.upload_manager = oci.object_storage.UploadManager(self.client)
+        self.bucket_exists(self.remote)  # pyright: ignore
 
     def upload_file(self, filename: str):
         """Upload file from local instance to OCI Cloud Storage bucket.
@@ -319,6 +362,27 @@ class OCIUploader(CloudUploader):
                 progress_callback=lambda bytes_transferred: pbar.update(bytes_transferred),
             )
         self.clear_local(local=local_filename)
+
+    def bucket_exists(self, remote: str):
+        """Raise an exception if the bucket does not exist.
+
+        Args:
+            remote (str): S3 bucket path.
+
+        Raises:
+            error: Bucket does not exist.
+        """
+        from oci.exceptions import ServiceError
+
+        obj = urllib.parse.urlparse(remote)
+        bucket_name = obj.netloc.split('@' + self.namespace)[0]
+        try:
+            self.client.head_bucket(bucket_name=bucket_name, namespace_name=self.namespace)
+        except ServiceError as error:
+            if error.status == 404:
+                error.args = (f'Bucket `{bucket_name}` does not exist! ' +
+                              f'Check the bucket permission or create the bucket.',)
+            raise error
 
 
 class LocalUploader(CloudUploader):

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -14,8 +14,8 @@ from streaming.base.storage.upload import CloudUploader, GCSUploader, LocalUploa
 
 class TestCloudUploader:
 
-    @patch('streaming.base.storage.upload.S3Uploader.bucket_exists')
-    @patch('streaming.base.storage.upload.GCSUploader.bucket_exists')
+    @patch('streaming.base.storage.upload.S3Uploader.check_bucket_exists')
+    @patch('streaming.base.storage.upload.GCSUploader.check_bucket_exists')
     @pytest.mark.parametrize(
         'mapping',
         [['s3://bucket/dir/file', S3Uploader], [None, 's3://bucket/dir/file', S3Uploader],
@@ -73,7 +73,7 @@ class TestCloudUploader:
         assert not os.path.exists(local_file_path)
 
     @pytest.mark.parametrize('out', ['s3://bucket/dir', 'gs://bucket/dir'])
-    def test_bucket_exists_exception(self, out: str):
+    def test_check_bucket_exists_exception(self, out: str):
         import botocore
         with pytest.raises(botocore.exceptions.ClientError):
             _ = CloudUploader.get(out=out)
@@ -81,7 +81,7 @@ class TestCloudUploader:
 
 class TestS3Uploader:
 
-    @patch('streaming.base.storage.upload.S3Uploader.bucket_exists')
+    @patch('streaming.base.storage.upload.S3Uploader.check_bucket_exists')
     @pytest.mark.parametrize('out', ['s3://bucket/dir', ('./dir1', 's3://bucket/dir/')])
     def test_instantiation(self, mocked_requests: Mock, out: Any):
         mocked_requests.side_effect = None
@@ -126,7 +126,7 @@ class TestS3Uploader:
             assert not os.path.exists(local_file_path)
 
     @pytest.mark.parametrize('out', ['s3://bucket/dir'])
-    def test_bucket_exists_exception(self, out: str):
+    def test_check_bucket_exists_exception(self, out: str):
         import botocore
         with pytest.raises(botocore.exceptions.ClientError):
             _ = S3Uploader(out=out)
@@ -134,7 +134,7 @@ class TestS3Uploader:
 
 class TestGCSUploader:
 
-    @patch('streaming.base.storage.upload.GCSUploader.bucket_exists')
+    @patch('streaming.base.storage.upload.GCSUploader.check_bucket_exists')
     @pytest.mark.parametrize('out', ['gs://bucket/dir', ('./dir1', 'gs://bucket/dir/')])
     def test_instantiation(self, mocked_requests: Mock, out: Any):
         mocked_requests.side_effect = None
@@ -179,7 +179,7 @@ class TestGCSUploader:
             assert not os.path.exists(local_file_path)
 
     @pytest.mark.parametrize('out', ['gs://bucket/dir'])
-    def test_bucket_exists_exception(self, out: str):
+    def test_check_bucket_exists_exception(self, out: str):
         import botocore
         with pytest.raises(botocore.exceptions.ClientError):
             _ = GCSUploader(out=out)


### PR DESCRIPTION
## Description of changes:
- Raise an exception if the bucket does not exist.
  - [Before] Silent failure where traceback is absent and zero files were upload to remote cloud storage location.
  - [After] Raise an exception if bucket does not exist during shard file upload as part of `Writer()`.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:
STR-37

## Testing
### 1. Invalid bucket [AWS S3]
```
Traceback (most recent call last):
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/vision/convert/cifar10.py", line 88, in <module>
    main(parse_args())
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/vision/convert/cifar10.py", line 83, in main
    convert_image_class_dataset(dataset, args.out_root, split, args.compression, hashes,
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/vision/convert/base.py", line 56, in convert_image_class_dataset
    with MDSWriter(out=out_split_dir,
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/format/mds/writer.py", line 60, in __init__
    super().__init__(out=out,
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/format/base/writer.py", line 318, in __init__
    super().__init__(out=out,
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/format/base/writer.py", line 102, in __init__
    self.cloud_writer = CloudUploader.get(out, keep_local, kwargs.get('progress_bar', False))
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/storage/upload.py", line 57, in get
    return getattr(sys.modules[__name__], UPLOADERS[obj.scheme])(out, keep_local, progress_bar)
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/storage/upload.py", line 181, in __init__
    self.bucket_exists(self.remote)  # pyright: ignore
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/storage/upload.py", line 225, in bucket_exists
    raise error
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/storage/upload.py", line 220, in bucket_exists
    self.s3.head_bucket(Bucket=bucket_name)
  File "/Users/karan/.virtualenvs/cloud_upload_streaming/lib/python3.10/site-packages/botocore/client.py", line 530, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/karan/.virtualenvs/cloud_upload_streaming/lib/python3.10/site-packages/botocore/client.py", line 960, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: Bucket `streaming-test-bucket-1` does not exist! Check the bucket permission or create the bucket.
```

### 2. Invalid bucket [GCS]
```
Traceback (most recent call last):
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/vision/convert/cifar10.py", line 88, in <module>
    main(parse_args())
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/vision/convert/cifar10.py", line 83, in main
    convert_image_class_dataset(dataset, args.out_root, split, args.compression, hashes,
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/vision/convert/base.py", line 56, in convert_image_class_dataset
    with MDSWriter(out=out_split_dir,
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/format/mds/writer.py", line 60, in __init__
    super().__init__(out=out,
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/format/base/writer.py", line 318, in __init__
    super().__init__(out=out,
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/format/base/writer.py", line 102, in __init__
    self.cloud_writer = CloudUploader.get(out, keep_local, kwargs.get('progress_bar', False))
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/storage/upload.py", line 57, in get
    return getattr(sys.modules[__name__], UPLOADERS[obj.scheme])(out, keep_local, progress_bar)
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/storage/upload.py", line 259, in __init__
    self.bucket_exists(self.remote)  # pyright: ignore
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/storage/upload.py", line 303, in bucket_exists
    raise error
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/storage/upload.py", line 298, in bucket_exists
    self.gcs_client.head_bucket(Bucket=bucket_name)
  File "/Users/karan/.virtualenvs/cloud_upload_streaming/lib/python3.10/site-packages/botocore/client.py", line 530, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/karan/.virtualenvs/cloud_upload_streaming/lib/python3.10/site-packages/botocore/client.py", line 960, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: Bucket `streaming-test-bucket-1` does not exist! Check the bucket permission or create the bucket.
```

### 3. Invalid bucket [OCI]
```
Traceback (most recent call last):
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/vision/convert/cifar10.py", line 88, in <module>
    main(parse_args())
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/vision/convert/cifar10.py", line 83, in main
    convert_image_class_dataset(dataset, args.out_root, split, args.compression, hashes,
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/vision/convert/base.py", line 56, in convert_image_class_dataset
    with MDSWriter(out=out_split_dir,
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/format/mds/writer.py", line 60, in __init__
    super().__init__(out=out,
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/format/base/writer.py", line 318, in __init__
    super().__init__(out=out,
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/format/base/writer.py", line 102, in __init__
    self.cloud_writer = CloudUploader.get(out, keep_local, kwargs.get('progress_bar', False))
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/storage/upload.py", line 57, in get
    return getattr(sys.modules[__name__], UPLOADERS[obj.scheme])(out, keep_local, progress_bar)
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/storage/upload.py", line 336, in __init__
    self.bucket_exists(self.remote)  # pyright: ignore
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/storage/upload.py", line 385, in bucket_exists
    raise error
  File "/Users/karan/Projects/bucket_do_not_exist_streaming/streaming/base/storage/upload.py", line 380, in bucket_exists
    self.client.head_bucket(bucket_name=bucket_name, namespace_name=self.namespace)
  File "/Users/karan/.virtualenvs/cloud_upload_streaming/lib/python3.10/site-packages/oci/object_storage/object_storage_client.py", line 2951, in head_bucket
    return retry_strategy.make_retrying_call(
  File "/Users/karan/.virtualenvs/cloud_upload_streaming/lib/python3.10/site-packages/oci/retry/retry.py", line 308, in make_retrying_call
    response = func_ref(*func_args, **func_kwargs)
  File "/Users/karan/.virtualenvs/cloud_upload_streaming/lib/python3.10/site-packages/oci/base_client.py", line 485, in call_api
    response = self.request(request, allow_control_chars, operation_name, api_reference_link)
  File "/Users/karan/.virtualenvs/cloud_upload_streaming/lib/python3.10/site-packages/circuitbreaker.py", line 159, in wrapper
    return call(function, *args, **kwargs)
  File "/Users/karan/.virtualenvs/cloud_upload_streaming/lib/python3.10/site-packages/circuitbreaker.py", line 170, in call
    return func(*args, **kwargs)
  File "/Users/karan/.virtualenvs/cloud_upload_streaming/lib/python3.10/site-packages/oci/base_client.py", line 632, in request
    self.raise_service_error(request, response, service_code, message, operation_name, api_reference_link, target_service, request_endpoint, client_version, timestamp, deserialized_data)
  File "/Users/karan/.virtualenvs/cloud_upload_streaming/lib/python3.10/site-packages/oci/base_client.py", line 789, in raise_service_error
    raise exceptions.ServiceError(
oci.exceptions.ServiceError: Bucket `streaming-test-bucket-1` does not exist! Check the bucket permission or create the bucket.
```

### 4. Valid bucket
```
.........
Uploading to s3://streaming-test-bucket/cifar10_mds/val/shard.00020.mds: 100%|██████████████████████████████████| 1.05M/1.05M [00:05<00:00, 204kB/s]
Uploading to s3://streaming-test-bucket/cifar10_mds/val/shard.00027.mds: 100%|██████████████████████████████████| 1.05M/1.05M [00:04<00:00, 234kB/s]
Uploading to s3://streaming-test-bucket/cifar10_mds/val/shard.00028.mds: 100%|██████████████████████████████████| 1.05M/1.05M [00:04<00:00, 237kB/s]
Uploading to s3://streaming-test-bucket/cifar10_mds/val/shard.00029.mds: 100%|████████████████████████████████████| 797k/797k [00:02<00:00, 370kB/s]
Uploading to s3://streaming-test-bucket/cifar10_mds/val/shard.00018.mds: 100%|██████████████████████████████████| 1.05M/1.05M [00:06<00:00, 170kB/s]
```

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
