### PR TITLE
Raise descriptive error message when index.json is corrupted

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -16,6 +16,7 @@ from filelock import FileLock
 from numpy.typing import NDArray
 from torch.utils.data import IterableDataset
 
+from streaming.base.format import get_index_basename
 from streaming.base.partition import get_partitions
 from streaming.base.shared import CreateSharedMemory, SharedBarrier, get_shm_prefix
 from streaming.base.shuffle import get_shuffle
@@ -264,6 +265,10 @@ class StreamingDataset(IterableDataset):
         for stream_id, stream in enumerate(self.streams):
             stream_shards = stream.get_shards(world)
             samples = sum(map(len, stream_shards))
+            if samples == 0:
+                index_json_filepath = os.path.join(stream.local, stream.split,
+                                                   get_index_basename())
+                raise RuntimeError(f'Empty `shards` in {index_json_filepath} file.')
             stream_per_shard += [stream_id] * len(stream_shards)
             self.shard_offset_per_stream[stream_id] = len(self.shards)
             self.shards_per_stream[stream_id] = len(stream_shards)

--- a/streaming/base/stream.py
+++ b/streaming/base/stream.py
@@ -306,7 +306,11 @@ class Stream:
         wait_for_file_to_exist(filename, TICK, self.download_timeout,
                                f'{filename} file took too long to download')
 
-        obj = json.load(open(filename))
+        try:
+            obj = json.load(open(filename))
+        except json.decoder.JSONDecodeError as error:
+            error.args = (f'Either {filename} is empty or corrupted. ' + error.args[0],)
+            raise error
         if obj['version'] != 2:
             raise ValueError(f'Unsupported version: {obj["version"]}')
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,12 +1,13 @@
 # Copyright 2023 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import logging
 import os
 import shutil
 import tempfile
 import time
-from typing import Any
+from typing import Any, Tuple
 
 import pytest
 
@@ -218,3 +219,35 @@ def test_dataset_split_instantiation(mds_dataset_dir: Any):
         remote_split_dir = os.path.join(remote_dir, split)
         copy_all_files(remote_dir, remote_split_dir)
         _ = StreamingDataset(local=local_dir, remote=remote_dir, split=split)
+
+
+@pytest.mark.usefixtures('mds_dataset_dir')
+def test_invalid_index_json_exception(local_remote_dir: Tuple[str, str]):
+    local_dir, _ = local_remote_dir
+    filename = 'index.json'
+    if not os.path.exists(local_dir):
+        os.mkdir(local_dir)
+
+    # Creates an empty file
+    with open(os.path.join(local_dir, filename), 'w') as _:
+        pass
+
+    with pytest.raises(json.decoder.JSONDecodeError, match=f'Either.*is empty or corrupted'):
+        _ = StreamingDataset(local=local_dir)
+
+
+@pytest.mark.usefixtures('mds_dataset_dir')
+def test_empty_shards_index_json_exception(local_remote_dir: Tuple[str, str]):
+    local_dir, _ = local_remote_dir
+    filename = 'index.json'
+    content = {'shards': [], 'version': 2}
+
+    if not os.path.exists(local_dir):
+        os.mkdir(local_dir)
+
+    # Creates a `index.json` file and write the content to it
+    with open(os.path.join(local_dir, filename), 'w') as outfile:
+        json.dump(content, outfile)
+
+    with pytest.raises(RuntimeError, match=f'Empty `shards` in.*file.'):
+        _ = StreamingDataset(local=local_dir)


### PR DESCRIPTION
## Description of changes:
- Raise descriptive error message when `index.json` is empty or corrupted.
- Raise descriptive error message when `shards` is empty in `index.json` file.
- Added test case for both

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:
STR-42

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
