### PR TITLE
Update readthedocs python version to 3.9

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,14 +5,19 @@
 # Required
 version: 2
 
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: html
   configuration: docs/source/conf.py
 
-# Optionally set the version of Python and requirements required to build your docs
+# Optionally declare the Python requirements required to build your docs
 python:
-  version: "3.9"
   install:
     - method: pip
       path: .[all]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: "3.8"
+  version: "3.9"
   install:
     - method: pip
       path: .[all]


### PR DESCRIPTION
## Description of changes:
- Update readthedocs python version to 3.9.
- Latest `Ipython` version `8.13.0` supports Python 3.9 and above.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->