### PR TITLE
Add support for Azure cloud storage

### DIFF
--- a/docs/source/how_to_guides/configure_cloud_storage_cred.md
+++ b/docs/source/how_to_guides/configure_cloud_storage_cred.md
@@ -176,3 +176,38 @@ export S3_ENDPOINT_URL='https://<accountid>.r2.cloudflarestorage.com'
 ````
 
 The above step will add an environment variable `S3_ENDPOINT_URL` to your runs and the streaming dataset fetches those environment variables for authentication and stream data into your instance.
+
+## Azure
+
+If you wish to create a new storage account, you can use the [Azure Portal](https://docs.microsoft.com/azure/storage/common/storage-quickstart-create-account?tabs=azure-portal), [Azure PowerShell](https://docs.microsoft.com/azure/storage/common/storage-quickstart-create-account?tabs=azure-powershell), or [Azure CLI](https://docs.microsoft.com/azure/storage/common/storage-quickstart-create-account?tabs=azure-cli):
+
+```
+# Create a new resource group to hold the storage account -
+# if using an existing resource group, skip this step
+az group create --name my-resource-group --location westus2
+
+# Create the storage account
+az storage account create -n my-storage-account-name -g my-resource-group
+```
+
+Users must set their Azure `account name` and Azure `account access key` in the run environment.
+
+The `account access key` can be found in the Azure Portal under the `"Access Keys"` section or by running the following Azure CLI command:
+
+```
+az storage account keys list -g MyResourceGroup -n MyStorageAccount
+```
+
+````{tabs}
+```{code-tab} py
+os.environ['AZURE_ACCOUNT_NAME'] = 'test'
+os.environ['AZURE_ACCOUNT_ACCESS_KEY'] = 'NN1KHxKKkj20ZO92EMiDQjx3wp2kZG4UUvfAGlgGWRn6sPRmGY/TEST/Dri+ExAmPlEExAmPlExA+ExAmPlExA=='
+```
+
+```{code-tab} sh
+export AZURE_ACCOUNT_NAME='test'
+export AZURE_ACCOUNT_ACCESS_KEY='NN1KHxKKkj20ZO92EMiDQjx3wp2kZG4UUvfAGlgGWRn6sPRmGY/TEST/Dri+ExAmPlEExAmPlExA+ExAmPlExA=='
+```
+````
+
+The above step will add two environment variables `AZURE_ACCOUNT_NAME` and `AZURE_ACCOUNT_ACCESS_KEY` to your runs and the streaming dataset fetches those environment variables for authentication and stream data into your instance.

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,20 @@ classifiers = [
 ]
 
 install_requires = [
-    'boto3>=1.21.45,<2', 'Brotli>=1.0.9', 'matplotlib>=3.5.2,<4', 'paramiko>=2.11.0,<4',
-    'python-snappy>=0.6.1,<1', 'torch>=1.10,<3', 'torchtext>=0.10', 'torchvision>=0.10',
-    'tqdm>=4.64.0,<5', 'transformers>=4.21.3,<5', 'xxhash>=3.0.0,<4', 'zstd>=1.5.2.5,<2',
-    'oci>=2.88,<3', 'azure-storage-blob>=12.0.0,<13'
+    'boto3>=1.21.45,<2',
+    'Brotli>=1.0.9',
+    'matplotlib>=3.5.2,<4',
+    'paramiko>=2.11.0,<4',
+    'python-snappy>=0.6.1,<1',
+    'torch>=1.10,<3',
+    'torchtext>=0.10',
+    'torchvision>=0.10',
+    'tqdm>=4.64.0,<5',
+    'transformers>=4.21.3,<5',
+    'xxhash>=3.0.0,<4',
+    'zstd>=1.5.2.5,<2',
+    'oci>=2.88,<3',
+    'azure-storage-blob>=12.0.0,<13',
 ]
 
 extra_deps = {}

--- a/setup.py
+++ b/setup.py
@@ -42,19 +42,10 @@ classifiers = [
 ]
 
 install_requires = [
-    'boto3>=1.21.45,<2',
-    'Brotli>=1.0.9',
-    'matplotlib>=3.5.2,<4',
-    'paramiko>=2.11.0,<4',
-    'python-snappy>=0.6.1,<1',
-    'torch>=1.10,<3',
-    'torchtext>=0.10',
-    'torchvision>=0.10',
-    'tqdm>=4.64.0,<5',
-    'transformers>=4.21.3,<5',
-    'xxhash>=3.0.0,<4',
-    'zstd>=1.5.2.5,<2',
-    'oci>=2.88,<3',
+    'boto3>=1.21.45,<2', 'Brotli>=1.0.9', 'matplotlib>=3.5.2,<4', 'paramiko>=2.11.0,<4',
+    'python-snappy>=0.6.1,<1', 'torch>=1.10,<3', 'torchtext>=0.10', 'torchvision>=0.10',
+    'tqdm>=4.64.0,<5', 'transformers>=4.21.3,<5', 'xxhash>=3.0.0,<4', 'zstd>=1.5.2.5,<2',
+    'oci>=2.88,<3', 'azure-storage-blob>=12.0.0,<13'
 ]
 
 extra_deps = {}

--- a/streaming/base/storage/__init__.py
+++ b/streaming/base/storage/__init__.py
@@ -4,10 +4,10 @@
 """Base module for downloading/uploading files from/to cloud storage."""
 
 from streaming.base.storage.download import download_file, download_or_wait
-from streaming.base.storage.upload import (CloudUploader, GCSUploader, LocalUploader, OCIUploader,
-                                           S3Uploader)
+from streaming.base.storage.upload import (AzureUploader, CloudUploader, GCSUploader,
+                                           LocalUploader, OCIUploader, R2Uploader, S3Uploader)
 
 __all__ = [
     'download_file', 'download_or_wait', 'CloudUploader', 'S3Uploader', 'GCSUploader',
-    'OCIUploader', 'LocalUploader'
+    'OCIUploader', 'LocalUploader', 'R2Uploader', 'AzureUploader'
 ]

--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -485,6 +485,7 @@ class AzureUploader(CloudUploader):
 
     Args:
         out (str | Tuple[str, str]): Output dataset directory to save shard files.
+
             1. If ``out`` is a local directory, shard files are saved locally.
             2. If ``out`` is a remote directory, a local temporary directory is created to
                cache the shard files and then the shard files are uploaded to a remote

--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -16,7 +16,8 @@ import tqdm
 from streaming.base.storage.download import BOTOCORE_CLIENT_ERROR_CODES
 
 __all__ = [
-    'CloudUploader', 'S3Uploader', 'GCSUploader', 'OCIUploader', 'R2Uploader', 'LocalUploader'
+    'CloudUploader', 'S3Uploader', 'GCSUploader', 'OCIUploader', 'R2Uploader', 'AzureUploader',
+    'LocalUploader'
 ]
 
 logger = logging.getLogger(__name__)
@@ -26,6 +27,7 @@ UPLOADERS = {
     'gs': 'GCSUploader',
     'oci': 'OCIUploader',
     'r2': 'R2Uploader',
+    'azure': 'AzureUploader',
     '': 'LocalUploader',
 }
 
@@ -476,6 +478,82 @@ class R2Uploader(CloudUploader):
                 error.args = (f'Either bucket `{bucket_name}` does not exist! ' +
                               f'or check the bucket permission.',)
             raise error
+
+
+class AzureUploader(CloudUploader):
+    """Upload file from local machine to Microsoft Azure bucket.
+
+    Args:
+        out (str | Tuple[str, str]): Output dataset directory to save shard files.
+            1. If ``out`` is a local directory, shard files are saved locally.
+            2. If ``out`` is a remote directory, a local temporary directory is created to
+               cache the shard files and then the shard files are uploaded to a remote
+               location. At the end, the temp directory is deleted once shards are uploaded.
+            3. If ``out`` is a tuple of ``(local_dir, remote_dir)``, shard files are saved in
+               the `local_dir` and also uploaded to a remote location.
+        keep_local (bool): If the dataset is uploaded, whether to keep the local dataset
+            shard file or remove it after uploading. Defaults to ``False``.
+        progress_bar (bool): Display TQDM progress bars for uploading output dataset files to
+            a remote location. Default to ``False``.
+    """
+
+    def __init__(self,
+                 out: Union[str, Tuple[str, str]],
+                 keep_local: bool = False,
+                 progress_bar: bool = False) -> None:
+        super().__init__(out, keep_local, progress_bar)
+
+        from azure.storage.blob import BlobServiceClient
+
+        # Create a session and use it to make our client. Unlike Resources and Sessions,
+        # clients are generally thread-safe.
+        self.azure_service = BlobServiceClient(
+            account_url=f"https://{os.environ['AZURE_ACCOUNT_NAME']}.blob.core.windows.net",
+            credential=os.environ['AZURE_ACCOUNT_ACCESS_KEY'])
+        self.check_bucket_exists(self.remote)  # pyright: ignore
+
+    def upload_file(self, filename: str):
+        """Upload file from local instance to Cloudflare R2 bucket.
+
+        Args:
+            filename (str): File to upload.
+        """
+        local_filename = os.path.join(self.local, filename)
+        local_filename = local_filename.replace('\\', '/')
+        remote_filename = os.path.join(self.remote, filename)  # pyright: ignore
+        remote_filename = remote_filename.replace('\\', '/')
+        obj = urllib.parse.urlparse(remote_filename)
+        logger.debug(f'Uploading to {remote_filename}')
+        file_size = os.stat(local_filename).st_size
+        container_client = self.azure_service.get_container_client(container=obj.netloc)
+
+        with tqdm.tqdm(total=file_size,
+                       unit='B',
+                       unit_scale=True,
+                       desc=f'Uploading to {remote_filename}',
+                       disable=(not self.progress_bar)) as pbar:
+            with open(local_filename, 'rb') as data:
+                container_client.upload_blob(
+                    name=obj.path.lstrip('/'),
+                    data=data,
+                    progress_hook=lambda bytes_transferred, _: pbar.update(bytes_transferred),
+                    overwrite=True)
+        self.clear_local(local=local_filename)
+
+    def check_bucket_exists(self, remote: str):
+        """Raise an exception if the bucket does not exist.
+
+        Args:
+            remote (str): azure bucket path.
+
+        Raises:
+            error: Bucket does not exist.
+        """
+        bucket_name = urllib.parse.urlparse(remote).netloc
+        if self.azure_service.get_container_client(container=bucket_name).exists() == False:
+            raise FileNotFoundError(
+                f'Either bucket `{bucket_name}` does not exist! ' +
+                f'or check the bucket permission.',)
 
 
 class LocalUploader(CloudUploader):

--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -550,7 +550,7 @@ class AzureUploader(CloudUploader):
             error: Bucket does not exist.
         """
         bucket_name = urllib.parse.urlparse(remote).netloc
-        if self.azure_service.get_container_client(container=bucket_name).exists() == False:
+        if self.azure_service.get_container_client(container=bucket_name).exists() is False:
             raise FileNotFoundError(
                 f'Either bucket `{bucket_name}` does not exist! ' +
                 f'or check the bucket permission.',)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,13 @@ def pytest_runtest_call(item: Any):
 
 
 @pytest.fixture(scope='session', autouse=True)
+def azure_credentials():
+    """Mocked azure Credentials."""
+    os.environ['AZURE_ACCOUNT_NAME'] = 'testing'
+    os.environ['AZURE_ACCOUNT_ACCESS_KEY'] = 'testing'
+
+
+@pytest.fixture(scope='session', autouse=True)
 def aws_credentials():
     """Mocked AWS Credentials for moto."""
     os.environ['AWS_ACCESS_KEY_ID'] = 'testing'

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -10,8 +10,9 @@ import boto3
 import pytest
 from botocore.exceptions import ClientError
 
-from streaming.base.storage.download import (download_file, download_from_gcs, download_from_local,
-                                             download_from_r2, download_from_s3, download_or_wait)
+from streaming.base.storage.download import (download_file, download_from_azure, download_from_gcs,
+                                             download_from_local, download_from_r2,
+                                             download_from_s3, download_or_wait)
 from tests.conftest import GCS_URL, MY_BUCKET, R2_URL
 
 MY_PREFIX = 'train'
@@ -31,6 +32,16 @@ def remote_local_file() -> Any:
             mock_local_dir.cleanup()  # pyright: ignore
 
     return _method
+
+
+class TestAzureClient:
+
+    @pytest.mark.usefixtures('remote_local_file')
+    def test_invalid_cloud_prefix(self, remote_local_file: Any):
+        with pytest.raises(ValueError):
+            mock_remote_filepath, mock_local_filepath = remote_local_file(
+                cloud_prefix='aaazure://')
+            download_from_azure(mock_remote_filepath, mock_local_filepath)
 
 
 class TestS3Client:
@@ -148,6 +159,14 @@ class TestDownload:
     @pytest.mark.usefixtures('remote_local_file')
     def test_download_from_r2_gets_called(self, mocked_requests: Mock, remote_local_file: Any):
         mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='r2://')
+        download_file(mock_remote_filepath, mock_local_filepath, 60)
+        mocked_requests.assert_called_once()
+        mocked_requests.assert_called_once_with(mock_remote_filepath, mock_local_filepath)
+
+    @patch('streaming.base.storage.download.download_from_azure')
+    @pytest.mark.usefixtures('remote_local_file')
+    def test_download_from_azure_gets_called(self, mocked_requests: Mock, remote_local_file: Any):
+        mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='azure://')
         download_file(mock_remote_filepath, mock_local_filepath, 60)
         mocked_requests.assert_called_once()
         mocked_requests.assert_called_once_with(mock_remote_filepath, mock_local_filepath)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -9,8 +9,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from streaming.base.storage.upload import (CloudUploader, GCSUploader, LocalUploader, R2Uploader,
-                                           S3Uploader)
+from streaming.base.storage.upload import (AzureUploader, CloudUploader, GCSUploader,
+                                           LocalUploader, R2Uploader, S3Uploader)
 
 
 class TestCloudUploader:
@@ -237,6 +237,41 @@ class TestR2Uploader:
         import botocore
         with pytest.raises(botocore.exceptions.ClientError):
             _ = R2Uploader(out=out)
+
+
+class TestAzureUploader:
+
+    @patch('streaming.base.storage.upload.AzureUploader.check_bucket_exists')
+    @pytest.mark.usefixtures('azure_credentials')
+    @pytest.mark.parametrize('out', ['azure://bucket/dir', ('./dir1', 'azure://bucket/dir/')])
+    def test_instantiation(self, mocked_requests: Mock, out: Any):
+        mocked_requests.side_effect = None
+        _ = AzureUploader(out=out)
+        if not isinstance(out, str):
+            shutil.rmtree(out[0])
+
+    @pytest.mark.parametrize('out', ['ss4://bucket/dir'])
+    def test_invalid_remote_str(self, out: str):
+        with pytest.raises(ValueError) as exc_info:
+            _ = AzureUploader(out=out)
+        assert exc_info.match(r'Invalid Cloud provider prefix.*')
+
+    @pytest.mark.parametrize('out', ['ss4://bucket/dir', ('./dir1', 'gcs://bucket/dir/')])
+    def test_invalid_remote_list(self, out: Any):
+        with pytest.raises(ValueError) as exc_info:
+            _ = AzureUploader(out=out)
+        assert exc_info.match(r'Invalid Cloud provider prefix.*')
+
+    def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
+        with pytest.raises(FileExistsError) as exc_info:
+            local, _ = local_remote_dir
+            os.makedirs(local, exist_ok=True)
+            local_file_path = os.path.join(local, 'file.txt')
+            # Creating an empty file at specified location
+            with open(local_file_path, 'w') as _:
+                pass
+            _ = AzureUploader(out=local)
+        assert exc_info.match(r'Directory is not empty.*')
 
 
 class TestLocalUploader:


### PR DESCRIPTION
## Description of changes:

Add support for Azure cloud storage.

Authentication with storage account [shared key](https://docs.microsoft.com/rest/api/storageservices/authenticate-with-shared-key/) aka account key or access key

use environment variables `AZURE_ACCOUNT_NAME` and `AZURE_ACCOUNT_ACCESS_KEY`

test coverage is minimal, I didn't find a library to mock Azure, I suppose I can add more test coverage if absolutely required, but it does work

```
>>> import numpy as np
>>> from PIL import Image
>>> from streaming import MDSWriter
>>>
>>> # Local or remote directory in which to store the compressed output files
>>> data_dir = 'azure://test'
>>>
>>> # A dictionary mapping input fields to their data types
>>> columns = {
...     'image': 'jpeg',
...     'class': 'int'
... }
>>>
>>> # Shard compression, if any
>>> compression = 'zstd'
>>>
>>> # Save the samples as shards using MDSWriter
>>> with MDSWriter(out=data_dir, columns=columns, compression=compression) as out:
...     for i in range(10000):
...         sample = {
...             'image': Image.fromarray(np.random.randint(0, 256, (32, 32, 3), np.uint8)),
...             'class': np.random.randint(10),
...         }
...         out.write(sample)
...
>>>
>>> from torch.utils.data import DataLoader
>>> from streaming import StreamingDataset
>>>
>>> # Remote path where full dataset is persistently stored
>>> remote = 'azure://test'
>>>
>>> # Local working dir where dataset is cached during operation
>>> local = './test'
>>>
>>> # Create streaming dataset
>>> dataset = StreamingDataset(local=local, remote=remote, shuffle=True)
>>>
>>> # Let's see what is in sample #1337...
>>> sample = dataset[1337]
>>> img = sample['image']
>>> cls = sample['class']
>>>
>>> # Create PyTorch DataLoader
>>> dataloader = DataLoader(dataset)
>>> sample
{'class': 9, 'image': <PIL.JpegImagePlugin.JpegImageFile image mode=RGB size=32x32 at 0x2DACE9C55D0>}
```

![image](https://github.com/mosaicml/streaming/assets/106811348/9567a778-4315-4eb6-99ff-941348a74e03)


## Issue #, if available:

#254 

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
