### PR TITLE
Support any S3-compatible object store (R2, Coreweave, Backblaze, etc.)

### DIFF
--- a/docs/source/how_to_guides/configure_cloud_storage_cred.md
+++ b/docs/source/how_to_guides/configure_cloud_storage_cred.md
@@ -2,8 +2,11 @@
 
 Streaming dataset supports the following cloud storage providers to stream your data directly to your instance.
 - Amazon S3
+- S3 compatible object store
 - Google Cloud Storage
 - Oracle Cloud Storage
+- Azure Blob Storage
+
 
 ## Amazon S3
 
@@ -69,6 +72,29 @@ export MOSAICML_STREAMING_AWS_REQUESTER_PAYS='streaming-bucket,another-bucket'
 ```
 ````
 
+## S3 compatible object store
+For any S3 compatible object store such as [Cloudflare R2](https://www.cloudflare.com/products/r2/), [Coreweave](https://docs.coreweave.com/storage/object-storage), [Backblaze b2](https://www.backblaze.com/b2/cloud-storage.html), etc., setup your credentials as mentioned in the above `Amazon S3` section. The only difference is you must set your object store endpoint url. To do this, you need to set the ``S3_ENDPOINT_URL`` environment variable.
+
+Below is one of such example on setting a R2 `endpoint url` in your run environment.
+
+```{note}
+Your endpoint url is `https://<accountid>.r2.cloudflarestorage.com`. The account ID can be retrieved through your [Cloudflare console](https://dash.cloudflare.com/).
+```
+
+````{tabs}
+```{code-tab} py
+import os
+os.environ['S3_ENDPOINT_URL'] = 'https://<accountid>.r2.cloudflarestorage.com'
+```
+
+```{code-tab} sh
+export S3_ENDPOINT_URL='https://<accountid>.r2.cloudflarestorage.com'
+```
+````
+
+The above step will add an environment variable `S3_ENDPOINT_URL` to your runs and the streaming dataset fetches those environment variables for authentication and stream data into your instance.
+
+
 ## Google Cloud Storage
 
 ### MosaicML platform
@@ -125,59 +151,7 @@ region=us-ashburn-1
 
 The key file (`~/.oci/oci_api_key.pem`) is a PEM file that would look like a typical RSA private key file. The streaming dataset authenticates the credentials by reading the `~/.oci/config` and `~/.oci/oci_api_key.pem`.
 
-## Cloudflare R2
-
-First, make sure the `awscli` is installed, and then run `aws configure` to create the config and credential files:
-
-```
-python -m pip install awscli
-aws configure
-```
-
-```{note}
-The requested credentials can be retrieved through your [Cloudflare console](https://dash.cloudflare.com/), navigate to `Manage R2 API Tokens` > `Create API token`.
-```
-
-Your config and credentials files should follow the standard structure output by `aws configure`:
-
-`~/.aws/config`
-
-```
-[default]
-region=auto
-output=json
-
-```
-
-`~/.aws/credentials`
-
-```
-[default]
-aws_access_key_id=AKIAIOSFODNN7EXAMPLE
-aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-
-```
-
-Users must set their R2 `endpoint url` in the run environment.
-
-```{note}
-Your endpoint url is `https://<accountid>.r2.cloudflarestorage.com`. The account ID can be retrieved through your [Cloudflare console](https://dash.cloudflare.com/).
-```
-
-````{tabs}
-```{code-tab} py
-import os
-os.environ['S3_ENDPOINT_URL'] = 'https://<accountid>.r2.cloudflarestorage.com'
-```
-
-```{code-tab} sh
-export S3_ENDPOINT_URL='https://<accountid>.r2.cloudflarestorage.com'
-```
-````
-
-The above step will add an environment variable `S3_ENDPOINT_URL` to your runs and the streaming dataset fetches those environment variables for authentication and stream data into your instance.
-
-## Azure
+## Azure Blob Storage
 
 If you wish to create a new storage account, you can use the [Azure Portal](https://docs.microsoft.com/azure/storage/common/storage-quickstart-create-account?tabs=azure-portal), [Azure PowerShell](https://docs.microsoft.com/azure/storage/common/storage-quickstart-create-account?tabs=azure-powershell), or [Azure CLI](https://docs.microsoft.com/azure/storage/common/storage-quickstart-create-account?tabs=azure-cli):
 

--- a/docs/source/how_to_guides/configure_cloud_storage_cred.md
+++ b/docs/source/how_to_guides/configure_cloud_storage_cred.md
@@ -2,11 +2,10 @@
 
 Streaming dataset supports the following cloud storage providers to stream your data directly to your instance.
 - Amazon S3
-- S3 compatible object store
+- Any S3 compatible object store
 - Google Cloud Storage
 - Oracle Cloud Storage
 - Azure Blob Storage
-
 
 ## Amazon S3
 
@@ -49,7 +48,7 @@ aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 
 ```
 
-More details on these files can be found [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html). The streaming dataset reads the `~/.aws/config` and `~/.aws/credentials` to authenticate your credentials and stream data into your instance.
+More details about the authentication can be found [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html).
 
 ### Requester Pays Bucket
 
@@ -72,10 +71,10 @@ export MOSAICML_STREAMING_AWS_REQUESTER_PAYS='streaming-bucket,another-bucket'
 ```
 ````
 
-## S3 compatible object store
+## Any S3 compatible object store
 For any S3 compatible object store such as [Cloudflare R2](https://www.cloudflare.com/products/r2/), [Coreweave](https://docs.coreweave.com/storage/object-storage), [Backblaze b2](https://www.backblaze.com/b2/cloud-storage.html), etc., setup your credentials as mentioned in the above `Amazon S3` section. The only difference is you must set your object store endpoint url. To do this, you need to set the ``S3_ENDPOINT_URL`` environment variable.
 
-Below is one of such example on setting a R2 `endpoint url` in your run environment.
+Below is one such example, which sets a R2 `endpoint url` in your run environment.
 
 ```{note}
 Your endpoint url is `https://<accountid>.r2.cloudflarestorage.com`. The account ID can be retrieved through your [Cloudflare console](https://dash.cloudflare.com/).
@@ -91,9 +90,6 @@ os.environ['S3_ENDPOINT_URL'] = 'https://<accountid>.r2.cloudflarestorage.com'
 export S3_ENDPOINT_URL='https://<accountid>.r2.cloudflarestorage.com'
 ```
 ````
-
-The above step will add an environment variable `S3_ENDPOINT_URL` to your runs and the streaming dataset fetches those environment variables for authentication and stream data into your instance.
-
 
 ## Google Cloud Storage
 
@@ -119,8 +115,6 @@ export GCS_KEY='AKIAIOSFODNN7EXAMPLE'
 export GCS_SECRET='wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
 ```
 ````
-
-The above step will add two environment variables `GCS_KEY` and `GCS_SECRET` to your runs and the streaming dataset fetches those environment variables for authentication and stream data into your instance.
 
 ## Oracle Cloud Storage
 
@@ -183,5 +177,3 @@ export AZURE_ACCOUNT_NAME='test'
 export AZURE_ACCOUNT_ACCESS_KEY='NN1KHxKKkj20ZO92EMiDQjx3wp2kZG4UUvfAGlgGWRn6sPRmGY/TEST/Dri+ExAmPlEExAmPlExA+ExAmPlExA=='
 ```
 ````
-
-The above step will add two environment variables `AZURE_ACCOUNT_NAME` and `AZURE_ACCOUNT_ACCESS_KEY` to your runs and the streaming dataset fetches those environment variables for authentication and stream data into your instance.

--- a/streaming/base/storage/__init__.py
+++ b/streaming/base/storage/__init__.py
@@ -5,9 +5,9 @@
 
 from streaming.base.storage.download import download_file, download_or_wait
 from streaming.base.storage.upload import (AzureUploader, CloudUploader, GCSUploader,
-                                           LocalUploader, OCIUploader, R2Uploader, S3Uploader)
+                                           LocalUploader, OCIUploader, S3Uploader)
 
 __all__ = [
     'download_file', 'download_or_wait', 'CloudUploader', 'S3Uploader', 'GCSUploader',
-    'OCIUploader', 'LocalUploader', 'R2Uploader', 'AzureUploader'
+    'OCIUploader', 'LocalUploader', 'AzureUploader'
 ]

--- a/streaming/base/storage/download.py
+++ b/streaming/base/storage/download.py
@@ -15,7 +15,7 @@ BOTOCORE_CLIENT_ERROR_CODES = {'403', '404', 'NoSuchKey'}
 
 
 def download_from_s3(remote: str, local: str, timeout: float) -> None:
-    """Download a file from remote AWS S3 to local.
+    """Download a file from remote AWS S3 (or any S3 compatible object store) to local.
 
     Args:
         remote (str): Remote path (S3).
@@ -28,8 +28,10 @@ def download_from_s3(remote: str, local: str, timeout: float) -> None:
         """Download the file from AWS S3 bucket. The bucket can be either public or private.
 
         Args:
-            unsigned (bool, optional):  Set to True if it is a public bucket. Defaults to False.
-            extra_args (Dict[str, Any], optional): Extra arguments supported by boto3. Defaults to None.
+            unsigned (bool, optional):  Set to True if it is a public bucket.
+                Defaults to ``False``.
+            extra_args (Dict[str, Any], optional): Extra arguments supported by boto3.
+                Defaults to ``None``.
         """
         if unsigned:
             # Client will be using unsigned mode in which public

--- a/streaming/base/storage/download.py
+++ b/streaming/base/storage/download.py
@@ -44,7 +44,7 @@ def download_from_s3(remote: str, local: str, timeout: float) -> None:
         # Create a new session per thread
         session = boto3.session.Session()
         # Create a resource client using a thread's session object
-        s3 = session.client('s3', config=config)
+        s3 = session.client('s3', config=config, endpoint_url=os.environ.get('S3_ENDPOINT_URL'))
         # Threads calling S3 operations return RuntimeError (cannot schedule new futures after
         # interpreter shutdown). Temporary solution is to have `use_threads` as `False`.
         # Issue: https://github.com/boto/boto3/issues/3113
@@ -213,42 +213,6 @@ def download_from_oci(remote: str, local: str) -> None:
     os.rename(local_tmp, local)
 
 
-def download_from_r2(remote: str, local: str) -> None:
-    """Download a file from remote Cloudflare R2 to local.
-
-    Args:
-        remote (str): Remote path (R2).
-        local (str): Local path (local filesystem).
-    """
-    import boto3
-    from boto3.s3.transfer import TransferConfig
-    from botocore.exceptions import ClientError
-
-    obj = urllib.parse.urlparse(remote)
-    if obj.scheme != 'r2':
-        raise ValueError(f'Expected obj.scheme to be "r2", got {obj.scheme} for remote={remote}')
-
-    # Create a new session per thread
-    session = boto3.session.Session()
-    # Create a resource client using a thread's session object
-    r2_client = session.client('s3',
-                               region_name='auto',
-                               endpoint_url=os.environ['S3_ENDPOINT_URL'])
-    try:
-        # Threads calling S3 operations return RuntimeError (cannot schedule new futures after
-        # interpreter shutdown). Temporary solution is to have `use_threads` as `False`.
-        # Issue: https://github.com/boto/boto3/issues/3113
-        r2_client.download_file(obj.netloc,
-                                obj.path.lstrip('/'),
-                                local,
-                                Config=TransferConfig(use_threads=False))
-    except ClientError as e:
-        if e.response['Error']['Code'] in BOTOCORE_CLIENT_ERROR_CODES:
-            raise FileNotFoundError(f'Object {remote} not found.') from e
-    except Exception:
-        raise
-
-
 def download_from_azure(remote: str, local: str) -> None:
     """Download a file from remote Microsoft Azure to local.
 
@@ -323,8 +287,6 @@ def download_file(remote: Optional[str], local: str, timeout: float):
         download_from_gcs(remote, local)
     elif remote.startswith('oci://'):
         download_from_oci(remote, local)
-    elif remote.startswith('r2://'):
-        download_from_r2(remote, local)
     elif remote.startswith('azure://'):
         download_from_azure(remote, local)
     else:

--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -88,7 +88,7 @@ class CloudUploader:
                 ]))
             obj = urllib.parse.urlparse(out[1])
         if obj.scheme not in UPLOADERS:
-            raise ValueError('Invalid Cloud provider prefix.')
+            raise ValueError(f'Invalid Cloud provider prefix: {obj.scheme}.')
 
     def __init__(self,
                  out: Union[str, Tuple[str, str]],

--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -156,7 +156,7 @@ class CloudUploader:
 
 
 class S3Uploader(CloudUploader):
-    """Upload file from local machine to AWS S3 bucket.
+    """Upload file from local machine to AWS S3 bucket (or any S3 compatible object store).
 
     Args:
         out (str | Tuple[str, str]): Output dataset directory to save shard files.

--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -16,8 +16,7 @@ import tqdm
 from streaming.base.storage.download import BOTOCORE_CLIENT_ERROR_CODES
 
 __all__ = [
-    'CloudUploader', 'S3Uploader', 'GCSUploader', 'OCIUploader', 'R2Uploader', 'AzureUploader',
-    'LocalUploader'
+    'CloudUploader', 'S3Uploader', 'GCSUploader', 'OCIUploader', 'AzureUploader', 'LocalUploader'
 ]
 
 logger = logging.getLogger(__name__)
@@ -26,7 +25,6 @@ UPLOADERS = {
     's3': 'S3Uploader',
     'gs': 'GCSUploader',
     'oci': 'OCIUploader',
-    'r2': 'R2Uploader',
     'azure': 'AzureUploader',
     '': 'LocalUploader',
 }
@@ -187,7 +185,9 @@ class S3Uploader(CloudUploader):
         # Create a session and use it to make our client. Unlike Resources and Sessions,
         # clients are generally thread-safe.
         session = boto3.session.Session()
-        self.s3 = session.client('s3', config=config)
+        self.s3 = session.client('s3',
+                                 config=config,
+                                 endpoint_url=os.environ.get('S3_ENDPOINT_URL'))
         self.check_bucket_exists(self.remote)  # pyright: ignore
 
     def upload_file(self, filename: str):
@@ -398,88 +398,6 @@ class OCIUploader(CloudUploader):
             raise error
 
 
-class R2Uploader(CloudUploader):
-    """Upload file from local machine to Cloudflare R2 bucket.
-
-    Args:
-        out (str | Tuple[str, str]): Output dataset directory to save shard files.
-
-            1. If ``out`` is a local directory, shard files are saved locally.
-            2. If ``out`` is a remote directory, a local temporary directory is created to
-               cache the shard files and then the shard files are uploaded to a remote
-               location. At the end, the temp directory is deleted once shards are uploaded.
-            3. If ``out`` is a tuple of ``(local_dir, remote_dir)``, shard files are saved in
-               the `local_dir` and also uploaded to a remote location.
-        keep_local (bool): If the dataset is uploaded, whether to keep the local dataset
-            shard file or remove it after uploading. Defaults to ``False``.
-        progress_bar (bool): Display TQDM progress bars for uploading output dataset files to
-            a remote location. Default to ``False``.
-    """
-
-    def __init__(self,
-                 out: Union[str, Tuple[str, str]],
-                 keep_local: bool = False,
-                 progress_bar: bool = False) -> None:
-        super().__init__(out, keep_local, progress_bar)
-
-        import boto3
-
-        # Create a session and use it to make our client. Unlike Resources and Sessions,
-        # clients are generally thread-safe.
-        session = boto3.session.Session()
-        self.r2_client = session.client('s3',
-                                        region_name='auto',
-                                        endpoint_url=os.environ['S3_ENDPOINT_URL'])
-        self.check_bucket_exists(self.remote)  # pyright: ignore
-
-    def upload_file(self, filename: str):
-        """Upload file from local instance to Cloudflare R2 bucket.
-
-        Args:
-            filename (str): File to upload.
-        """
-        local_filename = os.path.join(self.local, filename)
-        remote_filename = os.path.join(self.remote, filename)  # pyright: ignore
-        # fix paths for windows
-        local_filename = local_filename.replace('\\', '/')
-        remote_filename = remote_filename.replace('\\', '/')
-        obj = urllib.parse.urlparse(remote_filename)
-        logger.debug(f'Uploading to {remote_filename}')
-        file_size = os.stat(local_filename).st_size
-        with tqdm.tqdm(total=file_size,
-                       unit='B',
-                       unit_scale=True,
-                       desc=f'Uploading to {remote_filename}',
-                       disable=(not self.progress_bar)) as pbar:
-            self.r2_client.upload_file(
-                local_filename,
-                obj.netloc,
-                obj.path.lstrip('/'),
-                Callback=lambda bytes_transferred: pbar.update(bytes_transferred),
-            )
-        self.clear_local(local=local_filename)
-
-    def check_bucket_exists(self, remote: str):
-        """Raise an exception if the bucket does not exist.
-
-        Args:
-            remote (str): R2 bucket path.
-
-        Raises:
-            error: Bucket does not exist.
-        """
-        from botocore.exceptions import ClientError
-
-        bucket_name = urllib.parse.urlparse(remote).netloc
-        try:
-            self.r2_client.head_bucket(Bucket=bucket_name)
-        except ClientError as error:
-            if error.response['Error']['Code'] == BOTOCORE_CLIENT_ERROR_CODES:
-                error.args = (f'Either bucket `{bucket_name}` does not exist! ' +
-                              f'or check the bucket permission.',)
-            raise error
-
-
 class AzureUploader(CloudUploader):
     """Upload file from local machine to Microsoft Azure bucket.
 
@@ -514,7 +432,7 @@ class AzureUploader(CloudUploader):
         self.check_bucket_exists(self.remote)  # pyright: ignore
 
     def upload_file(self, filename: str):
-        """Upload file from local instance to Cloudflare R2 bucket.
+        """Upload file from local instance to Microsoft Azure bucket.
 
         Args:
             filename (str): File to upload.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,10 +110,13 @@ def test_list_gcs_buckets():
     assert buckets['Buckets'][0]['Name'] == MY_BUCKET
 
 
-@pytest.fixture(scope='session', autouse=True)
+@pytest.fixture()
 def r2_credentials():
     """Mocked R2 Credentials for moto."""
     os.environ['S3_ENDPOINT_URL'] = R2_URL
+    yield
+    # Line after `yield` gets called at the end of test function.
+    del os.environ['S3_ENDPOINT_URL']
 
 
 @pytest.fixture()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -107,20 +107,20 @@ class TestR2Client:
             mock_remote_filepath, _ = remote_local_file(cloud_prefix='s3://', filename=file_name)
             client = boto3.client('s3', region_name='us-east-1', endpoint_url=R2_URL)
             client.put_object(Bucket=MY_BUCKET, Key=os.path.join(MY_PREFIX, file_name), Body='')
-            download_from_s3(mock_remote_filepath, tmp.name)
+            download_from_s3(mock_remote_filepath, tmp.name, 60)
             assert os.path.isfile(tmp.name)
 
     @pytest.mark.usefixtures('r2_client', 'r2_test', 'remote_local_file')
     def test_filenotfound_exception(self, remote_local_file: Any):
         with pytest.raises(FileNotFoundError):
             mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='s3://')
-            download_from_s3(mock_remote_filepath, mock_local_filepath)
+            download_from_s3(mock_remote_filepath, mock_local_filepath, 60)
 
     @pytest.mark.usefixtures('r2_client', 'r2_test', 'remote_local_file')
     def test_invalid_cloud_prefix(self, remote_local_file: Any):
         with pytest.raises(ValueError):
             mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='s3://')
-            download_from_s3(mock_remote_filepath, mock_local_filepath)
+            download_from_s3(mock_remote_filepath, mock_local_filepath, 60)
 
 
 def test_download_from_local():

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -11,8 +11,8 @@ import pytest
 from botocore.exceptions import ClientError
 
 from streaming.base.storage.download import (download_file, download_from_azure, download_from_gcs,
-                                             download_from_local, download_from_r2,
-                                             download_from_s3, download_or_wait)
+                                             download_from_local, download_from_s3,
+                                             download_or_wait)
 from tests.conftest import GCS_URL, MY_BUCKET, R2_URL
 
 MY_PREFIX = 'train'
@@ -107,20 +107,20 @@ class TestR2Client:
             mock_remote_filepath, _ = remote_local_file(cloud_prefix='s3://', filename=file_name)
             client = boto3.client('s3', region_name='us-east-1', endpoint_url=R2_URL)
             client.put_object(Bucket=MY_BUCKET, Key=os.path.join(MY_PREFIX, file_name), Body='')
-            download_from_r2(mock_remote_filepath, tmp.name)
+            download_from_s3(mock_remote_filepath, tmp.name)
             assert os.path.isfile(tmp.name)
 
     @pytest.mark.usefixtures('r2_client', 'r2_test', 'remote_local_file')
     def test_filenotfound_exception(self, remote_local_file: Any):
         with pytest.raises(FileNotFoundError):
             mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='s3://')
-            download_from_r2(mock_remote_filepath, mock_local_filepath)
+            download_from_s3(mock_remote_filepath, mock_local_filepath)
 
     @pytest.mark.usefixtures('r2_client', 'r2_test', 'remote_local_file')
     def test_invalid_cloud_prefix(self, remote_local_file: Any):
         with pytest.raises(ValueError):
             mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='s3://')
-            download_from_r2(mock_remote_filepath, mock_local_filepath)
+            download_from_s3(mock_remote_filepath, mock_local_filepath)
 
 
 def test_download_from_local():
@@ -151,14 +151,6 @@ class TestDownload:
     @pytest.mark.usefixtures('remote_local_file')
     def test_download_from_gcs_gets_called(self, mocked_requests: Mock, remote_local_file: Any):
         mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='gs://')
-        download_file(mock_remote_filepath, mock_local_filepath, 60)
-        mocked_requests.assert_called_once()
-        mocked_requests.assert_called_once_with(mock_remote_filepath, mock_local_filepath)
-
-    @patch('streaming.base.storage.download.download_from_r2')
-    @pytest.mark.usefixtures('remote_local_file')
-    def test_download_from_r2_gets_called(self, mocked_requests: Mock, remote_local_file: Any):
-        mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='s3://')
         download_file(mock_remote_filepath, mock_local_filepath, 60)
         mocked_requests.assert_called_once()
         mocked_requests.assert_called_once_with(mock_remote_filepath, mock_local_filepath)

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -104,7 +104,7 @@ class TestR2Client:
     def test_download_from_r2(self, remote_local_file: Any):
         with tempfile.NamedTemporaryFile(delete=True, suffix='.txt') as tmp:
             file_name = tmp.name.split(os.sep)[-1]
-            mock_remote_filepath, _ = remote_local_file(cloud_prefix='r2://', filename=file_name)
+            mock_remote_filepath, _ = remote_local_file(cloud_prefix='s3://', filename=file_name)
             client = boto3.client('s3', region_name='us-east-1', endpoint_url=R2_URL)
             client.put_object(Bucket=MY_BUCKET, Key=os.path.join(MY_PREFIX, file_name), Body='')
             download_from_r2(mock_remote_filepath, tmp.name)
@@ -113,7 +113,7 @@ class TestR2Client:
     @pytest.mark.usefixtures('r2_client', 'r2_test', 'remote_local_file')
     def test_filenotfound_exception(self, remote_local_file: Any):
         with pytest.raises(FileNotFoundError):
-            mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='r2://')
+            mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='s3://')
             download_from_r2(mock_remote_filepath, mock_local_filepath)
 
     @pytest.mark.usefixtures('r2_client', 'r2_test', 'remote_local_file')
@@ -158,7 +158,7 @@ class TestDownload:
     @patch('streaming.base.storage.download.download_from_r2')
     @pytest.mark.usefixtures('remote_local_file')
     def test_download_from_r2_gets_called(self, mocked_requests: Mock, remote_local_file: Any):
-        mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='r2://')
+        mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='s3://')
         download_file(mock_remote_filepath, mock_local_filepath, 60)
         mocked_requests.assert_called_once()
         mocked_requests.assert_called_once_with(mock_remote_filepath, mock_local_filepath)

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -189,7 +189,7 @@ class TestGCSUploader:
 class TestR2Uploader:
 
     @patch('streaming.base.storage.upload.R2Uploader.check_bucket_exists')
-    @pytest.mark.parametrize('out', ['r2://bucket/dir', ('./dir1', 'r2://bucket/dir/')])
+    @pytest.mark.parametrize('out', ['s3://bucket/dir', ('./dir1', 's3://bucket/dir/')])
     def test_instantiation(self, mocked_requests: Mock, out: Any):
         mocked_requests.side_effect = None
         _ = R2Uploader(out=out)
@@ -224,7 +224,7 @@ class TestR2Uploader:
         with tempfile.NamedTemporaryFile(delete=True, suffix='.txt') as tmp:
             filename = tmp.name.split(os.sep)[-1]
             local, _ = local_remote_dir
-            remote = 'r2://streaming-test-bucket/path'
+            remote = 's3://streaming-test-bucket/path'
             local_file_path = os.path.join(local, filename)
             r2w = R2Uploader(out=(local, remote))
             with open(local_file_path, 'w') as _:
@@ -232,7 +232,7 @@ class TestR2Uploader:
             r2w.upload_file(filename)
             assert not os.path.exists(local_file_path)
 
-    @pytest.mark.parametrize('out', ['r2://bucket/dir'])
+    @pytest.mark.parametrize('out', ['s3://bucket/dir'])
     def test_check_bucket_exists_exception(self, out: str):
         import botocore
         with pytest.raises(botocore.exceptions.ClientError):

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from streaming.base.storage.upload import (AzureUploader, CloudUploader, GCSUploader,
-                                           LocalUploader, R2Uploader, S3Uploader)
+                                           LocalUploader, S3Uploader)
 
 
 class TestCloudUploader:
@@ -126,6 +126,19 @@ class TestS3Uploader:
             s3w.upload_file(filename)
             assert not os.path.exists(local_file_path)
 
+    @pytest.mark.usefixtures('r2_client', 'r2_test')
+    def test_upload_file_to_r2(self, local_remote_dir: Tuple[str, str]):
+        with tempfile.NamedTemporaryFile(delete=True, suffix='.txt') as tmp:
+            filename = tmp.name.split(os.sep)[-1]
+            local, _ = local_remote_dir
+            remote = 's3://streaming-test-bucket/path'
+            local_file_path = os.path.join(local, filename)
+            s3w = S3Uploader(out=(local, remote))
+            with open(local_file_path, 'w') as _:
+                pass
+            s3w.upload_file(filename)
+            assert not os.path.exists(local_file_path)
+
     @pytest.mark.parametrize('out', ['s3://bucket/dir'])
     def test_check_bucket_exists_exception(self, out: str):
         import botocore
@@ -184,59 +197,6 @@ class TestGCSUploader:
         import botocore
         with pytest.raises(botocore.exceptions.ClientError):
             _ = GCSUploader(out=out)
-
-
-class TestR2Uploader:
-
-    @patch('streaming.base.storage.upload.R2Uploader.check_bucket_exists')
-    @pytest.mark.parametrize('out', ['s3://bucket/dir', ('./dir1', 's3://bucket/dir/')])
-    def test_instantiation(self, mocked_requests: Mock, out: Any):
-        mocked_requests.side_effect = None
-        _ = R2Uploader(out=out)
-        if not isinstance(out, str):
-            shutil.rmtree(out[0])
-
-    @pytest.mark.parametrize('out', ['r3://bucket/dir'])
-    def test_invalid_remote_str(self, out: str):
-        with pytest.raises(ValueError) as exc_info:
-            _ = R2Uploader(out=out)
-        assert exc_info.match(r'Invalid Cloud provider prefix.*')
-
-    @pytest.mark.parametrize('out', ['r3://bucket/dir', ('./dir1', 'ocix://bucket/dir/')])
-    def test_invalid_remote_list(self, out: Any):
-        with pytest.raises(ValueError) as exc_info:
-            _ = R2Uploader(out=out)
-        assert exc_info.match(r'Invalid Cloud provider prefix.*')
-
-    def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
-        with pytest.raises(FileExistsError) as exc_info:
-            local, _ = local_remote_dir
-            os.makedirs(local, exist_ok=True)
-            local_file_path = os.path.join(local, 'file.txt')
-            # Creating an empty file at specified location
-            with open(local_file_path, 'w') as _:
-                pass
-            _ = R2Uploader(out=local)
-        assert exc_info.match(r'Directory is not empty.*')
-
-    @pytest.mark.usefixtures('r2_client', 'r2_test')
-    def test_upload_file(self, local_remote_dir: Tuple[str, str]):
-        with tempfile.NamedTemporaryFile(delete=True, suffix='.txt') as tmp:
-            filename = tmp.name.split(os.sep)[-1]
-            local, _ = local_remote_dir
-            remote = 's3://streaming-test-bucket/path'
-            local_file_path = os.path.join(local, filename)
-            r2w = R2Uploader(out=(local, remote))
-            with open(local_file_path, 'w') as _:
-                pass
-            r2w.upload_file(filename)
-            assert not os.path.exists(local_file_path)
-
-    @pytest.mark.parametrize('out', ['s3://bucket/dir'])
-    def test_check_bucket_exists_exception(self, out: str):
-        import botocore
-        with pytest.raises(botocore.exceptions.ClientError):
-            _ = R2Uploader(out=out)
 
 
 class TestAzureUploader:

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -11,6 +11,7 @@ import pytest
 
 from streaming.base.storage.upload import (AzureUploader, CloudUploader, GCSUploader,
                                            LocalUploader, S3Uploader)
+from tests.conftest import R2_URL
 
 
 class TestCloudUploader:
@@ -37,18 +38,16 @@ class TestCloudUploader:
 
     @pytest.mark.parametrize('out', [(), ('s3://bucket/dir',), ('./dir1', './dir2', './dir3')])
     def test_invalid_out_parameter_length(self, out: Any):
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match=f'Invalid `out` argument.*'):
             _ = CloudUploader.get(out=out)
-        assert exc_info.match(r'Invalid `out` argument.*')
 
     @pytest.mark.parametrize('out', [('./dir1', 'gcs://bucket/dir/'), ('./dir1', None)])
     def test_invalid_out_parameter_type(self, out: Any):
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = CloudUploader.get(out=out)
-        assert exc_info.match(r'Invalid Cloud provider prefix.*')
 
     def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
-        with pytest.raises(FileExistsError) as exc_info:
+        with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
             local, _ = local_remote_dir
             os.makedirs(local, exist_ok=True)
             local_file_path = os.path.join(local, 'file.txt')
@@ -56,7 +55,6 @@ class TestCloudUploader:
             with open(local_file_path, 'w') as _:
                 pass
             _ = CloudUploader.get(out=local)
-        assert exc_info.match(r'Directory is not empty.*')
 
     def test_local_directory_is_created(self, local_remote_dir: Tuple[str, str]):
         local, _ = local_remote_dir
@@ -92,18 +90,16 @@ class TestS3Uploader:
 
     @pytest.mark.parametrize('out', ['ss4://bucket/dir'])
     def test_invalid_remote_str(self, out: str):
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = S3Uploader(out=out)
-        assert exc_info.match(r'Invalid Cloud provider prefix.*')
 
     @pytest.mark.parametrize('out', ['ss4://bucket/dir', ('./dir1', 'gcs://bucket/dir/')])
     def test_invalid_remote_list(self, out: Any):
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = S3Uploader(out=out)
-        assert exc_info.match(r'Invalid Cloud provider prefix.*')
 
     def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
-        with pytest.raises(FileExistsError) as exc_info:
+        with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
             local, _ = local_remote_dir
             os.makedirs(local, exist_ok=True)
             local_file_path = os.path.join(local, 'file.txt')
@@ -111,7 +107,6 @@ class TestS3Uploader:
             with open(local_file_path, 'w') as _:
                 pass
             _ = S3Uploader(out=local)
-        assert exc_info.match(r'Directory is not empty.*')
 
     @pytest.mark.usefixtures('s3_client', 's3_test')
     def test_upload_file(self, local_remote_dir: Tuple[str, str]):
@@ -137,6 +132,7 @@ class TestS3Uploader:
             with open(local_file_path, 'w') as _:
                 pass
             s3w.upload_file(filename)
+            assert os.environ['S3_ENDPOINT_URL'] == R2_URL
             assert not os.path.exists(local_file_path)
 
     @pytest.mark.parametrize('out', ['s3://bucket/dir'])
@@ -158,18 +154,16 @@ class TestGCSUploader:
 
     @pytest.mark.parametrize('out', ['gcs://bucket/dir'])
     def test_invalid_remote_str(self, out: str):
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = GCSUploader(out=out)
-        assert exc_info.match(r'Invalid Cloud provider prefix.*')
 
     @pytest.mark.parametrize('out', ['gcs://bucket/dir', ('./dir1', 'ocix://bucket/dir/')])
     def test_invalid_remote_list(self, out: Any):
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = GCSUploader(out=out)
-        assert exc_info.match(r'Invalid Cloud provider prefix.*')
 
     def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
-        with pytest.raises(FileExistsError) as exc_info:
+        with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
             local, _ = local_remote_dir
             os.makedirs(local, exist_ok=True)
             local_file_path = os.path.join(local, 'file.txt')
@@ -177,7 +171,6 @@ class TestGCSUploader:
             with open(local_file_path, 'w') as _:
                 pass
             _ = GCSUploader(out=local)
-        assert exc_info.match(r'Directory is not empty.*')
 
     @pytest.mark.usefixtures('gcs_client', 'gcs_test')
     def test_upload_file(self, local_remote_dir: Tuple[str, str]):
@@ -212,18 +205,16 @@ class TestAzureUploader:
 
     @pytest.mark.parametrize('out', ['ss4://bucket/dir'])
     def test_invalid_remote_str(self, out: str):
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = AzureUploader(out=out)
-        assert exc_info.match(r'Invalid Cloud provider prefix.*')
 
     @pytest.mark.parametrize('out', ['ss4://bucket/dir', ('./dir1', 'gcs://bucket/dir/')])
     def test_invalid_remote_list(self, out: Any):
-        with pytest.raises(ValueError) as exc_info:
+        with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = AzureUploader(out=out)
-        assert exc_info.match(r'Invalid Cloud provider prefix.*')
 
     def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
-        with pytest.raises(FileExistsError) as exc_info:
+        with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
             local, _ = local_remote_dir
             os.makedirs(local, exist_ok=True)
             local_file_path = os.path.join(local, 'file.txt')
@@ -231,7 +222,6 @@ class TestAzureUploader:
             with open(local_file_path, 'w') as _:
                 pass
             _ = AzureUploader(out=local)
-        assert exc_info.match(r'Directory is not empty.*')
 
 
 class TestLocalUploader:


### PR DESCRIPTION
## Description of changes:

This PR removes R2-specific download handlers and just relies on the S3 handler with `endpoint_url`. 
It also changes the `r2://` prefix to `s3://` which is the recommended naming convention by R2 (and Backblaze, and likely others).

## Issue #, if available:
https://github.com/mosaicml/streaming/issues/260

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
