### PR TITLE
Fix README slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
     <a href="https://streaming.docs.mosaicml.com">
         <img alt="Documentation" src="https://readthedocs.org/projects/streaming/badge/?version=stable">
     </a>
-    <a href="https://join.slack.com/t/mosaicml-community/shared_invite/zt-1btms90mc-GipE2ufuPkKY0QBrmF3LSA">
+    <a href="https://mosaicml-community.slack.com/join/shared_invite/zt-1btms90mc-GipE2ufuPkKY0QBrmF3LSA#/shared-invite/email">
         <img alt="Chat @ Slack" src="https://img.shields.io/badge/slack-chat-2eb67d.svg?logo=slack">
     </a>
     <a href="https://github.com/mosaicml/streaming/blob/main/LICENSE">


### PR DESCRIPTION
README slack link currently requires a @mosaicml.com email address