### PR TITLE
James/length

### DIFF
--- a/streaming/base/shared/array.py
+++ b/streaming/base/shared/array.py
@@ -35,6 +35,14 @@ class SharedArray:
         """
         return np.ndarray(self.shape, buffer=self.shm.buf, dtype=self.dtype)
 
+    def __len__(self) -> int:
+        """Get the length (i.e., size along the first axis).
+
+        Returns:
+            int: The length.
+        """
+        return int(self.shape[0])
+
     def __getitem__(self, index: Any) -> Any:
         """Get the scalar(s) at the given index, slice, or array of indices.
 

--- a/streaming/multimodal/convert/webvid/crawl_webvid_subsets.py
+++ b/streaming/multimodal/convert/webvid/crawl_webvid_subsets.py
@@ -215,7 +215,7 @@ def main(args: Namespace) -> None:
         dirname = os.path.join(args.mds_root, name)
         stream = Stream(local=dirname, proportion=1 / len(subsets_present))
         streams.append(stream)
-    dataset = StreamingDataset(streams=streams, choose=50)
+    dataset = StreamingDataset(streams=streams, epoch_size=50)
 
     # Print the size of each sub-dataset.
     for name, num_samples in zip(sorted(subsets_present), dataset.samples_per_stream):

--- a/streaming/multimodal/webvid.py
+++ b/streaming/multimodal/webvid.py
@@ -34,10 +34,10 @@ class StreamingInsideWebVid(StreamingDataset):
         keep_zip (bool): Whether to keep or delete the compressed form when decompressing
             downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
             ``False``.
-        choose (int, optional): Number of samples to draw per epoch balanced across all streams.
-            If ``None``, takes its value from the total number of underlying samples. Provide this
-            field if you are weighting streams relatively to target a larger or smaller epoch size.
-            Defaults to ``None``.
+        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
+            streams. If ``None``, takes its value from the total number of underlying samples.
+            Provide this field if you are weighting streams relatively to target a larger or
+            smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
             number of workers provided in a dataloader while iterating. Defaults to ``512``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
@@ -94,10 +94,10 @@ class StreamingOutsideGIWebVid(StreamingDataset):
         keep_zip (bool): Whether to keep or delete the compressed form when decompressing
             downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
             ``False``.
-        choose (int, optional): Number of samples to draw per epoch balanced across all streams.
-            If ``None``, takes its value from the total number of underlying samples. Provide this
-            field if you are weighting streams relatively to target a larger or smaller epoch size.
-            Defaults to ``None``.
+        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
+            streams. If ``None``, takes its value from the total number of underlying samples.
+            Provide this field if you are weighting streams relatively to target a larger or
+            smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
             number of workers provided in a dataloader while iterating. Defaults to ``512``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
@@ -128,7 +128,7 @@ class StreamingOutsideGIWebVid(StreamingDataset):
                  download_timeout: float = 60,
                  validate_hash: Optional[str] = None,
                  keep_zip: bool = False,
-                 choose: Optional[int] = None,
+                 epoch_size: Optional[int] = None,
                  predownload: Optional[int] = 512,
                  cache_limit: Optional[int] = None,
                  partition_algo: str = 'orig',
@@ -147,7 +147,7 @@ class StreamingOutsideGIWebVid(StreamingDataset):
                          download_timeout=download_timeout,
                          validate_hash=validate_hash,
                          keep_zip=keep_zip,
-                         choose=choose,
+                         epoch_size=epoch_size,
                          predownload=predownload,
                          cache_limit=cache_limit,
                          partition_algo=partition_algo,
@@ -212,10 +212,10 @@ class StreamingOutsideDTWebVid(StreamingDataset):
         keep_zip (bool): Whether to keep or delete the compressed form when decompressing
             downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
             ``False``.
-        choose (int, optional): Number of samples to draw per epoch balanced across all streams.
-            If ``None``, takes its value from the total number of underlying samples. Provide this
-            field if you are weighting streams relatively to target a larger or smaller epoch size.
-            Defaults to ``None``.
+        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
+            streams. If ``None``, takes its value from the total number of underlying samples.
+            Provide this field if you are weighting streams relatively to target a larger or
+            smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
             number of workers provided in a dataloader while iterating. Defaults to ``512``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
@@ -246,7 +246,7 @@ class StreamingOutsideDTWebVid(StreamingDataset):
                  download_timeout: float = 60,
                  validate_hash: Optional[str] = None,
                  keep_zip: bool = False,
-                 choose: Optional[int] = None,
+                 epoch_size: Optional[int] = None,
                  predownload: Optional[int] = 512,
                  cache_limit: Optional[int] = None,
                  partition_algo: str = 'orig',
@@ -265,7 +265,7 @@ class StreamingOutsideDTWebVid(StreamingDataset):
                          download_timeout=download_timeout,
                          validate_hash=validate_hash,
                          keep_zip=keep_zip,
-                         choose=choose,
+                         epoch_size=epoch_size,
                          predownload=predownload,
                          cache_limit=cache_limit,
                          partition_algo=partition_algo,

--- a/streaming/text/c4.py
+++ b/streaming/text/c4.py
@@ -36,10 +36,10 @@ class StreamingC4(StreamingDataset):
         keep_zip (bool): Whether to keep or delete the compressed form when decompressing
             downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
             ``False``.
-        choose (int, optional): Number of samples to draw per epoch balanced across all streams.
-            If ``None``, takes its value from the total number of underlying samples. Provide this
-            field if you are weighting streams relatively to target a larger or smaller epoch size.
-            Defaults to ``None``.
+        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
+            streams. If ``None``, takes its value from the total number of underlying samples.
+            Provide this field if you are weighting streams relatively to target a larger or
+            smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
             number of workers provided in a dataloader while iterating. Defaults to ``512``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
@@ -72,7 +72,7 @@ class StreamingC4(StreamingDataset):
                  download_timeout: float = 60,
                  validate_hash: Optional[str] = None,
                  keep_zip: bool = False,
-                 choose: Optional[int] = None,
+                 epoch_size: Optional[int] = None,
                  predownload: Optional[int] = 512,
                  cache_limit: Optional[int] = None,
                  partition_algo: str = 'orig',
@@ -95,7 +95,7 @@ class StreamingC4(StreamingDataset):
                          download_timeout=download_timeout,
                          validate_hash=validate_hash,
                          keep_zip=keep_zip,
-                         choose=choose,
+                         epoch_size=epoch_size,
                          predownload=predownload,
                          cache_limit=cache_limit,
                          partition_algo=partition_algo,

--- a/streaming/text/enwiki.py
+++ b/streaming/text/enwiki.py
@@ -32,10 +32,10 @@ class StreamingEnWiki(StreamingDataset):
         keep_zip (bool): Whether to keep or delete the compressed form when decompressing
             downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
             ``False``.
-        choose (int, optional): Number of samples to draw per epoch balanced across all streams.
-            If ``None``, takes its value from the total number of underlying samples. Provide this
-            field if you are weighting streams relatively to target a larger or smaller epoch size.
-            Defaults to ``None``.
+        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
+            streams. If ``None``, takes its value from the total number of underlying samples.
+            Provide this field if you are weighting streams relatively to target a larger or
+            smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
             number of workers provided in a dataloader while iterating. Defaults to ``512``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
@@ -64,7 +64,7 @@ class StreamingEnWiki(StreamingDataset):
                  download_timeout: float = 60,
                  validate_hash: Optional[str] = None,
                  keep_zip: bool = False,
-                 choose: Optional[int] = None,
+                 epoch_size: Optional[int] = None,
                  predownload: Optional[int] = 512,
                  cache_limit: Optional[int] = None,
                  partition_algo: str = 'orig',
@@ -81,7 +81,7 @@ class StreamingEnWiki(StreamingDataset):
                          download_timeout=download_timeout,
                          validate_hash=validate_hash,
                          keep_zip=keep_zip,
-                         choose=choose,
+                         epoch_size=epoch_size,
                          predownload=predownload,
                          cache_limit=cache_limit,
                          partition_algo=partition_algo,

--- a/streaming/text/pile.py
+++ b/streaming/text/pile.py
@@ -36,10 +36,10 @@ class StreamingPile(StreamingDataset):
         keep_zip (bool): Whether to keep or delete the compressed form when decompressing
             downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
             ``False``.
-        choose (int, optional): Number of samples to draw per epoch balanced across all streams.
-            If ``None``, takes its value from the total number of underlying samples. Provide this
-            field if you are weighting streams relatively to target a larger or smaller epoch size.
-            Defaults to ``None``.
+        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
+            streams. If ``None``, takes its value from the total number of underlying samples.
+            Provide this field if you are weighting streams relatively to target a larger or
+            smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
             number of workers provided in a dataloader while iterating. Defaults to ``512``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
@@ -72,7 +72,7 @@ class StreamingPile(StreamingDataset):
                  download_timeout: float = 60,
                  validate_hash: Optional[str] = None,
                  keep_zip: bool = False,
-                 choose: Optional[int] = None,
+                 epoch_size: Optional[int] = None,
                  predownload: Optional[int] = 512,
                  cache_limit: Optional[int] = None,
                  partition_algo: str = 'orig',
@@ -95,7 +95,7 @@ class StreamingPile(StreamingDataset):
                          download_timeout=download_timeout,
                          validate_hash=validate_hash,
                          keep_zip=keep_zip,
-                         choose=choose,
+                         epoch_size=epoch_size,
                          predownload=predownload,
                          cache_limit=cache_limit,
                          partition_algo=partition_algo,

--- a/streaming/vision/ade20k.py
+++ b/streaming/vision/ade20k.py
@@ -34,10 +34,10 @@ class StreamingADE20K(StreamingDataset):
         keep_zip (bool): Whether to keep or delete the compressed form when decompressing
             downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
             ``False``.
-        choose (int, optional): Number of samples to draw per epoch balanced across all streams.
-            If ``None``, takes its value from the total number of underlying samples. Provide this
-            field if you are weighting streams relatively to target a larger or smaller epoch size.
-            Defaults to ``None``.
+        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
+            streams. If ``None``, takes its value from the total number of underlying samples.
+            Provide this field if you are weighting streams relatively to target a larger or
+            smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
             number of workers provided in a dataloader while iterating. Defaults to ``512``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
@@ -72,7 +72,7 @@ class StreamingADE20K(StreamingDataset):
                  download_timeout: float = 60,
                  validate_hash: Optional[str] = None,
                  keep_zip: bool = False,
-                 choose: Optional[int] = None,
+                 epoch_size: Optional[int] = None,
                  predownload: Optional[int] = 512,
                  partition_algo: str = 'orig',
                  cache_limit: Optional[int] = None,
@@ -92,7 +92,7 @@ class StreamingADE20K(StreamingDataset):
                          download_timeout=download_timeout,
                          validate_hash=validate_hash,
                          keep_zip=keep_zip,
-                         choose=choose,
+                         epoch_size=epoch_size,
                          predownload=predownload,
                          cache_limit=cache_limit,
                          partition_algo=partition_algo,

--- a/streaming/vision/base.py
+++ b/streaming/vision/base.py
@@ -66,10 +66,10 @@ class StreamingVisionDataset(StreamingDataset, VisionDataset):
         keep_zip (bool): Whether to keep or delete the compressed form when decompressing
             downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
             ``False``.
-        choose (int, optional): Number of samples to draw per epoch balanced across all streams.
-            If ``None``, takes its value from the total number of underlying samples. Provide this
-            field if you are weighting streams relatively to target a larger or smaller epoch size.
-            Defaults to ``None``.
+        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
+            streams. If ``None``, takes its value from the total number of underlying samples.
+            Provide this field if you are weighting streams relatively to target a larger or
+            smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
             number of workers provided in a dataloader while iterating. Defaults to ``512``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
@@ -104,7 +104,7 @@ class StreamingVisionDataset(StreamingDataset, VisionDataset):
                  download_timeout: float = 60,
                  validate_hash: Optional[str] = None,
                  keep_zip: bool = False,
-                 choose: Optional[int] = None,
+                 epoch_size: Optional[int] = None,
                  predownload: Optional[int] = 512,
                  cache_limit: Optional[int] = None,
                  partition_algo: str = 'orig',
@@ -125,7 +125,7 @@ class StreamingVisionDataset(StreamingDataset, VisionDataset):
                                   download_timeout=download_timeout,
                                   validate_hash=validate_hash,
                                   keep_zip=keep_zip,
-                                  choose=choose,
+                                  epoch_size=epoch_size,
                                   predownload=predownload,
                                   cache_limit=cache_limit,
                                   partition_algo=partition_algo,

--- a/streaming/vision/cifar10.py
+++ b/streaming/vision/cifar10.py
@@ -32,10 +32,10 @@ class StreamingCIFAR10(StreamingVisionDataset):
         keep_zip (bool): Whether to keep or delete the compressed form when decompressing
             downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
             ``False``.
-        choose (int, optional): Number of samples to draw per epoch balanced across all streams.
-            If ``None``, takes its value from the total number of underlying samples. Provide this
-            field if you are weighting streams relatively to target a larger or smaller epoch size.
-            Defaults to ``None``.
+        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
+            streams. If ``None``, takes its value from the total number of underlying samples.
+            Provide this field if you are weighting streams relatively to target a larger or
+            smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
             number of workers provided in a dataloader while iterating. Defaults to ``512``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.

--- a/streaming/vision/coco.py
+++ b/streaming/vision/coco.py
@@ -34,10 +34,10 @@ class StreamingCOCO(StreamingDataset):
         keep_zip (bool): Whether to keep or delete the compressed form when decompressing
             downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
             ``False``.
-        choose (int, optional): Number of samples to draw per epoch balanced across all streams.
-            If ``None``, takes its value from the total number of underlying samples. Provide this
-            field if you are weighting streams relatively to target a larger or smaller epoch size.
-            Defaults to ``None``.
+        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
+            streams. If ``None``, takes its value from the total number of underlying samples.
+            Provide this field if you are weighting streams relatively to target a larger or
+            smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
             number of workers provided in a dataloader while iterating. Defaults to ``512``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
@@ -68,7 +68,7 @@ class StreamingCOCO(StreamingDataset):
                  download_timeout: float = 60,
                  validate_hash: Optional[str] = None,
                  keep_zip: bool = False,
-                 choose: Optional[int] = None,
+                 epoch_size: Optional[int] = None,
                  predownload: Optional[int] = 512,
                  partition_algo: str = 'orig',
                  cache_limit: Optional[int] = None,
@@ -86,7 +86,7 @@ class StreamingCOCO(StreamingDataset):
                          download_timeout=download_timeout,
                          validate_hash=validate_hash,
                          keep_zip=keep_zip,
-                         choose=choose,
+                         epoch_size=epoch_size,
                          predownload=predownload,
                          cache_limit=cache_limit,
                          partition_algo=partition_algo,

--- a/streaming/vision/imagenet.py
+++ b/streaming/vision/imagenet.py
@@ -32,10 +32,10 @@ class StreamingImageNet(StreamingVisionDataset):
         keep_zip (bool): Whether to keep or delete the compressed form when decompressing
             downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
             ``False``.
-        choose (int, optional): Number of samples to draw per epoch balanced across all streams.
-            If ``None``, takes its value from the total number of underlying samples. Provide this
-            field if you are weighting streams relatively to target a larger or smaller epoch size.
-            Defaults to ``None``.
+        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
+            streams. If ``None``, takes its value from the total number of underlying samples.
+            Provide this field if you are weighting streams relatively to target a larger or
+            smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
             number of workers provided in a dataloader while iterating. Defaults to ``512``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.

--- a/tests/test_mixing.py
+++ b/tests/test_mixing.py
@@ -178,7 +178,7 @@ def test_mix_proportion_range(root: str):
         subroot = os.path.join(root, str(i))
         stream = Stream(local=subroot, proportion=proportion[i])
         streams.append(stream)
-    dataset = StreamingDataset(streams=streams, choose=12)
+    dataset = StreamingDataset(streams=streams, epoch_size=12)
     assert dataset.num_samples == 8
     assert walk(dataset) == [2, 3, 4, 5, 4, 5, 6, 7, 6, 7, 6, 7]
     for i, stream in enumerate(streams):


### PR DESCRIPTION
## Description of changes:

- Rename `StreamingDataset.choose` to `StreamingDataset.epoch_size`
- Fix bug in length calculation to use resampled epoch size, not underlying num samples

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
