### PR TITLE
Fixed performance degradation when not doing shard eviction

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -1151,7 +1151,7 @@ class StreamingDataset(Array, IterableDataset):
 
             # Wait for the shard for this sample to be downloaded and decompressed, if not already.
             shard_id, _ = self.spanner[sample_id]
-            # During cold shard eviction, shard state might go in a reverse direction. If a shard
+            # During cold shard eviction, shard state might go in the reverse direction. If a shard
             # is missing while fetching a sample, download it.
             if self._shard_states[shard_id] == _ShardState.MISSING:
                 self.download_shard(shard_id, False)


### PR DESCRIPTION
## Description of changes:
- When not performing CSE, avoid thread sync between `_download_thread` and `_ready_thread` since shard state only goes in forward direction.
- When performing CSE, ensure `_ready_thread` checks for the shard existence, if not present, download it since there could be a case where `_download_thread` might have evicted that shard earlier based least recently accessed policy.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
