### PR TITLE
Derived predownload value using batch size and NCN

### DIFF
--- a/docs/source/fundamentals/shuffling.md
+++ b/docs/source/fundamentals/shuffling.md
@@ -17,7 +17,7 @@ StreamingDataset also takes two other arguments that shuffling interacts with:
 
 | Parameter | Type | Description |
 | :-------- | :--- | :---------- |
-| `predownload` | `Optional[int] = 512` | tune together with shuffle block size to keep workers from ever starving of shard pre-downloads while iterating (none means no limit) |
+| `predownload` | `Optional[int] = None` | tune together with shuffle block size to keep workers from ever starving of shard pre-downloads while iterating (`None` means derive its value using batch size and number of canonical nodes `max(batch_size, 256 * batch_size // num_canonical_nodes)`) |
 | `num_canonical_nodes` | `Optional[int] = None` | number of divisions of the sample space, which are iterated from beginning to end concurrently (defaults to number of initial physical nodes) |
 
 ## Algorithms

--- a/streaming/multimodal/webvid.py
+++ b/streaming/multimodal/webvid.py
@@ -39,7 +39,9 @@ class StreamingInsideWebVid(StreamingDataset):
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. Defaults to ``512``.
+            number of workers provided in a dataloader while iterating. If ``None``, its value
+            gets derived using batch size and number of canonical nodes
+            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
@@ -99,7 +101,9 @@ class StreamingOutsideGIWebVid(StreamingDataset):
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. Defaults to ``512``.
+            number of workers provided in a dataloader while iterating. If ``None``, its value
+            gets derived using batch size and number of canonical nodes
+            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
@@ -129,7 +133,7 @@ class StreamingOutsideGIWebVid(StreamingDataset):
                  validate_hash: Optional[str] = None,
                  keep_zip: bool = False,
                  epoch_size: Optional[int] = None,
-                 predownload: Optional[int] = 512,
+                 predownload: Optional[int] = None,
                  cache_limit: Optional[int] = None,
                  partition_algo: str = 'orig',
                  num_canonical_nodes: Optional[int] = None,
@@ -217,7 +221,9 @@ class StreamingOutsideDTWebVid(StreamingDataset):
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. Defaults to ``512``.
+            number of workers provided in a dataloader while iterating. If ``None``, its value
+            gets derived using batch size and number of canonical nodes
+            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
@@ -247,7 +253,7 @@ class StreamingOutsideDTWebVid(StreamingDataset):
                  validate_hash: Optional[str] = None,
                  keep_zip: bool = False,
                  epoch_size: Optional[int] = None,
-                 predownload: Optional[int] = 512,
+                 predownload: Optional[int] = None,
                  cache_limit: Optional[int] = None,
                  partition_algo: str = 'orig',
                  num_canonical_nodes: Optional[int] = None,

--- a/streaming/text/c4.py
+++ b/streaming/text/c4.py
@@ -41,7 +41,9 @@ class StreamingC4(StreamingDataset):
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. Defaults to ``512``.
+            number of workers provided in a dataloader while iterating. If ``None``, its value
+            gets derived using batch size and number of canonical nodes
+            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
@@ -73,7 +75,7 @@ class StreamingC4(StreamingDataset):
                  validate_hash: Optional[str] = None,
                  keep_zip: bool = False,
                  epoch_size: Optional[int] = None,
-                 predownload: Optional[int] = 512,
+                 predownload: Optional[int] = None,
                  cache_limit: Optional[int] = None,
                  partition_algo: str = 'orig',
                  num_canonical_nodes: Optional[int] = None,

--- a/streaming/text/enwiki.py
+++ b/streaming/text/enwiki.py
@@ -37,7 +37,9 @@ class StreamingEnWiki(StreamingDataset):
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. Defaults to ``512``.
+            number of workers provided in a dataloader while iterating. If ``None``, its value
+            gets derived using batch size and number of canonical nodes
+            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
@@ -65,7 +67,7 @@ class StreamingEnWiki(StreamingDataset):
                  validate_hash: Optional[str] = None,
                  keep_zip: bool = False,
                  epoch_size: Optional[int] = None,
-                 predownload: Optional[int] = 512,
+                 predownload: Optional[int] = None,
                  cache_limit: Optional[int] = None,
                  partition_algo: str = 'orig',
                  num_canonical_nodes: Optional[int] = None,

--- a/streaming/text/pile.py
+++ b/streaming/text/pile.py
@@ -41,7 +41,9 @@ class StreamingPile(StreamingDataset):
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. Defaults to ``512``.
+            number of workers provided in a dataloader while iterating. If ``None``, its value
+            gets derived using batch size and number of canonical nodes
+            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
@@ -73,7 +75,7 @@ class StreamingPile(StreamingDataset):
                  validate_hash: Optional[str] = None,
                  keep_zip: bool = False,
                  epoch_size: Optional[int] = None,
-                 predownload: Optional[int] = 512,
+                 predownload: Optional[int] = None,
                  cache_limit: Optional[int] = None,
                  partition_algo: str = 'orig',
                  num_canonical_nodes: Optional[int] = None,

--- a/streaming/vision/ade20k.py
+++ b/streaming/vision/ade20k.py
@@ -39,7 +39,9 @@ class StreamingADE20K(StreamingDataset):
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. Defaults to ``512``.
+            number of workers provided in a dataloader while iterating. If ``None``, its value
+            gets derived using batch size and number of canonical nodes
+            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
@@ -73,7 +75,7 @@ class StreamingADE20K(StreamingDataset):
                  validate_hash: Optional[str] = None,
                  keep_zip: bool = False,
                  epoch_size: Optional[int] = None,
-                 predownload: Optional[int] = 512,
+                 predownload: Optional[int] = None,
                  partition_algo: str = 'orig',
                  cache_limit: Optional[int] = None,
                  num_canonical_nodes: Optional[int] = None,

--- a/streaming/vision/base.py
+++ b/streaming/vision/base.py
@@ -71,7 +71,9 @@ class StreamingVisionDataset(StreamingDataset, VisionDataset):
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. Defaults to ``512``.
+            number of workers provided in a dataloader while iterating. If ``None``, its value
+            gets derived using batch size and number of canonical nodes
+            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
@@ -105,7 +107,7 @@ class StreamingVisionDataset(StreamingDataset, VisionDataset):
                  validate_hash: Optional[str] = None,
                  keep_zip: bool = False,
                  epoch_size: Optional[int] = None,
-                 predownload: Optional[int] = 512,
+                 predownload: Optional[int] = None,
                  cache_limit: Optional[int] = None,
                  partition_algo: str = 'orig',
                  num_canonical_nodes: Optional[int] = None,

--- a/streaming/vision/cifar10.py
+++ b/streaming/vision/cifar10.py
@@ -37,7 +37,9 @@ class StreamingCIFAR10(StreamingVisionDataset):
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. Defaults to ``512``.
+            number of workers provided in a dataloader while iterating. If ``None``, its value
+            gets derived using batch size and number of canonical nodes
+            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to

--- a/streaming/vision/coco.py
+++ b/streaming/vision/coco.py
@@ -39,7 +39,9 @@ class StreamingCOCO(StreamingDataset):
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. Defaults to ``512``.
+            number of workers provided in a dataloader while iterating. If ``None``, its value
+            gets derived using batch size and number of canonical nodes
+            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
@@ -69,7 +71,7 @@ class StreamingCOCO(StreamingDataset):
                  validate_hash: Optional[str] = None,
                  keep_zip: bool = False,
                  epoch_size: Optional[int] = None,
-                 predownload: Optional[int] = 512,
+                 predownload: Optional[int] = None,
                  partition_algo: str = 'orig',
                  cache_limit: Optional[int] = None,
                  num_canonical_nodes: Optional[int] = None,

--- a/streaming/vision/imagenet.py
+++ b/streaming/vision/imagenet.py
@@ -37,7 +37,9 @@ class StreamingImageNet(StreamingVisionDataset):
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
         predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. Defaults to ``512``.
+            number of workers provided in a dataloader while iterating. If ``None``, its value
+            gets derived using batch size and number of canonical nodes
+            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to


### PR DESCRIPTION
## Description of changes:
- Derived `predownload` value using batch size and NCN if not provided.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
