### PR TITLE
Change the default number of canonical nodes

### DIFF
--- a/docs/source/fundamentals/shuffling.md
+++ b/docs/source/fundamentals/shuffling.md
@@ -18,7 +18,7 @@ StreamingDataset also takes two other arguments that shuffling interacts with:
 | Parameter | Type | Description |
 | :-------- | :--- | :---------- |
 | `predownload` | `Optional[int] = None` | tune together with shuffle block size to keep workers from ever starving of shard pre-downloads while iterating (`None` means derive its value using batch size and number of canonical nodes `max(batch_size, 256 * batch_size // num_canonical_nodes)`) |
-| `num_canonical_nodes` | `Optional[int] = None` | number of divisions of the sample space, which are iterated from beginning to end concurrently (defaults to number of initial physical nodes) |
+| `num_canonical_nodes` | `Optional[int] = None` | number of divisions of the sample space, which are iterated from beginning to end concurrently (defaults to 64 times the number of initial physical nodes) |
 
 ## Algorithms
 

--- a/streaming/multimodal/webvid.py
+++ b/streaming/multimodal/webvid.py
@@ -48,8 +48,16 @@ class StreamingInsideWebVid(StreamingDataset):
             disable shard eviction. Defaults to ``None``.
         partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. Defaults to ``None``, which is interpreted as the number of nodes of the
-            initial run.
+            resumption. The sample space is divided evenly according to the number of canonical
+            nodes. The higher the value, the more independent non-overlapping paths the
+            StreamingDataset replicas take through the shards per model replica (increasing data
+            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
+            of nodes of the initial run.
+
+            .. note::
+
+                For sequential sample ordering, set ``shuffle`` to ``False`` and
+                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
         shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to
@@ -110,8 +118,16 @@ class StreamingOutsideGIWebVid(StreamingDataset):
             disable shard eviction. Defaults to ``None``.
         partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. Defaults to ``None``, which is interpreted as the number of nodes of the
-            initial run.
+            resumption. The sample space is divided evenly according to the number of canonical
+            nodes. The higher the value, the more independent non-overlapping paths the
+            StreamingDataset replicas take through the shards per model replica (increasing data
+            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
+            of nodes of the initial run.
+
+            .. note::
+
+                For sequential sample ordering, set ``shuffle`` to ``False`` and
+                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
         shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to
@@ -230,8 +246,16 @@ class StreamingOutsideDTWebVid(StreamingDataset):
             disable shard eviction. Defaults to ``None``.
         partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. Defaults to ``None``, which is interpreted as the number of nodes of the
-            initial run.
+            resumption. The sample space is divided evenly according to the number of canonical
+            nodes. The higher the value, the more independent non-overlapping paths the
+            StreamingDataset replicas take through the shards per model replica (increasing data
+            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
+            of nodes of the initial run.
+
+            .. note::
+
+                For sequential sample ordering, set ``shuffle`` to ``False`` and
+                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
         shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to

--- a/streaming/text/c4.py
+++ b/streaming/text/c4.py
@@ -50,8 +50,16 @@ class StreamingC4(StreamingDataset):
             disable shard eviction. Defaults to ``None``.
         partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. Defaults to ``None``, which is interpreted as the number of nodes of the
-            initial run.
+            resumption. The sample space is divided evenly according to the number of canonical
+            nodes. The higher the value, the more independent non-overlapping paths the
+            StreamingDataset replicas take through the shards per model replica (increasing data
+            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
+            of nodes of the initial run.
+
+            .. note::
+
+                For sequential sample ordering, set ``shuffle`` to ``False`` and
+                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
         shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to

--- a/streaming/text/enwiki.py
+++ b/streaming/text/enwiki.py
@@ -46,8 +46,16 @@ class StreamingEnWiki(StreamingDataset):
             disable shard eviction. Defaults to ``None``.
         partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. Defaults to ``None``, which is interpreted as the number of nodes of the
-            initial run.
+            resumption. The sample space is divided evenly according to the number of canonical
+            nodes. The higher the value, the more independent non-overlapping paths the
+            StreamingDataset replicas take through the shards per model replica (increasing data
+            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
+            of nodes of the initial run.
+
+            .. note::
+
+                For sequential sample ordering, set ``shuffle`` to ``False`` and
+                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
         shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to

--- a/streaming/text/pile.py
+++ b/streaming/text/pile.py
@@ -50,8 +50,16 @@ class StreamingPile(StreamingDataset):
             disable shard eviction. Defaults to ``None``.
         partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. Defaults to ``None``, which is interpreted as the number of nodes of the
-            initial run.
+            resumption. The sample space is divided evenly according to the number of canonical
+            nodes. The higher the value, the more independent non-overlapping paths the
+            StreamingDataset replicas take through the shards per model replica (increasing data
+            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
+            of nodes of the initial run.
+
+            .. note::
+
+                For sequential sample ordering, set ``shuffle`` to ``False`` and
+                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
         shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to

--- a/streaming/vision/ade20k.py
+++ b/streaming/vision/ade20k.py
@@ -48,8 +48,16 @@ class StreamingADE20K(StreamingDataset):
             disable shard eviction. Defaults to ``None``.
         partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. Defaults to ``None``, which is interpreted as the number of nodes of the
-            initial run.
+            resumption. The sample space is divided evenly according to the number of canonical
+            nodes. The higher the value, the more independent non-overlapping paths the
+            StreamingDataset replicas take through the shards per model replica (increasing data
+            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
+            of nodes of the initial run.
+
+            .. note::
+
+                For sequential sample ordering, set ``shuffle`` to ``False`` and
+                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
         shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to

--- a/streaming/vision/base.py
+++ b/streaming/vision/base.py
@@ -80,8 +80,16 @@ class StreamingVisionDataset(StreamingDataset, VisionDataset):
             disable shard eviction. Defaults to ``None``.
         partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. Defaults to ``None``, which is interpreted as the number of nodes of the
-            initial run.
+            resumption. The sample space is divided evenly according to the number of canonical
+            nodes. The higher the value, the more independent non-overlapping paths the
+            StreamingDataset replicas take through the shards per model replica (increasing data
+            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
+            of nodes of the initial run.
+
+            .. note::
+
+                For sequential sample ordering, set ``shuffle`` to ``False`` and
+                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
         shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to

--- a/streaming/vision/cifar10.py
+++ b/streaming/vision/cifar10.py
@@ -46,8 +46,16 @@ class StreamingCIFAR10(StreamingVisionDataset):
             disable shard eviction. Defaults to ``None``.
         partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. Defaults to ``None``, which is interpreted as the number of nodes of the
-            initial run.
+            resumption. The sample space is divided evenly according to the number of canonical
+            nodes. The higher the value, the more independent non-overlapping paths the
+            StreamingDataset replicas take through the shards per model replica (increasing data
+            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
+            of nodes of the initial run.
+
+            .. note::
+
+                For sequential sample ordering, set ``shuffle`` to ``False`` and
+                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
         shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to

--- a/streaming/vision/coco.py
+++ b/streaming/vision/coco.py
@@ -48,8 +48,16 @@ class StreamingCOCO(StreamingDataset):
             disable shard eviction. Defaults to ``None``.
         partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. Defaults to ``None``, which is interpreted as the number of nodes of the
-            initial run.
+            resumption. The sample space is divided evenly according to the number of canonical
+            nodes. The higher the value, the more independent non-overlapping paths the
+            StreamingDataset replicas take through the shards per model replica (increasing data
+            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
+            of nodes of the initial run.
+
+            .. note::
+
+                For sequential sample ordering, set ``shuffle`` to ``False`` and
+                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
         shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to

--- a/streaming/vision/imagenet.py
+++ b/streaming/vision/imagenet.py
@@ -46,8 +46,16 @@ class StreamingImageNet(StreamingVisionDataset):
             disable shard eviction. Defaults to ``None``.
         partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. Defaults to ``None``, which is interpreted as the number of nodes of the
-            initial run.
+            resumption. The sample space is divided evenly according to the number of canonical
+            nodes. The higher the value, the more independent non-overlapping paths the
+            StreamingDataset replicas take through the shards per model replica (increasing data
+            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
+            of nodes of the initial run.
+
+            .. note::
+
+                For sequential sample ordering, set ``shuffle`` to ``False`` and
+                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
         batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
             partitioned over the workers. Defaults to ``None``.
         shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to

--- a/tests/test_laziness.py
+++ b/tests/test_laziness.py
@@ -23,7 +23,7 @@ def two(remote: str, local: str):
     """
     Verify __iter__ -> __getitem__ accesses.
     """
-    dataset = StreamingDataset(local=remote)
+    dataset = StreamingDataset(local=remote, num_canonical_nodes=1)
     for i, sample in zip(range(dataset.num_samples), dataset):
         assert sample['value'] == i
 
@@ -43,7 +43,7 @@ def four(remote: str, local: str):
     """
     Verify __iter__ -> __getitem__ downloads/accesses.
     """
-    dataset = StreamingDataset(local=local, remote=remote)
+    dataset = StreamingDataset(local=local, remote=remote, num_canonical_nodes=1)
     for i, sample in zip(range(dataset.num_samples), dataset):
         assert sample['value'] == i
     del dataset

--- a/tests/test_mixing.py
+++ b/tests/test_mixing.py
@@ -40,7 +40,7 @@ def test_mix_none(root: str):
         subroot = os.path.join(root, str(i))
         stream = Stream(local=subroot)
         streams.append(stream)
-    dataset = StreamingDataset(streams=streams)
+    dataset = StreamingDataset(streams=streams, num_canonical_nodes=1)
     assert dataset.num_samples == 8
     assert walk(dataset) == list(range(8))
     for stream in streams:
@@ -55,7 +55,7 @@ def test_mix_choose_same(root: str):
         subroot = os.path.join(root, str(i))
         stream = Stream(local=subroot, choose=2)
         streams.append(stream)
-    dataset = StreamingDataset(streams=streams)
+    dataset = StreamingDataset(streams=streams, num_canonical_nodes=1)
     assert dataset.num_samples == 8
     assert walk(dataset) == list(range(8))
     for stream in streams:
@@ -70,7 +70,7 @@ def test_mix_choose_mul(root: str):
         subroot = os.path.join(root, str(i))
         stream = Stream(local=subroot, choose=4)
         streams.append(stream)
-    dataset = StreamingDataset(streams=streams)
+    dataset = StreamingDataset(streams=streams, num_canonical_nodes=1)
     assert dataset.num_samples == 8
     assert walk(dataset) == [0, 1, 0, 1, 2, 3, 2, 3, 4, 5, 4, 5, 6, 7, 6, 7]
     for stream in streams:
@@ -86,7 +86,7 @@ def test_mix_choose_range(root: str):
         subroot = os.path.join(root, str(i))
         stream = Stream(local=subroot, choose=choices[i])
         streams.append(stream)
-    dataset = StreamingDataset(streams=streams)
+    dataset = StreamingDataset(streams=streams, num_canonical_nodes=1)
     assert dataset.num_samples == 8
     assert walk(dataset) == [2, 3, 4, 5, 4, 5, 6, 7, 6, 7, 6, 7]
     for i, stream in enumerate(streams):
@@ -102,7 +102,7 @@ def test_mix_repeat(root: str):
         subroot = os.path.join(root, str(i))
         stream = Stream(local=subroot, repeat=repeat[i])
         streams.append(stream)
-    dataset = StreamingDataset(streams=streams)
+    dataset = StreamingDataset(streams=streams, num_canonical_nodes=1)
     assert dataset.num_samples == 8
     assert walk(dataset) == [2, 3, 4, 5, 4, 5, 6, 7, 6, 7, 6, 7]
     for i, stream in enumerate(streams):
@@ -124,7 +124,7 @@ def test_mix_repeat_and_choose(root: str):
         repeat, choose = weights[i]
         stream = Stream(local=subroot, repeat=repeat, choose=choose)
         streams.append(stream)
-    dataset = StreamingDataset(streams=streams)
+    dataset = StreamingDataset(streams=streams, num_canonical_nodes=1)
     assert dataset.num_samples == 8
     assert walk(dataset) == [2, 3, 4, 5, 4, 5, 6, 7, 6, 7, 6, 7]
     for i, stream in enumerate(streams):
@@ -146,7 +146,7 @@ def test_mix_repeat_choose_none(root: str):
         repeat, choose = weights[i]
         stream = Stream(local=subroot, repeat=repeat, choose=choose)
         streams.append(stream)
-    dataset = StreamingDataset(streams=streams)
+    dataset = StreamingDataset(streams=streams, num_canonical_nodes=1)
     assert dataset.num_samples == 8
     assert walk(dataset) == [2, 3, 4, 5, 4, 5, 6, 7, 6, 7, 6, 7]
     for i, stream in enumerate(streams):
@@ -162,7 +162,7 @@ def test_mix_proportion_equal(root: str):
         subroot = os.path.join(root, str(i))
         stream = Stream(local=subroot, proportion=proportion[i])
         streams.append(stream)
-    dataset = StreamingDataset(streams=streams)
+    dataset = StreamingDataset(streams=streams, num_canonical_nodes=1)
     assert dataset.num_samples == 8
     assert walk(dataset) == [0, 1, 2, 3, 4, 5, 6, 7]
     for i, stream in enumerate(streams):
@@ -178,7 +178,7 @@ def test_mix_proportion_range(root: str):
         subroot = os.path.join(root, str(i))
         stream = Stream(local=subroot, proportion=proportion[i])
         streams.append(stream)
-    dataset = StreamingDataset(streams=streams, epoch_size=12)
+    dataset = StreamingDataset(streams=streams, epoch_size=12, num_canonical_nodes=1)
     assert dataset.num_samples == 8
     assert walk(dataset) == [2, 3, 4, 5, 4, 5, 6, 7, 6, 7, 6, 7]
     for i, stream in enumerate(streams):
@@ -193,7 +193,7 @@ def test_mix_balance(root: str):
         subroot = os.path.join(root, str(i))
         stream = Stream(local=subroot, choose=3)
         streams.append(stream)
-    dataset = StreamingDataset(streams=streams)
+    dataset = StreamingDataset(streams=streams, num_canonical_nodes=1)
     counts = np.zeros(8, np.int64)
     for _ in range(1000):
         for value in walk(dataset):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -44,9 +44,10 @@ def mds_dataset_dir():
 @pytest.mark.parametrize('remote_arg', ['none', 'same', 'different'])
 @pytest.mark.parametrize('shuffle', [False, True])
 @pytest.mark.parametrize('seed', [5151])
+@pytest.mark.parametrize('num_canonical_nodes', [1])
 @pytest.mark.usefixtures('mds_dataset_dir')
 def test_dataset_sample_order(mds_dataset_dir: Any, batch_size: int, remote_arg: str,
-                              shuffle: bool, seed: int):
+                              shuffle: bool, seed: int, num_canonical_nodes: int):
     num_samples = 117
     remote_dir, local_dir = mds_dataset_dir
     if remote_arg == 'none':
@@ -64,7 +65,8 @@ def test_dataset_sample_order(mds_dataset_dir: Any, batch_size: int, remote_arg:
                                remote=remote_dir,
                                shuffle=shuffle,
                                batch_size=batch_size,
-                               shuffle_seed=seed)
+                               shuffle_seed=seed,
+                               num_canonical_nodes=num_canonical_nodes)
 
     # Test basic sample order
     rcvd_samples = 0

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -125,9 +125,10 @@ def test_dataloader_determinism(mds_dataset_dir: Any, batch_size: int, seed: int
 @pytest.mark.parametrize('shuffle', [False])
 @pytest.mark.parametrize('drop_last', [False, True])
 @pytest.mark.parametrize('num_workers', [0, 8])
+@pytest.mark.parametrize('num_canonical_nodes', [1])
 @pytest.mark.usefixtures('mds_dataset_dir')
 def test_dataloader_sample_order(mds_dataset_dir: Any, batch_size: int, seed: int, shuffle: bool,
-                                 drop_last: bool, num_workers: int):
+                                 drop_last: bool, num_workers: int, num_canonical_nodes: int):
     remote_dir, local_dir = mds_dataset_dir
 
     # Build StreamingDataset
@@ -135,7 +136,8 @@ def test_dataloader_sample_order(mds_dataset_dir: Any, batch_size: int, seed: in
                                remote=remote_dir,
                                shuffle=shuffle,
                                batch_size=batch_size,
-                               shuffle_seed=seed)
+                               shuffle_seed=seed,
+                               num_canonical_nodes=num_canonical_nodes)
 
     # Build DataLoader
     dataloader = StreamingDataLoader(dataset=dataset,
@@ -161,9 +163,11 @@ def test_dataloader_sample_order(mds_dataset_dir: Any, batch_size: int, seed: in
 @pytest.mark.parametrize('seed', [3456])
 @pytest.mark.parametrize('shuffle', [False, True])
 @pytest.mark.parametrize('num_workers', [0, 4])
+@pytest.mark.parametrize('num_canonical_nodes', [1])
 @pytest.mark.usefixtures('mds_dataset_dir')
 def test_streamingdataloader_mid_epoch_resumption(mds_dataset_dir: Any, batch_size: int, seed: int,
-                                                  shuffle: bool, num_workers: int):
+                                                  shuffle: bool, num_workers: int,
+                                                  num_canonical_nodes: int):
     remote_dir, local_dir = mds_dataset_dir
 
     # Build StreamingDataset
@@ -171,7 +175,8 @@ def test_streamingdataloader_mid_epoch_resumption(mds_dataset_dir: Any, batch_si
                                remote=remote_dir,
                                shuffle=shuffle,
                                batch_size=batch_size,
-                               shuffle_seed=seed)
+                               shuffle_seed=seed,
+                               num_canonical_nodes=num_canonical_nodes)
 
     # Build DataLoader
     dataloader = StreamingDataLoader(dataset=dataset,


### PR DESCRIPTION
## Description of changes:
- Change the default number of canonical nodes to 64 times of physical node(s) for better data source diversity.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
