### PR TITLE
Ensure int64

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -721,8 +721,8 @@ class StreamingDataset(Array, IterableDataset):
                     partial_repeat.sort()
                     sample_ids.append(partial_repeat)
 
-        shuffle_units = np.concatenate(shuffle_units)
-        sample_ids = np.concatenate(sample_ids)
+        shuffle_units = np.concatenate(shuffle_units).astype(np.int64)
+        sample_ids = np.concatenate(sample_ids).astype(np.int64)
         return shuffle_units, sample_ids
 
     def _generate_work(self, world: World, epoch: int, sample_in_epoch: int) -> NDArray[np.int64]:


### PR DESCRIPTION
## Description of changes:

tl;dr Fix a crash due to a float creeping into calculations.

```
shard_shuffle_units = [shard_samples] * (shard_choose // shard_samples)
```

In the above line of dataset.py, if we are choosing sufficiently few samples out of sufficiently many, the resulting list of shuffle units will be empty (i.e., no shards or partial shards). Numpy concatenate automatically assumes empty lists are of dtype float64. Numpy concatenate also automatically casts lists of both int64 and float64 to float64. This then shows up as the derived quantity num_samples being a float64 in the shuffling algorithms, causing the crash.

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
