### PR TITLE
Wait for thread job to finish and Fixed filelock directory structure

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -5,7 +5,7 @@
 
 import json
 import os
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, wait
 from concurrent.futures._base import Future
 from enum import IntEnum
 from math import ceil
@@ -1264,5 +1264,5 @@ class StreamingDataset(Array, IterableDataset):
         ready_future = self._executor.submit(self._ready_thread, it)
         ready_future.add_done_callback(self.on_exception)
         yield from map(self.__getitem__, self._each_sample_id(it))
-        self._executor.shutdown(wait=True)
+        wait([download_future, ready_future])
         it.exit()

--- a/streaming/base/shared/barrier.py
+++ b/streaming/base/shared/barrier.py
@@ -6,9 +6,6 @@
 Implemented with shared array and a filelock.
 """
 
-import atexit
-import os
-from shutil import rmtree
 from time import sleep
 
 import numpy as np
@@ -38,17 +35,7 @@ class SharedBarrier:
     def __init__(self, filelock_path: str, shm_name: str) -> None:
         # Create lock.
         self.filelock_path = filelock_path
-        dirname = os.path.dirname(filelock_path)
-        if dirname:
-            os.makedirs(dirname, exist_ok=True)
-        self.lock = FileLock(filelock_path)
-
-        def cleanup():
-            if os.path.islink(dirname):
-                os.unlink(dirname)
-            rmtree(dirname, ignore_errors=True)
-
-        atexit.register(cleanup)
+        self.lock = FileLock(self.filelock_path)
 
         # Create three int32 fields in shared memory: num_enter, num_exit, flag.
         self._arr = SharedArray(3, np.int32, shm_name)

--- a/tests/test_barrier.py
+++ b/tests/test_barrier.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import multiprocessing as mp
+import os
 import re
 from multiprocessing.managers import ListProxy
 from random import random
@@ -46,11 +47,13 @@ class TestSharedBarrier:
         shared_list.append(f'passed barrier again: {mp.current_process().name}')
 
     @pytest.mark.parametrize('num_process', [2, 3])
-    def test_barrier(self, num_process: int):
+    @pytest.mark.parametrize('filelock_root', ['/tmp/dir/'])
+    def test_barrier(self, num_process: int, filelock_root: str):
         mp.set_start_method('fork', force=True)
         manager = mp.Manager()
         shared_list = manager.list()
-        barrier = SharedBarrier('/tmp/dir/filelock_path', 'barrier_shm_name')
+        os.makedirs(filelock_root, exist_ok=True)
+        barrier = SharedBarrier(os.path.join(filelock_root, 'filelock_path'), 'barrier_shm_name')
         processes = [
             mp.Process(target=self.run, args=(num_process, barrier, shared_list))
             for _ in range(num_process)


### PR DESCRIPTION
## Description of changes:
- Wait for the thread to finish before existing the interpreter.
- Fixed the Filelock path, avoid creating a separate directory.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
