### PR TITLE
Improved shard eviction test execution time

### DIFF
--- a/tests/test_eviction.py
+++ b/tests/test_eviction.py
@@ -44,7 +44,7 @@ def shard_eviction_disabled(remote: str, local: str, keep_zip: bool):
     With shard eviction disabled.
     """
     dataset = StreamingDataset(remote=remote, local=local, keep_zip=keep_zip)
-    for _ in range(3):
+    for _ in range(2):
         for sample in dataset:  # pyright: ignore
             pass
 
@@ -61,7 +61,7 @@ def shard_eviction_too_high(remote: str, local: str, keep_zip: bool):
                                keep_zip=keep_zip,
                                cache_limit=1_000_000)
     dataloader = DataLoader(dataset=dataset, num_workers=8)
-    for _ in range(3):
+    for _ in range(2):
         for _ in dataloader:
             pass
     validate(remote, local, dataset, keep_zip, False)
@@ -72,9 +72,13 @@ def shard_eviction(remote: str, local: str, keep_zip: bool):
     """
     With shard eviction because cache_limit is smaller than the whole dataset.
     """
-    dataset = StreamingDataset(remote=remote, local=local, keep_zip=keep_zip, cache_limit='50kb')
+    cache_limit = '120kb' if keep_zip else '100kb'
+    dataset = StreamingDataset(remote=remote,
+                               local=local,
+                               keep_zip=keep_zip,
+                               cache_limit=cache_limit)
     dataloader = DataLoader(dataset=dataset, num_workers=8)
-    for _ in range(3):
+    for _ in range(2):
         for _ in dataloader:
             pass
     validate(remote, local, dataset, keep_zip, True)


### PR DESCRIPTION
## Description of changes:
- Improved shard eviction test execution time from 4+ mins to under 1 min.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
