### PR TITLE
py1bs shuffle algorithm ("staggered py1b")

### DIFF
--- a/streaming/base/shuffle/__init__.py
+++ b/streaming/base/shuffle/__init__.py
@@ -8,11 +8,13 @@ from numpy.typing import NDArray
 
 from streaming.base.shuffle.naive import get_shuffle_naive
 from streaming.base.shuffle.py1b import get_shuffle_py1b
+from streaming.base.shuffle.py1bs import get_shuffle_py1bs
 from streaming.base.shuffle.py1s import get_shuffle_py1s
 from streaming.base.shuffle.py2s import get_shuffle_py2s
 
 algos = {
     'py1b': get_shuffle_py1b,
+    'py1bs': get_shuffle_py1bs,
     'py1s': get_shuffle_py1s,
     'py2s': get_shuffle_py2s,
     'naive': get_shuffle_naive,

--- a/streaming/base/shuffle/py1bs.py
+++ b/streaming/base/shuffle/py1bs.py
@@ -13,11 +13,11 @@ from numpy.typing import NDArray
 from streaming.base.shuffle.py1s import divide_spans
 
 
-def get_shuffle_py1b(shard_sizes: NDArray[np.int64],
-                     num_canonical_nodes: int,
-                     seed: int,
-                     epoch: int,
-                     block_size: int = 1 << 18) -> NDArray[np.int64]:
+def get_shuffle_py1bs(shard_sizes: NDArray[np.int64],
+                      num_canonical_nodes: int,
+                      seed: int,
+                      epoch: int,
+                      block_size: int = 1 << 18) -> NDArray[np.int64]:
     """Get the shuffled global ordering of samples for an epoch.
 
     The assignment of shards to nodes is fixed across epochs, but each grouping of shards is

--- a/streaming/base/shuffle/py1bs.py
+++ b/streaming/base/shuffle/py1bs.py
@@ -1,0 +1,72 @@
+# Copyright 2023 MosaicML Streaming authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shuffling algorithm that shuffles in fixed-size blocks.
+
+These units are presumably larger or much larger than single shards, leading to better shuffledness
+at the cost of having to download more shards to make progress.
+"""
+
+import numpy as np
+from numpy.typing import NDArray
+
+from streaming.base.shuffle.py1s import divide_spans
+
+
+def get_shuffle_py1b(shard_sizes: NDArray[np.int64],
+                     num_canonical_nodes: int,
+                     seed: int,
+                     epoch: int,
+                     block_size: int = 1 << 18) -> NDArray[np.int64]:
+    """Get the shuffled global ordering of samples for an epoch.
+
+    The assignment of shards to nodes is fixed across epochs, but each grouping of shards is
+    processed concurrently in a different order by each node's workers each epoch.
+
+    Args:
+        shard_sizes (NDArray[np.int64]): Number of samples contained in each shard, in order.
+        num_canonical_nodes (int): Number of canonical nodes.
+        seed (int): Base random seed, which is held constant over an entire training run.
+        epoch (int): Current epoch, which is added to the seed to get a different deterministic
+            shuffle each epoch.
+        block_size (int): Unit of shuffle. Defaults to ``1 << 18``.
+
+    Returns:
+        NDArray[np.int64]: 1:1 mapping of sample ID to shuffled sample ID.
+    """
+    # Create each shard's sample ID span (begin, end excl).
+    spans = []
+    num_samples = 0
+    for shard_size in shard_sizes:
+        span = num_samples, num_samples + shard_size
+        spans.append(span)
+        num_samples += shard_size
+
+    # Generate the initial ordering of shards, which is fixed over an entire training run.
+    run_rng = np.random.default_rng(seed)
+    run_rng.shuffle(spans)
+
+    # Break the shard spans at canonical node boundaries.
+    spans, super_spans = divide_spans(spans, num_samples, num_canonical_nodes)
+
+    # Shuffle the span ordering within each canonical node uniquely to this epoch.
+    epoch_rng = np.random.default_rng(seed + epoch)
+    for begin, end in super_spans:
+        part = spans[begin:end]
+        epoch_rng.shuffle(part)  # pyright: ignore
+        spans[begin:end] = part
+
+    # Populate the global sample ID mapping, shuffling within each block within each super-span.
+    ids = np.empty(num_samples, np.int64)
+    offset = 0
+    for super_begin, super_end in super_spans:
+        super_offset = offset
+        for begin, end in spans[super_begin:super_end]:
+            span_size = end - begin
+            ids[offset:offset + span_size] = np.arange(begin, end)
+            offset += span_size
+        for start in range(super_offset, offset, block_size):
+            stop = min(start + block_size, offset)
+            epoch_rng.shuffle(ids[start:stop])
+
+    return ids


### PR DESCRIPTION
## Description of changes:

Add a new shuffling algorithm that is `py1b` but staggers how deep into the shuffle block each canonical node starts, in order to smooth shard download traffic.

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
