### PR TITLE
Propagate exception between threads and processes and improved error message

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -1030,6 +1030,7 @@ class StreamingDataset(Array, IterableDataset):
         shard = self.shards[shard_id]
 
         sample = None
+        errors = []
         for _ in range(1 + retry):
             try:
                 # Shortcut path: just assume the shard is present. Using exceptions as control flow
@@ -1046,18 +1047,23 @@ class StreamingDataset(Array, IterableDataset):
 
                 # On success, break out.
                 break
-            except FileNotFoundError:
+            except FileNotFoundError as e:
                 # Fallback: shard file is missing (generates `FileNotFoundError` exception),
                 # ensure the shard file is downloaded, then try to access the sample again.
                 # Loops because it may become evicted in the meantime.
+                errors.append(str(e))
                 self.download_shard(shard_id)
         else:
+            # Main process failed. Let the threads know to terminate.
+            self._event.set()
             if self.cache_limit:
-                raise RuntimeError(f'StreamingDataset repeatedly failed to download a shard. ' +
-                                   f'This may be due to thrashing caused by `cache_limit` ' +
-                                   f'being set too low.')
+                raise RuntimeError(f'{errors[-1]}. StreamingDataset repeatedly failed to ' +
+                                   f'download a shard. This may be due to thrashing caused by ' +
+                                   f'`cache_limit` being set too low.')
             else:
-                raise RuntimeError(f'StreamingDataset repeatedly failed to download a shard.')
+                raise RuntimeError(f'{errors[-1]}. Check if the shard file exists in your ' +
+                                   f'remote location or have you deleted the shard file from ' +
+                                   f'the local directory?')
 
         return sample
 
@@ -1101,6 +1107,10 @@ class StreamingDataset(Array, IterableDataset):
 
             # If we're out of samples this epoch, exit this thread because we are done downloading.
             if it.download_index == it.total:
+                break
+
+            # Background thread or a main process crashed, terminate this thread.
+            if self._event.is_set():
                 break
 
             # If we are requested to only pre-download so many samples, if we have as many or more
@@ -1149,6 +1159,10 @@ class StreamingDataset(Array, IterableDataset):
 
             # If we're out of samples this epoch, exit this thread because we are done downloading.
             if it.ready_index == it.total:
+                break
+
+            # Background thread or a main process crashed, terminate this thread.
+            if self._event.is_set():
                 break
 
             # If we are requested to only pre-download so many samples, if we have as many or more
@@ -1208,7 +1222,7 @@ class StreamingDataset(Array, IterableDataset):
 
             # Background thread crashed, terminate the main process
             if self._event.is_set():
-                raise RuntimeError('Background thread failed. Check other traceback.')
+                break
 
             # Is there a sample ready to yield?
             if it.ready_index <= it.yield_index:

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 @pytest.fixture(scope='function')
 def mds_dataset_dir():
     try:
-        mock_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        mock_dir = tempfile.TemporaryDirectory()
         remote_dir = os.path.join(mock_dir.name, 'remote')
         local_dir = os.path.join(mock_dir.name, 'local')
         num_samples = 117
@@ -304,3 +304,4 @@ def test_accidental_shard_delete_exception(mds_dataset_dir: Any):
             if os.path.exists(os.path.join(local_dir, filename)):
                 os.remove(os.path.join(local_dir, filename))
             pass
+    shutil.rmtree(local_dir, ignore_errors=True)


### PR DESCRIPTION
## Description of changes:
- If the main process dies, let the thread know to stop execution.
- Improved the error message by adding a file location to the exception message.
- Added the unit test for the same.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
