### PR TITLE
Add secrets check as part of pre-commit

### DIFF
--- a/.github/secrets/exclude.yaml
+++ b/.github/secrets/exclude.yaml
@@ -1,0 +1,2 @@
+.git/.*
+docs/source/_static/js/posthog.js

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,3 +97,13 @@ repos:
         entry: yamllint
         language: python
         types: [file, yaml]
+  - repo: https://github.com/trufflesecurity/trufflehog.git
+    rev: v3.40.0
+    hooks:
+      - id: trufflehog
+        name: secret scan
+        entry: trufflehog filesystem ./
+        args:
+          - --only-verified
+          - --fail
+          - --exclude-paths=./.github/secrets/exclude.yaml


### PR DESCRIPTION
## Description of changes:
- Add secrets check as part of pre-commit.
- The `pre-commit run` command would fail if there is a verified secret leak. 

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:
CO-2201

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
