### PR TITLE
Download the index.json file as tmp extension until it finishes

### DIFF
--- a/streaming/base/stream.py
+++ b/streaming/base/stream.py
@@ -421,7 +421,12 @@ class Stream:
         filename = os.path.join(self.local, self.split, basename)  # pyright: ignore
         if world.is_local_leader:
             if self.remote:
-                filename = self._download_file(basename)
+                # Downloads the `index.json` as `index.json.tmp` fully and then rename it to
+                # `index.json` since only one process downloads the `index.json` file while
+                # other processes wait for it to get downloaded. Hence, It avoids loading the
+                # in-progress downloading `index.json`.
+                tmp_filename = self._download_file(basename, basename + '.tmp')
+                os.rename(tmp_filename, filename)
             else:
                 if not os.path.exists(filename):
                     raise RuntimeError(f'No `remote` provided, but local file {filename} ' +


### PR DESCRIPTION
## Description of changes:
- Download the index.json file as tmp extension until it finishes

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:
https://github.com/mosaicml/streaming/issues/345

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#running-tests))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
