### PR TITLE
Add support for downloading from Unity Catalog volumes

### DIFF
--- a/docs/source/how_to_guides/configure_cloud_storage_credentials.md
+++ b/docs/source/how_to_guides/configure_cloud_storage_credentials.md
@@ -6,7 +6,7 @@ Streaming dataset supports the following cloud storage providers to stream your 
 - Google Cloud Storage
 - Oracle Cloud Storage
 - Azure Blob Storage
-- Databricks File System (DBFS)
+- Databricks
 
 ## Amazon S3
 
@@ -208,9 +208,9 @@ export AZURE_ACCOUNT_ACCESS_KEY='NN1KHxKKkj20ZO92EMiDQjx3wp2kZG4UUvfAGlgGWRn6sPR
 ```
 ````
 
-## Databricks File System (DBFS)
+## Databricks
 
-To upload data to and download data from the Databricks File System (DBFS), users must set their Databricks host (`DATABRICKS_HOST`) and access token (`DATABRICKS_TOKEN`) in the run environment.
+To authenticate Databricks access for both Unity Catalog and Databricks File System (DBFS), users must set their Databricks host (`DATABRICKS_HOST`) and access token (`DATABRICKS_TOKEN`) in the run environment.
 
 See the [Databricks documentation](https://docs.databricks.com/en/dev-tools/auth.html#databricks-personal-access-token-authentication) for instructions on how to create a personal access token.
 

--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -603,6 +603,7 @@ class DatabricksUploader(CloudUploader):
 
     Args:
         out (str | Tuple[str, str]): Output dataset directory to save shard files.
+
             1. If ``out`` is a local directory, shard files are saved locally.
             2. If ``out`` is a remote directory, a local temporary directory is created to
                cache the shard files and then the shard files are uploaded to a remote
@@ -657,6 +658,7 @@ class DatabricksUnityCatalogUploader(DatabricksUploader):
 
     def upload_file(self, filename: str):
         """Upload file from local instance to Databricks Unity Catalog.
+
         Args:
             filename (str): Relative filepath to copy.
         """
@@ -697,6 +699,7 @@ class DBFSUploader(DatabricksUploader):
 
     def upload_file(self, filename: str):
         """Upload file from local instance to DBFS. Does not overwrite.
+
         Args:
             filename (str): Relative filepath to copy.
         """
@@ -709,6 +712,7 @@ class DBFSUploader(DatabricksUploader):
 
     def check_folder_exists(self):
         """Raise an exception if the DBFS folder does not exist.
+
         Raises:
             error: Folder does not exist.
         """

--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -24,6 +24,7 @@ __all__ = [
     'GCSUploader',
     'OCIUploader',
     'AzureUploader',
+    'DatabricksUnityCatalogUploader',
     'DBFSUploader',
     'LocalUploader',
 ]
@@ -37,6 +38,7 @@ UPLOADERS = {
     'azure': 'AzureUploader',
     'azure-dl': 'AzureDataLakeUploader',
     'dbfs': 'DBFSUploader',
+    'uc': 'DatabricksUnityCatalogUploader',
     '': 'LocalUploader',
 }
 
@@ -596,7 +598,78 @@ class AzureDataLakeUploader(CloudUploader):
                 f'or check the container permission.',)
 
 
-class DBFSUploader(CloudUploader):
+class DatabricksUploader(CloudUploader):
+    """Parent class for uploading files from local machine to a Databricks workspace.
+
+    Args:
+        out (str | Tuple[str, str]): Output dataset directory to save shard files.
+            1. If ``out`` is a local directory, shard files are saved locally.
+            2. If ``out`` is a remote directory, a local temporary directory is created to
+               cache the shard files and then the shard files are uploaded to a remote
+               location. At the end, the temp directory is deleted once shards are uploaded.
+            3. If ``out`` is a tuple of ``(local_dir, remote_dir)``, shard files are saved in
+               the `local_dir` and also uploaded to a remote location.
+        keep_local (bool): If the dataset is uploaded, whether to keep the local dataset
+            shard file or remove it after uploading. Defaults to ``False``.
+        progress_bar (bool): Display TQDM progress bars for uploading output dataset files to
+            a remote location. Default to ``False``.
+    """
+
+    def __init__(self,
+                 out: Union[str, Tuple[str, str]],
+                 keep_local: bool = False,
+                 progress_bar: bool = False) -> None:
+        super().__init__(out, keep_local, progress_bar)
+        self.client = self._create_workspace_client()
+
+    def _create_workspace_client(self):
+        try:
+            from databricks.sdk import WorkspaceClient
+            return WorkspaceClient()
+        except ImportError as e:
+            e.msg = get_import_exception_message(e.name)  # pyright: ignore
+            raise e
+
+
+class DatabricksUnityCatalogUploader(DatabricksUploader):
+    """Upload file from local machine to Databricks Unity Catalog.
+
+    Args:
+        out (str | Tuple[str, str]): Output dataset directory to save shard files.
+
+            1. If ``out`` is a local directory, shard files are saved locally.
+            2. If ``out`` is a remote directory, a local temporary directory is created to
+               cache the shard files and then the shard files are uploaded to a remote
+               location. At the end, the temp directory is deleted once shards are uploaded.
+            3. If ``out`` is a tuple of ``(local_dir, remote_dir)``, shard files are saved in
+               the `local_dir` and also uploaded to a remote location.
+        keep_local (bool): If the dataset is uploaded, whether to keep the local dataset
+            shard file or remove it after uploading. Defaults to ``False``.
+        progress_bar (bool): Display TQDM progress bars for uploading output dataset files to
+            a remote location. Default to ``False``.
+    """
+
+    def __init__(self,
+                 out: Union[str, Tuple[str, str]],
+                 keep_local: bool = False,
+                 progress_bar: bool = False) -> None:
+        super().__init__(out, keep_local, progress_bar)
+
+    def upload_file(self, filename: str):
+        """Upload file from local instance to Databricks Unity Catalog.
+        Args:
+            filename (str): Relative filepath to copy.
+        """
+        local_filename = os.path.join(self.local, filename)
+        local_filename = local_filename.replace('\\', '/')
+        remote_filename = os.path.join(self.remote, filename)  # pyright: ignore
+        remote_filename = remote_filename.replace('\\', '/')
+        remote_file_path = remote_filename.lstrip('uc:/')
+        with open(local_filename, 'rb') as f:
+            self.client.files.upload(remote_file_path, f)
+
+
+class DBFSUploader(DatabricksUploader):
     """Upload file from local machine to Databricks File System (DBFS).
 
     Args:
@@ -619,22 +692,11 @@ class DBFSUploader(CloudUploader):
                  keep_local: bool = False,
                  progress_bar: bool = False) -> None:
         super().__init__(out, keep_local, progress_bar)
-        self.client = self._create_workspace_client()
         self.dbfs_path = self.remote.lstrip('dbfs:')  # pyright: ignore
         self.check_folder_exists()
 
-    def _create_workspace_client(self):
-        try:
-            from databricks.sdk import WorkspaceClient
-        except ImportError as e:
-            e.msg = get_import_exception_message(e.name)  # pyright: ignore
-            raise e
-
-        return WorkspaceClient()
-
     def upload_file(self, filename: str):
         """Upload file from local instance to DBFS. Does not overwrite.
-
         Args:
             filename (str): Relative filepath to copy.
         """
@@ -647,7 +709,6 @@ class DBFSUploader(CloudUploader):
 
     def check_folder_exists(self):
         """Raise an exception if the DBFS folder does not exist.
-
         Raises:
             error: Folder does not exist.
         """

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -188,7 +188,8 @@ class TestDownload:
 
     @patch('streaming.base.storage.download.download_from_databricks_unity_catalog')
     @pytest.mark.usefixtures('remote_local_file')
-    def test_download_from_databricks_unity_catalog_gets_called(self, mocked_requests: Mock, remote_local_file: Any):
+    def test_download_from_databricks_unity_catalog_gets_called(self, mocked_requests: Mock,
+                                                                remote_local_file: Any):
         mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='uc://')
         download_file(mock_remote_filepath, mock_local_filepath, 60)
         mocked_requests.assert_called_once()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -186,6 +186,14 @@ class TestDownload:
         mocked_requests.assert_called_once()
         mocked_requests.assert_called_once_with(mock_remote_filepath, mock_local_filepath)
 
+    @patch('streaming.base.storage.download.download_from_databricks_unity_catalog')
+    @pytest.mark.usefixtures('remote_local_file')
+    def test_download_from_databricks_unity_catalog_gets_called(self, mocked_requests: Mock, remote_local_file: Any):
+        mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='uc://')
+        download_file(mock_remote_filepath, mock_local_filepath, 60)
+        mocked_requests.assert_called_once()
+        mocked_requests.assert_called_once_with(mock_remote_filepath, mock_local_filepath)
+
     @patch('streaming.base.storage.download.download_from_dbfs')
     @pytest.mark.usefixtures('remote_local_file')
     def test_download_from_dbfs_gets_called(self, mocked_requests: Mock, remote_local_file: Any):

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -10,8 +10,9 @@ from unittest.mock import Mock, patch
 import pytest
 
 from streaming.base.storage.upload import (AzureDataLakeUploader, AzureUploader, CloudUploader,
-                                           DatabricksUnityCatalogUploader, DBFSUploader, GCSAuthentication,
-                                           GCSUploader, LocalUploader, S3Uploader)
+                                           DatabricksUnityCatalogUploader, DBFSUploader,
+                                           GCSAuthentication, GCSUploader, LocalUploader,
+                                           S3Uploader)
 from tests.conftest import R2_URL
 
 
@@ -319,18 +320,25 @@ class TestAzureDataLakeUploader:
 
 class TestDatabricksUnityCatalogUploader:
 
+    @patch('streaming.base.storage.upload.DatabricksUploader._create_workspace_client')
     @pytest.mark.parametrize('out', ['uc://container/dir', ('./dir1', 'uc://container/dir/')])
-    def test_instantiation(self, out: Any):
+    def test_instantiation(self, mock_create_client: Mock, out: Any):
+        mock_create_client.side_effect = None
         _ = DatabricksUnityCatalogUploader(out=out)
         if not isinstance(out, str):
             shutil.rmtree(out[0], ignore_errors=True)
 
+    @patch('streaming.base.storage.upload.DatabricksUploader._create_workspace_client')
     @pytest.mark.parametrize('out', ['ss4://bucket/dir', ('./dir1', 'gcs://bucket/dir/')])
-    def test_invalid_remote_list(self, out: Any):
+    def test_invalid_remote_list(self, mock_create_client: Mock, out: Any):
+        mock_create_client.side_effect = None
         with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = DatabricksUnityCatalogUploader(out=out)
 
-    def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
+    @patch('streaming.base.storage.upload.DatabricksUploader._create_workspace_client')
+    def test_local_directory_is_empty(self, mock_create_client: Mock,
+                                      local_remote_dir: Tuple[str, str]):
+        mock_create_client.side_effect = None
         with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
             local, _ = local_remote_dir
             os.makedirs(local, exist_ok=True)
@@ -343,7 +351,7 @@ class TestDatabricksUnityCatalogUploader:
 
 class TestDBFSUploader:
 
-    @patch('streaming.base.storage.upload.DBFSUploader._create_workspace_client')
+    @patch('streaming.base.storage.upload.DatabricksUploader._create_workspace_client')
     @pytest.mark.parametrize('out', ['dbfs:/container/dir', ('./dir1', 'dbfs:/container/dir/')])
     def test_instantiation(self, mock_create_client: Mock, out: Any):
         mock_create_client.side_effect = None
@@ -351,14 +359,14 @@ class TestDBFSUploader:
         if not isinstance(out, str):
             shutil.rmtree(out[0], ignore_errors=True)
 
-    @patch('streaming.base.storage.upload.DBFSUploader._create_workspace_client')
+    @patch('streaming.base.storage.upload.DatabricksUploader._create_workspace_client')
     @pytest.mark.parametrize('out', ['ss4://bucket/dir', ('./dir1', 'gcs://bucket/dir/')])
     def test_invalid_remote_list(self, mock_create_client: Mock, out: Any):
         mock_create_client.side_effect = None
         with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = DBFSUploader(out=out)
 
-    @patch('streaming.base.storage.upload.DBFSUploader._create_workspace_client')
+    @patch('streaming.base.storage.upload.DatabricksUploader._create_workspace_client')
     def test_local_directory_is_empty(self, mock_create_client: Mock,
                                       local_remote_dir: Tuple[str, str]):
         with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):


### PR DESCRIPTION
## Description of changes:

This change allows users to upload data to and download data from Databricks Unity Catalog.

To configure authentication using mcli, user would run:
```
mcli create secret env DATABRICKS_HOST=...
mcli create secret env DATABRICKS_TOKEN=...
```

Env vars consistent with https://databricks-sdk-py.readthedocs.io/en/latest/authentication.html

## Issue #, if available:
STR-116

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
