### PR TITLE
Fixed CI test to perform proper directory cleanup

### DIFF
--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -19,25 +19,25 @@ from .datasets import NumberAndSayDataset, SequenceDataset
 def local_remote_dir() -> Any:
     """Creates a temporary directory and then deletes it when the calling function is done."""
     try:
-        mock_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        mock_dir = tempfile.TemporaryDirectory()
         mock_local_dir = os.path.join(mock_dir.name, 'local')
         mock_remote_dir = os.path.join(mock_dir.name, 'remote')
         yield mock_local_dir, mock_remote_dir
     finally:
-        mock_dir.cleanup()  # pyright: ignore
+        shutil.rmtree(mock_dir.name, ignore_errors=True)  # pyright: ignore
 
 
 @pytest.fixture(scope='function')
 def compressed_local_remote_dir() -> Any:
     """Creates a temporary directory and then deletes it when the calling function is done."""
     try:
-        mock_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        mock_dir = tempfile.TemporaryDirectory()
         mock_compressed_dir = os.path.join(mock_dir.name, 'compressed')
         mock_local_dir = os.path.join(mock_dir.name, 'local')
         mock_remote_dir = os.path.join(mock_dir.name, 'remote')
         yield mock_compressed_dir, mock_local_dir, mock_remote_dir
     finally:
-        mock_dir.cleanup()  # pyright: ignore
+        shutil.rmtree(mock_dir.name, ignore_errors=True)  # pyright: ignore
 
 
 def convert_to_mds(**kwargs: Any):

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -19,7 +19,7 @@ from .datasets import NumberAndSayDataset, SequenceDataset
 def local_remote_dir() -> Any:
     """Creates a temporary directory and then deletes it when the calling function is done."""
     try:
-        mock_dir = tempfile.TemporaryDirectory()
+        mock_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         mock_local_dir = os.path.join(mock_dir.name, 'local')
         mock_remote_dir = os.path.join(mock_dir.name, 'remote')
         yield mock_local_dir, mock_remote_dir
@@ -31,7 +31,7 @@ def local_remote_dir() -> Any:
 def compressed_local_remote_dir() -> Any:
     """Creates a temporary directory and then deletes it when the calling function is done."""
     try:
-        mock_dir = tempfile.TemporaryDirectory()
+        mock_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         mock_compressed_dir = os.path.join(mock_dir.name, 'compressed')
         mock_local_dir = os.path.join(mock_dir.name, 'local')
         mock_remote_dir = os.path.join(mock_dir.name, 'remote')


### PR DESCRIPTION
## Description of changes:
- If directory is not empty, `tempfile.TemporaryDirectory.cleanup()` throws an Exception saying `OSError: [Errno 39] Directory not empty: 'local'`. This PR ignores that Exception since shard file could be present during directory cleanup which is an expected behavior.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
