### PR TITLE
Check if index.json exists locally before downloading

### DIFF
--- a/streaming/base/stream.py
+++ b/streaming/base/stream.py
@@ -417,26 +417,28 @@ class Stream:
         Returns:
             `List[Reader]: Shard readers.
         """
-        # Download the index.
+        # Download the index file if it does not exist locally.
         basename = get_index_basename()
         filename = os.path.join(self.local, self.split, basename)  # pyright: ignore
-        if world.is_local_leader:
-            if self.remote:
-                # Downloads the `index.json` as `index.json.tmp` fully and then rename it to
-                # `index.json` since only one process downloads the `index.json` file while
-                # other processes wait for it to get downloaded. Hence, It avoids loading the
-                # in-progress downloading `index.json`.
-                tmp_filename = self._download_file(basename, basename + '.tmp')
-                os.rename(tmp_filename, filename)
+        if not os.path.exists(filename):
+            if world.is_local_leader:
+                if self.remote:
+                    # Downloads the `index.json` as `index.json.tmp` fully and then rename it to
+                    # `index.json` since only one process downloads the `index.json` file while
+                    # other processes wait for it to get downloaded. Hence, It avoids loading the
+                    # in-progress downloading `index.json`.
+                    tmp_filename = self._download_file(basename, basename + '.tmp')
+                    os.rename(tmp_filename, filename)
+                else:
+                    if not os.path.exists(filename):
+                        raise RuntimeError(f'No `remote` provided, but local file {filename} ' +
+                                           'does not exist either')
             else:
-                if not os.path.exists(filename):
-                    raise RuntimeError(f'No `remote` provided, but local file {filename} ' +
-                                       'does not exist either')
-        else:
-            wait_for_file_to_exist(
-                filename, TICK, self.download_timeout,
-                f'Index file {filename} took too long to download. Either ' +
-                f'increase the `download_timeout` value or check the other ' + f'traceback.')
+                wait_for_file_to_exist(
+                    filename, TICK, self.download_timeout,
+                    f'Index file {os.path.join(self.remote or "", self.split or "", basename)} ' +
+                    f'-> {filename} took too long to download. Either increase the ' +
+                    f'`download_timeout` value or check the other traceback.')
 
         # Load the index.
         try:

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -5,13 +5,14 @@ import hashlib
 import os
 import shutil
 import tempfile
-from typing import Optional
+from typing import Any, Optional
 
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 
-from streaming import Stream
+from streaming import Stream, StreamingDataset
 from streaming.base.distributed import barrier
+from tests.common.utils import convert_to_mds
 
 
 @pytest.mark.world_size(2)
@@ -54,3 +55,17 @@ def test_existing_local_raises_exception(monkeypatch: MonkeyPatch) -> None:
     with pytest.raises(ValueError, match=f'Could not create a temporary local directory.*'):
         _ = Stream()
     shutil.rmtree(local, ignore_errors=True)
+
+
+@pytest.mark.usefixtures('local_remote_dir')
+def test_missing_index_json_local(local_remote_dir: Any):
+    num_samples = 117
+    remote_dir, _ = local_remote_dir
+    convert_to_mds(out_root=remote_dir, dataset_name='sequencedataset', num_samples=num_samples)
+    if os.path.exists(os.path.join(remote_dir, 'index.json')):
+        os.remove(os.path.join(remote_dir, 'index.json'))
+    else:
+        raise Exception(f"Missing {os.path.join(remote_dir, 'index.json')}")
+    stream = Stream(remote=None, local=remote_dir)
+    with pytest.raises(RuntimeError, match='No `remote` provided, but local file.*'):
+        _ = StreamingDataset(streams=[stream])


### PR DESCRIPTION
## Description of changes:
- Check if index.json exists locally before downloading. Do not download if it exists, this would save egress fees.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:
STR-119

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
