### PR TITLE
Add google Application Default Credentials to download

### DIFF
--- a/docs/source/how_to_guides/configure_cloud_storage_credentials.md
+++ b/docs/source/how_to_guides/configure_cloud_storage_credentials.md
@@ -98,21 +98,6 @@ export S3_ENDPOINT_URL='https://<accountid>.r2.cloudflarestorage.com'
 For [MosaicML platform](https://www.mosaicml.com/cloud) users, follow the steps mentioned in the [Google Cloud Storage](https://mcli.docs.mosaicml.com/en/latest/secrets/gcp.html) MCLI doc on how to configure the cloud provider credentials.
 
 
-###  GCP Service Account Credentials Mounted as Environment Variables
-
-Users must set their GCP `account credentials` to point to their credentials file in the run environment.
-
-````{tabs}
-```{code-tab} py
-import os
-os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'KEY_FILE'
-```
-
-```{code-tab} sh
-export GOOGLE_APPLICATION_CREDENTIALS='KEY_FILE'
-```
-````
-
 ### GCP User Auth Credentials Mounted as Environment Variables
 
 Streaming dataset supports [GCP user credentials](https://cloud.google.com/storage/docs/authentication#user_accounts) or [HMAC keys for User account](https://cloud.google.com/storage/docs/authentication/hmackeys).  Users must set their GCP `user access key` and GCP `user access secret` in the run environment.
@@ -131,6 +116,34 @@ export GCS_KEY='AKIAIOSFODNN7EXAMPLE'
 export GCS_SECRET='wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
 ```
 ````
+
+
+###  GCP Application Default Credentials
+
+Streaming dataset supports the use of Application Default Credentials (ADC) to authenticate you with Google Cloud. When
+no HMAC keys are given (see above), it will attempt to authenticate using ADC. This will, in order, check
+
+1. a key-file whose path is given in the `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
+2. a key-file in the Google cloud configuration directory.
+3. the Google App Engine credentials.
+4. the GCE Metadata Service credentials.
+
+See the [Google Cloud Docs](https://cloud.google.com/docs/authentication/provide-credentials-adc) for more details.
+
+To explicitly use the `GOOGLE_APPLICATION_CREDENTIALS` (point 1 above), users must set their GCP `account credentials`
+to point to their credentials file in the run environment.
+
+````{tabs}
+```{code-tab} py
+import os
+os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'KEY_FILE'
+```
+
+```{code-tab} sh
+export GOOGLE_APPLICATION_CREDENTIALS='KEY_FILE'
+```
+````
+
 
 ## Oracle Cloud Storage
 

--- a/docs/source/how_to_guides/configure_cloud_storage_credentials.md
+++ b/docs/source/how_to_guides/configure_cloud_storage_credentials.md
@@ -95,7 +95,7 @@ export S3_ENDPOINT_URL='https://<accountid>.r2.cloudflarestorage.com'
 
 ### MosaicML platform
 
-For [MosaicML platform](https://www.mosaicml.com/cloud) users, follow the steps mentioned in the [Google Cloud Storage](https://mcli.docs.mosaicml.com/en/latest/secrets/gcp.html) MCLI doc on how to configure the cloud provider credentials.
+For [MosaicML platform](https://www.mosaicml.com/cloud) users, follow the steps mentioned in the [Google Cloud Storage](https://docs.mosaicml.com/projects/mcli/en/latest/resources/secrets/gcp.html) MCLI doc on how to configure the cloud provider credentials.
 
 
 ### GCP User Auth Credentials Mounted as Environment Variables

--- a/streaming/base/storage/download.py
+++ b/streaming/base/storage/download.py
@@ -158,19 +158,23 @@ def download_from_gcs(remote: str, local: str) -> None:
         remote (str): Remote path (GCS).
         local (str): Local path (local filesystem).
     """
+    from google.auth.exceptions import DefaultCredentialsError
     obj = urllib.parse.urlparse(remote)
     if obj.scheme != 'gs':
         raise ValueError(
             f'Expected obj.scheme to be `gs`, instead, got {obj.scheme} for remote={remote}')
 
-    if 'GOOGLE_APPLICATION_CREDENTIALS' in os.environ:
-        _gcs_with_service_account(local, obj)
-    elif 'GCS_KEY' in os.environ and 'GCS_SECRET' in os.environ:
+    if 'GCS_KEY' in os.environ and 'GCS_SECRET' in os.environ:
         _gcs_with_hmac(remote, local, obj)
     else:
-        raise ValueError(f'Either GOOGLE_APPLICATION_CREDENTIALS needs to be set for ' +
-                         f'service level accounts or GCS_KEY and GCS_SECRET needs to be ' +
-                         f'set for HMAC authentication')
+        try:
+            _gcs_with_service_account(local, obj)
+        except DefaultCredentialsError:
+            raise ValueError(
+                f'Either set the environment variables `GCS_KEY` and `GCS_SECRET` or ' +
+                f'use any of the methods in https://cloud.google.com/docs/authentication/external/set-up-adc '
+                + f'to set up Application Default Credentials. See also ' +
+                f'https://docs.mosaicml.com/projects/mcli/en/latest/resources/secrets/gcp.html.')
 
 
 def _gcs_with_hmac(remote: str, local: str, obj: urllib.parse.ParseResult) -> None:
@@ -215,11 +219,11 @@ def _gcs_with_service_account(local: str, obj: urllib.parse.ParseResult) -> None
         local (str): Local path (local filesystem).
         obj (ParseResult): ParseResult object of remote path (GCS).
     """
+    from google.auth import default as default_auth
     from google.cloud.storage import Blob, Bucket, Client
 
-    service_account_path = os.environ['GOOGLE_APPLICATION_CREDENTIALS']
-    gcs_client = Client.from_service_account_json(service_account_path)
-
+    credentials, _ = default_auth()
+    gcs_client = Client(credentials=credentials)
     blob = Blob(obj.path.lstrip('/'), Bucket(gcs_client, obj.netloc))
     blob.download_to_filename(local)
 

--- a/streaming/base/storage/download.py
+++ b/streaming/base/storage/download.py
@@ -13,6 +13,12 @@ __all__ = ['download_or_wait']
 
 BOTOCORE_CLIENT_ERROR_CODES = {'403', '404', 'NoSuchKey'}
 
+GCS_ERROR_NO_AUTHENTICATION = """\
+Either set the environment variables `GCS_KEY` and `GCS_SECRET` or use any of the methods in \
+https://cloud.google.com/docs/authentication/external/set-up-adc to set up Application Default Credentials. See also \
+https://docs.mosaicml.com/projects/mcli/en/latest/resources/secrets/gcp.html.
+"""
+
 
 def download_from_s3(remote: str, local: str, timeout: float) -> None:
     """Download a file from remote AWS S3 (or any S3 compatible object store) to local.
@@ -169,12 +175,8 @@ def download_from_gcs(remote: str, local: str) -> None:
     else:
         try:
             _gcs_with_service_account(local, obj)
-        except DefaultCredentialsError:
-            raise ValueError(
-                f'Either set the environment variables `GCS_KEY` and `GCS_SECRET` or ' +
-                f'use any of the methods in https://cloud.google.com/docs/authentication/external/set-up-adc '
-                + f'to set up Application Default Credentials. See also ' +
-                f'https://docs.mosaicml.com/projects/mcli/en/latest/resources/secrets/gcp.html.')
+        except (DefaultCredentialsError, EnvironmentError):
+            raise ValueError(GCS_ERROR_NO_AUTHENTICATION)
 
 
 def _gcs_with_hmac(remote: str, local: str, obj: urllib.parse.ParseResult) -> None:

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -110,6 +110,12 @@ class TestGCSClient:
             mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='s3://')
             download_from_gcs(mock_remote_filepath, mock_local_filepath)
 
+    def test_no_credentials_error(self, remote_local_file: Any):
+        """Ensure we raise a value error correctly if we have no credentials available."""
+        with pytest.raises(ValueError):
+            mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='gs://')
+            download_from_gcs(mock_remote_filepath, mock_local_filepath)
+
 
 def test_download_from_local():
     mock_remote_dir = tempfile.TemporaryDirectory()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -98,6 +98,16 @@ class TestGCSClient:
             download_from_gcs(mock_remote_filepath, tmp.name)
             assert os.path.isfile(tmp.name)
 
+    @patch('google.auth.default')
+    @patch('google.cloud.storage.Client')
+    @pytest.mark.usefixtures('gcs_service_account_credentials')
+    @pytest.mark.parametrize('out', ['gs://bucket/dir'])
+    def test_download_service_account(self, mock_client: Mock, mock_default: Mock, out: str):
+        with tempfile.NamedTemporaryFile(delete=True, suffix='.txt') as tmp:
+            mock_default.return_value = Mock(), None
+            download_from_gcs('gs://bucket_file', tmp.name)
+            assert os.path.isfile(tmp.name)
+
     @pytest.mark.usefixtures('gcs_hmac_client', 'gcs_test', 'remote_local_file')
     def test_filenotfound_exception(self, remote_local_file: Any):
         with pytest.raises(FileNotFoundError):

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -104,8 +104,10 @@ class TestGCSClient:
     @pytest.mark.parametrize('out', ['gs://bucket/dir'])
     def test_download_service_account(self, mock_client: Mock, mock_default: Mock, out: str):
         with tempfile.NamedTemporaryFile(delete=True, suffix='.txt') as tmp:
-            mock_default.return_value = Mock(), None
+            credentials_mock = Mock()
+            mock_default.return_value = credentials_mock, None
             download_from_gcs('gs://bucket_file', tmp.name)
+            mock_client.assert_called_once_with(credentials=credentials_mock)
             assert os.path.isfile(tmp.name)
 
     @pytest.mark.usefixtures('gcs_hmac_client', 'gcs_test', 'remote_local_file')

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -219,13 +219,11 @@ class TestGCSUploader:
         uploader = GCSUploader(out=out)
         assert uploader.authentication == GCSAuthentication.HMAC
 
-    @patch('streaming.base.storage.upload.GCSUploader.check_bucket_exists')
     @patch('google.auth.default')
     @patch('google.cloud.storage.Client')
     @pytest.mark.usefixtures('gcs_service_account_credentials')
     @pytest.mark.parametrize('out', ['gs://bucket/dir'])
-    def test_service_account_authentication(self, mocked_requests: Mock, mock_default: Mock,
-                                            mock_client: Mock, out: str):
+    def test_service_account_authentication(self, mock_client: Mock, mock_default: Mock, out: str):
         mock_default.return_value = Mock(), None
         uploader = GCSUploader(out=out)
         assert uploader.authentication == GCSAuthentication.SERVICE_ACCOUNT


### PR DESCRIPTION
## Description of changes:

#315 introduced GCS authentication for service accounts as an alternative to HMAC credentials. However, `google.auth` provides the `google.auth.default`  function that uses Application Default Credentials to obtain credentials. See https://cloud.google.com/docs/authentication/provide-credentials-adc for more details. This does the following (from their docs):

```
    1. If the environment variable ``GOOGLE_APPLICATION_CREDENTIALS`` is set
       to the path of a valid service account JSON private key file, then it is
       loaded and returned. [...]
    2. If the `Google Cloud SDK`_ is installed and has application default
       credentials set they are loaded and returned. [...]
    3. If the application is running in the `App Engine standard environment`_
       (first generation) then the credentials and project ID from the
       `App Identity Service`_ are used.
    4. If the application is running in `Compute Engine`_ or `Cloud Run`_ or
       the `App Engine flexible environment`_ or the `App Engine standard
       environment`_ (second generation) then the credentials and project ID
       are obtained from the `Metadata Service`_.
    5. If no credentials are found,
       :class:`~google.auth.exceptions.DefaultCredentialsError` will be raised.
```
Point 1 was introduces in #315, so this is essentially a superset of the service account authentication introduced in that PR.

This is important for us because we use the Compute Engine credentials to avoid mounting secrets in the container which have unrestricted lifetime. I assume others are in the same situation as this is the [recommended and more secure way](https://cloud.google.com/docs/authentication#adc).



Thanks to @b-chu for #315!

### Backwards-Incompatible Change

There is one backwards-incompatible change in the order of HMAC/Service Account. 

Previously, streaming prioritized a service account with an explicitly set `GOOGLE_APPLICATION_CREDENTIALS` environment variable over the HMAC credentials, i.e.

1. `GOOGLE_APPLICATION_CREDENTIALS`
2. HMAC

Now, this prioritizes HMAC over `GOOGLE_APPLICATION_CREDENTIALS` (the test has been changed correspondingly). This is because the `default` authentication includes explicit `GOOGLE_APPLICATION_CREDENTIALS` and we'd have to either (a) special-case outside of `default` authentication or (b) could not use HMAC if any of the `default` authentication methods in 2.-4. above were set. That means the order is

1. HMAC
2. `GOOGLE_APPLICATION_CREDENTIALS`
3. App Engine
4. Compute Engine
5. Raise an error

with 2.-4. provided by `google.auth.default`. This order allows us to explicitly set either HMAC or explicit service account credentials through environment variables, and use App Engine or Compute Engine if these are available.

I feel this backwards-incompatible change is acceptable because it only applies if both HMAC and `GOOGLE_APPLICATION_CREDENTIALS` are set at the same time. It also hasn't been part of any release yet, so we can expect adoption of `GOOGLE_APPLICATION_CREDENTIALS` isn't widespread.

If you disagree, I'll special-case it.

## Issue #, if available:

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
    - See above.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).
    - Note that the diff in the docs below is difficult to read because I moved the sections to have the new order. It looks like this:

<details>
<summary>Docs Screenshot</summary>

![image](https://github.com/mosaicml/streaming/assets/3789648/14c581dc-16d0-4c86-9490-1065a62a4d85)

</details>

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.


cc @fellhorn