### PR TITLE
Fixed fake AWS credentials

### DIFF
--- a/docs/source/how_to_guides/configure_cloud_storage_credentials.md
+++ b/docs/source/how_to_guides/configure_cloud_storage_credentials.md
@@ -107,12 +107,12 @@ From the Google Cloud console, navigate to `Google Storage` > `Settings (Left ve
 ````{tabs}
 ```{code-tab} py
 import os
-os.environ['GCS_KEY'] = 'AKIAIOSFODNN7EXAMPLE'
+os.environ['GCS_KEY'] = 'EXAMPLEFODNN7EXAMPLE'
 os.environ['GCS_SECRET'] = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
 ```
 
 ```{code-tab} sh
-export GCS_KEY='AKIAIOSFODNN7EXAMPLE'
+export GCS_KEY='EXAMPLEFODNN7EXAMPLE'
 export GCS_SECRET='wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
 ```
 ````


### PR DESCRIPTION
## Description of changes:
- Fixed fake AWS credentials to fixed the secret scan complaints. Previously, it was fake too based on [this official doc](https://docs.aws.amazon.com/IAM/latest/UserGuide/security-creds.html), however, I think the secret scan the few initial character plus the length for vulnerability without actually verifying the secrets via server API calls. I have changed the few initial characters to satisfy this.