### PR TITLE
Fixed predownload value to zero issue

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -5,6 +5,7 @@
 
 import json
 import os
+import warnings
 from concurrent.futures import ThreadPoolExecutor, wait
 from concurrent.futures._base import Future
 from enum import IntEnum
@@ -228,9 +229,11 @@ class StreamingDataset(Array, IterableDataset):
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``. Can also take in human-readable number
             abbreviations (e.g., ``"100k"``, ``"64M"``, ``"77b"``, and so on). Defaults to ``None``.
-        predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. If ``None``, its value
-            gets derived using batch size and number of canonical nodes
+        predownload (int, optional): Target number of samples to download the shards per
+            number of workers provided in a dataloader while iterating. Recommendation is to
+            provide a value greater than per device batch size to ensure at-least per device
+            batch size number of samples resides locally. If ``None``, its value gets derived
+            using per device batch size and number of canonical nodes
             ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (Union[int, str], optional): Maximum size in bytes of this StreamingDataset's
             shard cache. Before downloading a shard, the least recently used resident shard(s)
@@ -304,6 +307,13 @@ class StreamingDataset(Array, IterableDataset):
             raise ValueError(
                 f'Invalid sampling method: {sampling_method}. Must be one of `balanced` or `fixed`.'
             )
+
+        # Check that predownload is at least per device batch size.
+        if self.predownload is not None and self.batch_size is not None and \
+            self.predownload < self.batch_size:
+            warnings.warn(f'predownload < batch_size ({self.predownload} < {self.batch_size}).' +
+                          f'This may result in slower batch time. Recommendation is to set ' +
+                          f'predownload to at-least batch_size.')
         # Convert epoch size from string to int, if needed. Cannot be negative.
         epoch_size_value = None
         if epoch_size:
@@ -1159,7 +1169,7 @@ class StreamingDataset(Array, IterableDataset):
             # downloaded already, we wait and check again later.
             if self.predownload is not None:
                 samples_ahead = it.prepare_index - it.yield_index
-                if self.predownload <= samples_ahead:
+                if self.predownload < samples_ahead:
                     sleep(TICK)
                     continue
 
@@ -1211,7 +1221,7 @@ class StreamingDataset(Array, IterableDataset):
             # downloaded already, we wait and check again later.
             if self.predownload is not None:
                 samples_ahead = it.ready_index - it.yield_index
-                if self.predownload <= samples_ahead:
+                if self.predownload < samples_ahead:
                     sleep(TICK)
                     continue
 

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -229,12 +229,13 @@ class StreamingDataset(Array, IterableDataset):
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``. Can also take in human-readable number
             abbreviations (e.g., ``"100k"``, ``"64M"``, ``"77b"``, and so on). Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download the shards per
-            number of workers provided in a dataloader while iterating. Recommendation is to
-            provide a value greater than per device batch size to ensure at-least per device
-            batch size number of samples resides locally. If ``None``, its value gets derived
-            using per device batch size and number of canonical nodes
-            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
+        predownload (int, optional): Target number of samples to download per worker in advance
+            of current sample. Workers will attempt to download ahead by this many samples during,
+            but not before, training. Recommendation is to provide a value greater than per device
+            batch size to ensure at-least per device batch size number of samples cached locally.
+            If ``None``, its value gets derived using per device batch size and number of
+            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
+            Defaults to ``None``.
         cache_limit (Union[int, str], optional): Maximum size in bytes of this StreamingDataset's
             shard cache. Before downloading a shard, the least recently used resident shard(s)
             may be evicted (deleted from the local cache) in order to stay under the limit.

--- a/streaming/multimodal/webvid.py
+++ b/streaming/multimodal/webvid.py
@@ -38,9 +38,11 @@ class StreamingInsideWebVid(StreamingDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. If ``None``, its value
-            gets derived using batch size and number of canonical nodes
+        predownload (int, optional): Target number of samples to download the shards per
+            number of workers provided in a dataloader while iterating. Recommendation is to
+            provide a value greater than per device batch size to ensure at-least per device
+            batch size number of samples resides locally. If ``None``, its value gets derived
+            using per device batch size and number of canonical nodes
             ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
@@ -108,9 +110,11 @@ class StreamingOutsideGIWebVid(StreamingDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. If ``None``, its value
-            gets derived using batch size and number of canonical nodes
+        predownload (int, optional): Target number of samples to download the shards per
+            number of workers provided in a dataloader while iterating. Recommendation is to
+            provide a value greater than per device batch size to ensure at-least per device
+            batch size number of samples resides locally. If ``None``, its value gets derived
+            using per device batch size and number of canonical nodes
             ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
@@ -236,9 +240,11 @@ class StreamingOutsideDTWebVid(StreamingDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. If ``None``, its value
-            gets derived using batch size and number of canonical nodes
+        predownload (int, optional): Target number of samples to download the shards per
+            number of workers provided in a dataloader while iterating. Recommendation is to
+            provide a value greater than per device batch size to ensure at-least per device
+            batch size number of samples resides locally. If ``None``, its value gets derived
+            using per device batch size and number of canonical nodes
             ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted

--- a/streaming/multimodal/webvid.py
+++ b/streaming/multimodal/webvid.py
@@ -38,12 +38,13 @@ class StreamingInsideWebVid(StreamingDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download the shards per
-            number of workers provided in a dataloader while iterating. Recommendation is to
-            provide a value greater than per device batch size to ensure at-least per device
-            batch size number of samples resides locally. If ``None``, its value gets derived
-            using per device batch size and number of canonical nodes
-            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
+        predownload (int, optional): Target number of samples to download per worker in advance
+            of current sample. Workers will attempt to download ahead by this many samples during,
+            but not before, training. Recommendation is to provide a value greater than per device
+            batch size to ensure at-least per device batch size number of samples cached locally.
+            If ``None``, its value gets derived using per device batch size and number of
+            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
+            Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
@@ -110,12 +111,13 @@ class StreamingOutsideGIWebVid(StreamingDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download the shards per
-            number of workers provided in a dataloader while iterating. Recommendation is to
-            provide a value greater than per device batch size to ensure at-least per device
-            batch size number of samples resides locally. If ``None``, its value gets derived
-            using per device batch size and number of canonical nodes
-            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
+        predownload (int, optional): Target number of samples to download per worker in advance
+            of current sample. Workers will attempt to download ahead by this many samples during,
+            but not before, training. Recommendation is to provide a value greater than per device
+            batch size to ensure at-least per device batch size number of samples cached locally.
+            If ``None``, its value gets derived using per device batch size and number of
+            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
+            Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
@@ -240,12 +242,13 @@ class StreamingOutsideDTWebVid(StreamingDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download the shards per
-            number of workers provided in a dataloader while iterating. Recommendation is to
-            provide a value greater than per device batch size to ensure at-least per device
-            batch size number of samples resides locally. If ``None``, its value gets derived
-            using per device batch size and number of canonical nodes
-            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
+        predownload (int, optional): Target number of samples to download per worker in advance
+            of current sample. Workers will attempt to download ahead by this many samples during,
+            but not before, training. Recommendation is to provide a value greater than per device
+            batch size to ensure at-least per device batch size number of samples cached locally.
+            If ``None``, its value gets derived using per device batch size and number of
+            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
+            Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to

--- a/streaming/text/c4.py
+++ b/streaming/text/c4.py
@@ -40,9 +40,11 @@ class StreamingC4(StreamingDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. If ``None``, its value
-            gets derived using batch size and number of canonical nodes
+        predownload (int, optional): Target number of samples to download the shards per
+            number of workers provided in a dataloader while iterating. Recommendation is to
+            provide a value greater than per device batch size to ensure at-least per device
+            batch size number of samples resides locally. If ``None``, its value gets derived
+            using per device batch size and number of canonical nodes
             ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted

--- a/streaming/text/c4.py
+++ b/streaming/text/c4.py
@@ -40,12 +40,13 @@ class StreamingC4(StreamingDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download the shards per
-            number of workers provided in a dataloader while iterating. Recommendation is to
-            provide a value greater than per device batch size to ensure at-least per device
-            batch size number of samples resides locally. If ``None``, its value gets derived
-            using per device batch size and number of canonical nodes
-            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
+        predownload (int, optional): Target number of samples to download per worker in advance
+            of current sample. Workers will attempt to download ahead by this many samples during,
+            but not before, training. Recommendation is to provide a value greater than per device
+            batch size to ensure at-least per device batch size number of samples cached locally.
+            If ``None``, its value gets derived using per device batch size and number of
+            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
+            Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to

--- a/streaming/text/enwiki.py
+++ b/streaming/text/enwiki.py
@@ -36,9 +36,11 @@ class StreamingEnWiki(StreamingDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. If ``None``, its value
-            gets derived using batch size and number of canonical nodes
+        predownload (int, optional): Target number of samples to download the shards per
+            number of workers provided in a dataloader while iterating. Recommendation is to
+            provide a value greater than per device batch size to ensure at-least per device
+            batch size number of samples resides locally. If ``None``, its value gets derived
+            using per device batch size and number of canonical nodes
             ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted

--- a/streaming/text/enwiki.py
+++ b/streaming/text/enwiki.py
@@ -36,12 +36,13 @@ class StreamingEnWiki(StreamingDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download the shards per
-            number of workers provided in a dataloader while iterating. Recommendation is to
-            provide a value greater than per device batch size to ensure at-least per device
-            batch size number of samples resides locally. If ``None``, its value gets derived
-            using per device batch size and number of canonical nodes
-            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
+        predownload (int, optional): Target number of samples to download per worker in advance
+            of current sample. Workers will attempt to download ahead by this many samples during,
+            but not before, training. Recommendation is to provide a value greater than per device
+            batch size to ensure at-least per device batch size number of samples cached locally.
+            If ``None``, its value gets derived using per device batch size and number of
+            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
+            Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to

--- a/streaming/text/pile.py
+++ b/streaming/text/pile.py
@@ -40,12 +40,13 @@ class StreamingPile(StreamingDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download the shards per
-            number of workers provided in a dataloader while iterating. Recommendation is to
-            provide a value greater than per device batch size to ensure at-least per device
-            batch size number of samples resides locally. If ``None``, its value gets derived
-            using per device batch size and number of canonical nodes
-            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
+        predownload (int, optional): Target number of samples to download per worker in advance
+            of current sample. Workers will attempt to download ahead by this many samples during,
+            but not before, training. Recommendation is to provide a value greater than per device
+            batch size to ensure at-least per device batch size number of samples cached locally.
+            If ``None``, its value gets derived using per device batch size and number of
+            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
+            Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to

--- a/streaming/text/pile.py
+++ b/streaming/text/pile.py
@@ -40,9 +40,11 @@ class StreamingPile(StreamingDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. If ``None``, its value
-            gets derived using batch size and number of canonical nodes
+        predownload (int, optional): Target number of samples to download the shards per
+            number of workers provided in a dataloader while iterating. Recommendation is to
+            provide a value greater than per device batch size to ensure at-least per device
+            batch size number of samples resides locally. If ``None``, its value gets derived
+            using per device batch size and number of canonical nodes
             ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted

--- a/streaming/vision/ade20k.py
+++ b/streaming/vision/ade20k.py
@@ -38,12 +38,13 @@ class StreamingADE20K(StreamingDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download the shards per
-            number of workers provided in a dataloader while iterating. Recommendation is to
-            provide a value greater than per device batch size to ensure at-least per device
-            batch size number of samples resides locally. If ``None``, its value gets derived
-            using per device batch size and number of canonical nodes
-            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
+        predownload (int, optional): Target number of samples to download per worker in advance
+            of current sample. Workers will attempt to download ahead by this many samples during,
+            but not before, training. Recommendation is to provide a value greater than per device
+            batch size to ensure at-least per device batch size number of samples cached locally.
+            If ``None``, its value gets derived using per device batch size and number of
+            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
+            Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to

--- a/streaming/vision/ade20k.py
+++ b/streaming/vision/ade20k.py
@@ -38,9 +38,11 @@ class StreamingADE20K(StreamingDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. If ``None``, its value
-            gets derived using batch size and number of canonical nodes
+        predownload (int, optional): Target number of samples to download the shards per
+            number of workers provided in a dataloader while iterating. Recommendation is to
+            provide a value greater than per device batch size to ensure at-least per device
+            batch size number of samples resides locally. If ``None``, its value gets derived
+            using per device batch size and number of canonical nodes
             ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted

--- a/streaming/vision/base.py
+++ b/streaming/vision/base.py
@@ -70,12 +70,13 @@ class StreamingVisionDataset(StreamingDataset, VisionDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download the shards per
-            number of workers provided in a dataloader while iterating. Recommendation is to
-            provide a value greater than per device batch size to ensure at-least per device
-            batch size number of samples resides locally. If ``None``, its value gets derived
-            using per device batch size and number of canonical nodes
-            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
+        predownload (int, optional): Target number of samples to download per worker in advance
+            of current sample. Workers will attempt to download ahead by this many samples during,
+            but not before, training. Recommendation is to provide a value greater than per device
+            batch size to ensure at-least per device batch size number of samples cached locally.
+            If ``None``, its value gets derived using per device batch size and number of
+            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
+            Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to

--- a/streaming/vision/base.py
+++ b/streaming/vision/base.py
@@ -70,9 +70,11 @@ class StreamingVisionDataset(StreamingDataset, VisionDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. If ``None``, its value
-            gets derived using batch size and number of canonical nodes
+        predownload (int, optional): Target number of samples to download the shards per
+            number of workers provided in a dataloader while iterating. Recommendation is to
+            provide a value greater than per device batch size to ensure at-least per device
+            batch size number of samples resides locally. If ``None``, its value gets derived
+            using per device batch size and number of canonical nodes
             ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted

--- a/streaming/vision/cifar10.py
+++ b/streaming/vision/cifar10.py
@@ -36,12 +36,13 @@ class StreamingCIFAR10(StreamingVisionDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download the shards per
-            number of workers provided in a dataloader while iterating. Recommendation is to
-            provide a value greater than per device batch size to ensure at-least per device
-            batch size number of samples resides locally. If ``None``, its value gets derived
-            using per device batch size and number of canonical nodes
-            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
+        predownload (int, optional): Target number of samples to download per worker in advance
+            of current sample. Workers will attempt to download ahead by this many samples during,
+            but not before, training. Recommendation is to provide a value greater than per device
+            batch size to ensure at-least per device batch size number of samples cached locally.
+            If ``None``, its value gets derived using per device batch size and number of
+            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
+            Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to

--- a/streaming/vision/cifar10.py
+++ b/streaming/vision/cifar10.py
@@ -36,9 +36,11 @@ class StreamingCIFAR10(StreamingVisionDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. If ``None``, its value
-            gets derived using batch size and number of canonical nodes
+        predownload (int, optional): Target number of samples to download the shards per
+            number of workers provided in a dataloader while iterating. Recommendation is to
+            provide a value greater than per device batch size to ensure at-least per device
+            batch size number of samples resides locally. If ``None``, its value gets derived
+            using per device batch size and number of canonical nodes
             ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted

--- a/streaming/vision/coco.py
+++ b/streaming/vision/coco.py
@@ -38,12 +38,13 @@ class StreamingCOCO(StreamingDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download the shards per
-            number of workers provided in a dataloader while iterating. Recommendation is to
-            provide a value greater than per device batch size to ensure at-least per device
-            batch size number of samples resides locally. If ``None``, its value gets derived
-            using per device batch size and number of canonical nodes
-            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
+        predownload (int, optional): Target number of samples to download per worker in advance
+            of current sample. Workers will attempt to download ahead by this many samples during,
+            but not before, training. Recommendation is to provide a value greater than per device
+            batch size to ensure at-least per device batch size number of samples cached locally.
+            If ``None``, its value gets derived using per device batch size and number of
+            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
+            Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to

--- a/streaming/vision/coco.py
+++ b/streaming/vision/coco.py
@@ -38,9 +38,11 @@ class StreamingCOCO(StreamingDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. If ``None``, its value
-            gets derived using batch size and number of canonical nodes
+        predownload (int, optional): Target number of samples to download the shards per
+            number of workers provided in a dataloader while iterating. Recommendation is to
+            provide a value greater than per device batch size to ensure at-least per device
+            batch size number of samples resides locally. If ``None``, its value gets derived
+            using per device batch size and number of canonical nodes
             ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted

--- a/streaming/vision/imagenet.py
+++ b/streaming/vision/imagenet.py
@@ -36,12 +36,13 @@ class StreamingImageNet(StreamingVisionDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download the shards per
-            number of workers provided in a dataloader while iterating. Recommendation is to
-            provide a value greater than per device batch size to ensure at-least per device
-            batch size number of samples resides locally. If ``None``, its value gets derived
-            using per device batch size and number of canonical nodes
-            ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
+        predownload (int, optional): Target number of samples to download per worker in advance
+            of current sample. Workers will attempt to download ahead by this many samples during,
+            but not before, training. Recommendation is to provide a value greater than per device
+            batch size to ensure at-least per device batch size number of samples cached locally.
+            If ``None``, its value gets derived using per device batch size and number of
+            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
+            Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted
             (deleted from the local cache) in order to stay under the limit. Set to ``None`` to

--- a/streaming/vision/imagenet.py
+++ b/streaming/vision/imagenet.py
@@ -36,9 +36,11 @@ class StreamingImageNet(StreamingVisionDataset):
             streams. If ``None``, takes its value from the total number of underlying samples.
             Provide this field if you are weighting streams relatively to target a larger or
             smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples ahead to download the shards per
-            number of workers provided in a dataloader while iterating. If ``None``, its value
-            gets derived using batch size and number of canonical nodes
+        predownload (int, optional): Target number of samples to download the shards per
+            number of workers provided in a dataloader while iterating. Recommendation is to
+            provide a value greater than per device batch size to ensure at-least per device
+            batch size number of samples resides locally. If ``None``, its value gets derived
+            using per device batch size and number of canonical nodes
             ``max(batch_size, 256 * batch_size // num_canonical_nodes)``. Defaults to ``None``.
         cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
             Before downloading a shard, the least recently used resident shard(s) may be evicted

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -327,3 +327,16 @@ def test_accidental_shard_delete(local_remote_dir: Any):
             is_removed = True
     assert os.path.exists(filename), f'{basename} is missing'
     shutil.rmtree(local_dir, ignore_errors=True)
+
+
+@pytest.mark.usefixtures('local_remote_dir')
+def test_predownload_batch_size_warning(local_remote_dir: Any):
+    remote_dir, local_dir = local_remote_dir
+    convert_to_mds(out_root=remote_dir,
+                   dataset_name='sequencedataset',
+                   num_samples=117,
+                   size_limit=1 << 8)
+    with pytest.warns(UserWarning,
+                      match='predownload < batch_size.*This may result in slower ' +
+                      'batch time. Recommendation is to set'):
+        _ = StreamingDataset(local=local_dir, remote=remote_dir, predownload=4, batch_size=8)


### PR DESCRIPTION
## Description of changes:
**Before**
- Setting `predownload=0` results in indefinite hang.

**After**
- Change the logic of downloading samples to `n + 1` samples as compared to `n` where n is the predownload value. Hence `predownload=0` means that the streaming dataset downloads 1 sample at a time during each iter -> getitem call.
**- Consequences**
  - Each worker downloads one extra sample before it waits for sample ahead check. I think downloading one extra sample won't have much impact on the dataset iter time.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:
STR-121

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
