### PR TITLE
Plug hole in MDS type system: add arbitrary-precision decimal

### DIFF
--- a/scripts/serialization/survey_fixed_decimals.py
+++ b/scripts/serialization/survey_fixed_decimals.py
@@ -1,0 +1,118 @@
+# Copyright 2023 MosaicML Streaming authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Survey the space of practical fixed-size decimal encodings."""
+
+from argparse import ArgumentParser, Namespace
+
+import numpy as np
+
+
+def parse_args() -> Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        Namespace: Command-line arguments.
+    """
+    args = ArgumentParser()
+    args.add_argument(
+        '--byte_widths',
+        type=str,
+        default='4,8,16',
+        help='Comma-delited list of decimal type sizes in bytes',
+    )
+    args.add_argument(
+        '--min_exp_range',
+        type=int,
+        default=32,
+        help='Maximum number of possible decimal positions before we consider the exponent to be '
+        + 'excessively high and skip it',
+    )
+    args.add_argument(
+        '--max_exp_range',
+        type=int,
+        default=512,
+        help='Maximum number of possible decimal positions before we consider the exponent to be '
+        + 'excessively high and skip it',
+    )
+    return args.parse_args()
+
+
+def survey(min_exp_range: int, max_exp_range: int, byte_width: int, is_signed: bool) -> None:
+    """Survey possible fixed decimal types of a given byte width and signedness.
+
+    We assume our decimal type will be serialized as:
+    - Its digits as an integer, followed by
+    - Its exponent (i.e., how many places to shift the decimal point).
+
+    Specifically, for N-bit decimals which use K bits for the digits part:
+    - Unsigned:
+      - Int (K bits)
+      - Exponent sign (1 bit)
+      - Exponent magnitude (N - K - 1 bits)
+    - Signed:
+      - Int sign (1 bit)
+      - Int (K bits)
+      - Exponent sign (1vbit)
+      - Exponent magnitude (N - 1 - K - 1 bits)
+
+    Args:
+        min_exp_range (int): Minimum number of possible decimal positions before we consider the
+            exponent to be excessively low and skip it.
+        min_exp_range (int): Maximum number of possible decimal positions before we consider the
+            exponent to be excessively high and skip it.
+        byte_width (int): Width of the serialized form in bits.
+        is_signed (bool): Whether the number is signed.
+    """
+    header = 'int bits', 'pow bits', 'precision', 'dec range'
+    table = [tuple(map(str, header))]
+    bit_width = 8 * byte_width
+    int_sign_bits = int(is_signed)
+    prev_int_digits = None
+    for int_bits in range(1, bit_width - int_sign_bits - 1 - 1):
+        exp_bits = bit_width - int_sign_bits - int_bits - 1
+        assert exp_bits
+        max_int = 2**int_bits
+        int_digits = int(np.log10(float(max_int)))
+        exp_range = 2 * 2**exp_bits
+        if not (min_exp_range <= exp_range <= max_exp_range):
+            continue
+        if int_digits == prev_int_digits:
+            continue
+        prev_int_digits = int_digits
+        row = int_bits, exp_bits, int_digits, exp_range
+        row = tuple(map(str, row))
+        table.append(row)
+
+    is_signed_str = 'signed' if is_signed else 'unsigned'
+    print(f'{byte_width}-byte {is_signed_str} decimal:')
+    cols = zip(*table)
+    col_lens = [max(map(len, col)) for col in cols]
+    for row in table:
+        padded_row = [cell.rjust(col_len) for (cell, col_len) in zip(row, col_lens)]
+        print('    ' + ' | '.join(padded_row))
+    print()
+
+
+def main(args: Namespace) -> None:
+    """Survey the space of practical fixed-size decimal encodings.
+
+    Args:
+        Command-line arguments.
+    """
+    print('Columns:')
+    print('- int bits: bits used to hold the digits as a scalar.')
+    print('- pow bits: bits used to hold the exponent (location of decimal place).')
+    print('- precision: Digits of precision.')
+    print('- dec range: Range of decimal places (half left, half right).')
+    print()
+
+    get_list_arg = lambda x: x.split(',') if x else []
+    byte_widths = list(map(int, get_list_arg(args.byte_widths)))
+    for byte_width in byte_widths:
+        for is_signed in [False, True]:
+            survey(args.min_exp_range, args.max_exp_range, byte_width, is_signed)
+
+
+if __name__ == '__main__':
+    main(parse_args())

--- a/streaming/base/format/mds/encodings.py
+++ b/streaming/base/format/mds/encodings.py
@@ -402,12 +402,10 @@ class StrInt(StrEncoding):
 
     def encode(self, obj: int) -> bytes:
         self._validate(obj, int)
-        text = str(obj)
-        return text.encode('utf-8')
+        return str(obj).encode('utf-8')
 
     def decode(self, data: bytes) -> int:
-        text = data.decode('utf-8')
-        return int(text)
+        return int(data.decode('utf-8'))
 
 
 class StrFloat(Encoding):
@@ -415,12 +413,10 @@ class StrFloat(Encoding):
 
     def encode(self, obj: float) -> bytes:
         self._validate(obj, float)
-        text = str(obj)
-        return text.encode('utf-8')
+        return str(obj).encode('utf-8')
 
     def decode(self, data: bytes) -> float:
-        text = data.decode('utf-8')
-        return float(text)
+        return float(data.decode('utf-8'))
 
 
 class StrDecimal(Encoding):
@@ -428,12 +424,10 @@ class StrDecimal(Encoding):
 
     def encode(self, obj: Decimal) -> bytes:
         self._validate(obj, Decimal)
-        text = str(obj)
-        return text.encode('utf-8')
+        return str(obj).encode('utf-8')
 
     def decode(self, data: bytes) -> Decimal:
-        text = data.decode('utf-8')
-        return Decimal(text)
+        return Decimal(data.decode('utf-8'))
 
 
 class PIL(Encoding):

--- a/streaming/base/format/mds/encodings.py
+++ b/streaming/base/format/mds/encodings.py
@@ -6,6 +6,7 @@
 import json
 import pickle
 from abc import ABC, abstractmethod
+from decimal import Decimal
 from io import BytesIO
 from typing import Any, Optional, Set, Tuple
 
@@ -385,6 +386,56 @@ class Float64(Scalar):
         super().__init__(np.float64)
 
 
+class StrEncoding(Encoding):
+    """Base class for stringified types.
+
+    Using variable-length strings allows us to store scalars with arbitrary precision.
+
+    The encode/decode methods of subclasses are the same except for typing specializations.
+    """
+
+    pass
+
+
+class StrInt(StrEncoding):
+    """Store int as variable-length digits str."""
+
+    def encode(self, obj: int) -> bytes:
+        self._validate(obj, int)
+        text = str(obj)
+        return text.encode('utf-8')
+
+    def decode(self, data: bytes) -> int:
+        text = data.decode('utf-8')
+        return int(text)
+
+
+class StrFloat(Encoding):
+    """Store float as variable-length digits str."""
+
+    def encode(self, obj: float) -> bytes:
+        self._validate(obj, float)
+        text = str(obj)
+        return text.encode('utf-8')
+
+    def decode(self, data: bytes) -> float:
+        text = data.decode('utf-8')
+        return float(text)
+
+
+class StrDecimal(Encoding):
+    """Store decimal as variable-length digits str."""
+
+    def encode(self, obj: Decimal) -> bytes:
+        self._validate(obj, Decimal)
+        text = str(obj)
+        return text.encode('utf-8')
+
+    def decode(self, data: bytes) -> Decimal:
+        text = data.decode('utf-8')
+        return Decimal(text)
+
+
 class PIL(Encoding):
     """Store PIL image raw.
 
@@ -488,6 +539,9 @@ _encodings = {
     'float16': Float16,
     'float32': Float32,
     'float64': Float64,
+    'str_int': StrInt,
+    'str_float': StrFloat,
+    'str_decimal': StrDecimal,
     'pil': PIL,
     'jpeg': JPEG,
     'png': PNG,

--- a/tests/test_encodings.py
+++ b/tests/test_encodings.py
@@ -3,6 +3,7 @@
 
 import json
 import tempfile
+from decimal import Decimal
 from typing import Any, Tuple, Union
 
 import numpy as np
@@ -13,7 +14,6 @@ import streaming.base.format.json.encodings as jsonEnc
 import streaming.base.format.mds.encodings as mdsEnc
 import streaming.base.format.xsv.encodings as xsvEnc
 
-from decimal import Decimal
 
 class TestMDSEncodings:
 
@@ -422,7 +422,7 @@ class TestMDSEncodings:
         assert dec == decoded
 
     @pytest.mark.parametrize(('decoded', 'encoded'), [(42, b'42')])
-    def test_mds_StrInt(self, decoded: Decimal, encoded: bytes):
+    def test_mds_StrInt(self, decoded: int, encoded: bytes):
         coder = mdsEnc.StrInt()
         enc = coder.encode(decoded)
         assert isinstance(enc, bytes)
@@ -433,7 +433,7 @@ class TestMDSEncodings:
         assert dec == decoded
 
     @pytest.mark.parametrize(('decoded', 'encoded'), [(42.0, b'42.0')])
-    def test_mds_StrFloat(self, decoded: Decimal, encoded: bytes):
+    def test_mds_StrFloat(self, decoded: float, encoded: bytes):
         coder = mdsEnc.StrFloat()
         enc = coder.encode(decoded)
         assert isinstance(enc, bytes)

--- a/tests/test_encodings.py
+++ b/tests/test_encodings.py
@@ -421,7 +421,7 @@ class TestMDSEncodings:
         assert isinstance(dec, np.floating)
         assert dec == decoded
 
-    @pytest.mark.parametrize(('decoded', 'encoded'), [(42, b'42')])
+    @pytest.mark.parametrize(('decoded', 'encoded'), [(42, b'42'), (-42, b'-42')])
     def test_mds_StrInt(self, decoded: int, encoded: bytes):
         coder = mdsEnc.StrInt()
         enc = coder.encode(decoded)
@@ -432,7 +432,7 @@ class TestMDSEncodings:
         assert isinstance(dec, int)
         assert dec == decoded
 
-    @pytest.mark.parametrize(('decoded', 'encoded'), [(42.0, b'42.0')])
+    @pytest.mark.parametrize(('decoded', 'encoded'), [(42.0, b'42.0'), (-42.0, b'-42.0')])
     def test_mds_StrFloat(self, decoded: float, encoded: bytes):
         coder = mdsEnc.StrFloat()
         enc = coder.encode(decoded)
@@ -443,7 +443,8 @@ class TestMDSEncodings:
         assert isinstance(dec, float)
         assert dec == decoded
 
-    @pytest.mark.parametrize(('decoded', 'encoded'), [(Decimal('4E15'), b'4E+15')])
+    @pytest.mark.parametrize(('decoded', 'encoded'), [(Decimal('4E15'), b'4E+15'),
+                                                      (Decimal('-4E15'), b'-4E+15')])
     def test_mds_StrDecimal(self, decoded: Decimal, encoded: bytes):
         coder = mdsEnc.StrDecimal()
         enc = coder.encode(decoded)

--- a/tests/test_encodings.py
+++ b/tests/test_encodings.py
@@ -422,8 +422,8 @@ class TestMDSEncodings:
 
     def test_get_mds_encodings(self):
         uints = {'uint8', 'uint16', 'uint32', 'uint64'}
-        ints = {'int8', 'int16', 'int32', 'int64'}
-        floats = {'float16', 'float32', 'float64'}
+        ints = {'int8', 'int16', 'int32', 'int64', 'str_int'}
+        floats = {'float16', 'float32', 'float64', 'str_float', 'str_decimal'}
         scalars = uints | ints | floats
         expected_encodings = {
             'int', 'bytes', 'json', 'ndarray', 'png', 'jpeg', 'str', 'pil', 'pkl'

--- a/tests/test_encodings.py
+++ b/tests/test_encodings.py
@@ -13,6 +13,7 @@ import streaming.base.format.json.encodings as jsonEnc
 import streaming.base.format.mds.encodings as mdsEnc
 import streaming.base.format.xsv.encodings as xsvEnc
 
+from decimal import Decimal
 
 class TestMDSEncodings:
 
@@ -418,6 +419,39 @@ class TestMDSEncodings:
 
         dec = coder.decode(encoded)
         assert isinstance(dec, np.floating)
+        assert dec == decoded
+
+    @pytest.mark.parametrize(('decoded', 'encoded'), [(42, b'42')])
+    def test_mds_StrInt(self, decoded: Decimal, encoded: bytes):
+        coder = mdsEnc.StrInt()
+        enc = coder.encode(decoded)
+        assert isinstance(enc, bytes)
+        assert enc == encoded
+
+        dec = coder.decode(encoded)
+        assert isinstance(dec, int)
+        assert dec == decoded
+
+    @pytest.mark.parametrize(('decoded', 'encoded'), [(42.0, b'42.0')])
+    def test_mds_StrFloat(self, decoded: Decimal, encoded: bytes):
+        coder = mdsEnc.StrFloat()
+        enc = coder.encode(decoded)
+        assert isinstance(enc, bytes)
+        assert enc == encoded
+
+        dec = coder.decode(encoded)
+        assert isinstance(dec, float)
+        assert dec == decoded
+
+    @pytest.mark.parametrize(('decoded', 'encoded'), [(Decimal('4E15'), b'4E+15')])
+    def test_mds_StrDecimal(self, decoded: Decimal, encoded: bytes):
+        coder = mdsEnc.StrDecimal()
+        enc = coder.encode(decoded)
+        assert isinstance(enc, bytes)
+        assert enc == encoded
+
+        dec = coder.decode(encoded)
+        assert isinstance(dec, Decimal)
         assert dec == decoded
 
     def test_get_mds_encodings(self):


### PR DESCRIPTION
## Problem

Streaming PR [363](https://github.com/mosaicml/streaming/pull/363/) seeks to add delta to MDS conversion to Streaming. This means MDS must have an answer for each of the types in `pyspark.sql.types`.

## Non-solutions

Currently, we don't: arbitrary-precision decimals (and for that matter, ints) are not natively supported. Several workarounds are available using our current type system:
1. Use `pkl` encoding, which will correctly encode and decode, but with explosively bad data usage.
2. Use `json` encoding to dump the digits as str, then custom decode the field(s) in your subclass of StreamingDataset back to your arbitrary-precision int/float/Decimal type.
3. Use `bytes` encoding and roll your own custom encoding /and/ decoding.

Using Pickle will make me look incompetent, you say? How bad can it be?

```
for ty in [int, float, Decimal]:
    a = ty(0)
    b = pickle.dumps(a)
    c = pickle.loads(b)
    assert a == c
    print(str(type(a)), len(b))
```

```
<class 'int'> 5
<class 'float'> 21
<class 'decimal.Decimal'> 42
```

Oh. That is, if you were expecting serializing 0 to require 4 bytes, pickle is *5x* worse for floats and *10x* worse for decimals. At scale, that really adds up.

## Solution

This PR adds three new MDS types that are small, simple, and general: `str_int`, `str_float`, and `str_decimal`. We take the JSON approach of just dumping digits to str and decoding it back, providing arbitrary precision without any hassle or complexity.

Of course, ASCII digits are not the most efficient way to serialize. To support possible future work, we also include a script analyzing what the most useful configurations of fixed-size binary decimal types would be. The actual fixed-size decimal binary type(s) are not in this PR, as I would like to study the problem a bit more before committing to a certain API for them and that work is off the critical path.

```
Columns:
- int bits: bits used to hold the digits as a scalar.
- pow bits: bits used to hold the exponent (location of decimal place).
- precision: Digits of precision.
- dec range: Range of decimal places (half left, half right).

4-byte unsigned decimal:
    int bits | pow bits | precision | dec range
          23 |        8 |         6 |       512
          24 |        7 |         7 |       256
          27 |        4 |         8 |        32

4-byte signed decimal:
    int bits | pow bits | precision | dec range
          22 |        8 |         6 |       512
          24 |        6 |         7 |       128

8-byte unsigned decimal:
    int bits | pow bits | precision | dec range
          55 |        8 |        16 |       512
          57 |        6 |        17 |       128

8-byte signed decimal:
    int bits | pow bits | precision | dec range
          54 |        8 |        16 |       512
          57 |        5 |        17 |        64

16-byte unsigned decimal:
    int bits | pow bits | precision | dec range
         119 |        8 |        35 |       512
         120 |        7 |        36 |       256
         123 |        4 |        37 |        32

16-byte signed decimal:
    int bits | pow bits | precision | dec range
         118 |        8 |        35 |       512
         120 |        6 |        36 |       128
```