### PR TITLE
Reusable local directory when remote is None

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -420,8 +420,12 @@ class StreamingDataset(Array, IterableDataset):
         self.length = ceil(self.epoch_size / world.num_ranks)
 
         # Register/lookup our shared memory prefix and filelock root directory.
-        my_locals = [os.path.abspath(os.path.join(x.local, x.split)) for x in streams]
-        self._shm_prefix_int, self._locals_shm = get_shm_prefix(my_locals, world)
+        streams_local = [os.path.abspath(os.path.join(x.local, x.split)) for x in streams]
+        streams_remote = [
+            os.path.join(x.remote, x.split) if x.remote is not None else None for x in streams
+        ]
+        self._shm_prefix_int, self._locals_shm = get_shm_prefix(streams_local, streams_remote,
+                                                                world)
         self._filelock_root = os.path.join(os.path.sep, 'tmp', 'streaming')
         os.makedirs(self._filelock_root, exist_ok=True)
 

--- a/streaming/base/shared/prefix.py
+++ b/streaming/base/shared/prefix.py
@@ -113,12 +113,16 @@ def _check_and_find(streams_local: List[str], streams_remote: List[Union[str, No
         except FileNotFoundError:
             break
         their_locals, _ = _unpack_locals(bytes(shm.buf))
-        # If all the remote directories are None in a streams, get the new prefix_int and break
-        # even if local directory matches between the StreamingDataset instantiation.
+        # Do not check for a conflicting local directories across existing shared memory if
+        # remote directories are None. Get the next prefix.
         if any(streams_remote):
+            # Get the indices of the local directories which matches with the current
+            # shared memory.
             matching_index = np.where(np.in1d(streams_local, their_locals))[0]
             if matching_index.size > 0:
                 for idx in matching_index:
+                    # If there is a conflicting local directory for a non-None remote directory,
+                    # raise an exception.
                     if streams_remote[idx] is not None:
                         raise ValueError(
                             f'Reused local directory: {streams_local} vs ' +

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -12,23 +12,32 @@ from streaming.base.world import World
 @pytest.mark.usefixtures('local_remote_dir')
 def test_get_shm_prefix(local_remote_dir: Tuple[str, str]):
     local, remote = local_remote_dir
-    my_locals = [local, remote]
 
-    _, _ = get_shm_prefix(my_locals=my_locals, world=World())
+    _, _ = get_shm_prefix(streams_local=[local], streams_remote=[remote], world=World())
 
 
 @pytest.mark.usefixtures('local_remote_dir')
 def test_get_shm_prefix_same_local_dir(local_remote_dir: Tuple[str, str]):
-    local, _ = local_remote_dir
-    my_locals = [local, local]
+    local, remote = local_remote_dir
     with pytest.raises(ValueError, match='Reused local directory.*Provide a different one.'):
-        _, _ = get_shm_prefix(my_locals=my_locals, world=World())
+        _, _ = get_shm_prefix(streams_local=[local, local],
+                              streams_remote=[remote, remote],
+                              world=World())
 
 
 @pytest.mark.usefixtures('local_remote_dir')
 def test_get_shm_prefix_same_split_dir(local_remote_dir: Tuple[str, str]):
     local, remote = local_remote_dir
-    my_locals = [local, remote]
-    _, _ = get_shm_prefix(my_locals=my_locals, world=World())
+    _, _ = get_shm_prefix(streams_local=[local, remote],
+                          streams_remote=[local, remote],
+                          world=World())
     with pytest.raises(ValueError, match='Reused local directory.*vs.*Provide a different one.'):
-        _, _ = get_shm_prefix(my_locals=my_locals, world=World())
+        _, _ = get_shm_prefix(streams_local=[local, remote],
+                              streams_remote=[local, remote],
+                              world=World())
+
+
+def test_same_local_remote_none(local_remote_dir: Tuple[str, str]):
+    local, _ = local_remote_dir
+    _, _ = get_shm_prefix(streams_local=[local], streams_remote=[None], world=World())
+    _, _ = get_shm_prefix(streams_local=[local], streams_remote=[None], world=World())


### PR DESCRIPTION
## Description of changes:
- Added a feature to instantiate more than one StreamingDataset with same `local` directory and `remote=None`. This would be useful if there is a high-speed storage mounted on a node and multiple folks would read the dataset directly from mount storage on the same node without having to copy the data on local disk.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:
STR-129
https://github.com/mosaicml/streaming/issues/401

## Testing

### Unit test
- Added the unit test coverage

### Integration testing

Use-case: Y: Yes, N: No

- Single stream:
  - [Y] scenario-1 (Should work)
    - SD_1
      - Stream_11: `local=local` `remote=None`
    - SD_2
      - Stream_21: `local=local` `remote=None`
  - [Y] scenario-2 (Should work)
    - SD_1
      - Stream_11: `local=local` `remote=None`
    - SD_2
      - Stream_21: `local=local_1` `remote=None`
  - [Y] scenario-3 (Should work)
    - SD_1
      - Stream_11: `local=local` `remote=None`
    - SD_2
      - Stream_21: `local=local_1` `remote=s3://bucket/folder`
  - [N] scenario-4 (should NOT works due to same local and different remote)
    - SD_1
      - Stream_11: `local=local` `remote=None`
    - SD_2
      - Stream_21: `local=local` `remote=s2://bucket/folder`
- Multiple streams (2 streams per streamingDataset [SD]):
  - [Y] scenario-1 (should work)
    - SD_1
      - Stream_11: `local=local_1`, `remote=None`
      - Stream_12: `local=local_2`, `remote=None`
    - SD_2
      - Stream_21: `local=local_1`, `remote=None`
      - Stream_22: `local=local_2`, `remote=None`
  - [N] scenario-2 (should NOT work since same local directory in Stream_11 and Stream_12)
    - SD_1
      - Stream_11: `local=local_1`, `remote=None`
      - Stream_12: `local=local_1`, `remote=None`
    - SD_2
      - Stream_21: `local=local_1`, `remote=None`
      - Stream_22: `local=local_2`, `remote=None`
  - [N] scenario-3 (should NOT work since same local directory when there is a cloud remote location, Stream_12 and Stream_22)
    - SD_1
      - Stream_11: `local=local_1`, `remote=None`
      - Stream_12: `local=local_2`, `remote=s3:/bucket/folder`
    - SD_2
      - Stream_21: `local=local_1`, `remote=None`
      - Stream_22: `local=local_2`, `remote=s3:/bucket/folder`
  - [Y] scenario-4 (should work since local directory is different for SD_2/stream_22)
    - SD_1
      - Stream_11: `local=local_1`, `remote=None`
      - Stream_12: `local=local_2`, `remote=s3:/bucket/folder`
    - SD_2
      - Stream_21: `local=local_1`, `remote=None`
      - Stream_22: `local=local_3`, `remote=s3:/bucket/folder`
  - [N] scenario-5 (should NOT work since different remote directory (stream_12 and stream_22) maps to same local directory)
    - SD_1
      - Stream_11: `local=local_1`, `remote=None`
      - Stream_12: `local=local_2`, `remote=s3:/bucket/folder`
    - SD_2
      - Stream_21: `local=local_1`, `remote=None`
      - Stream_22: `local=local_2`, `remote=gcs:/bucket/folder`

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
