### PR TITLE
Raise an exception if cache limit is too low

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -395,7 +395,6 @@ class StreamingDataset(Array, IterableDataset):
         self.shards_per_stream = np.zeros(self.num_streams, np.int64)
         self.sample_offset_per_stream = np.zeros(self.num_streams, np.int64)
         self.samples_per_stream = np.zeros(self.num_streams, np.int64)
-        self.max_shard_size_across_all_streams = 0
         for stream_id, stream in enumerate(self.streams):
             stream_shards = stream.get_shards(world)
             num_stream_samples = sum(map(len, stream_shards))
@@ -403,9 +402,6 @@ class StreamingDataset(Array, IterableDataset):
                 index_filename = os.path.join(stream.local, stream.split, get_index_basename())
                 raise RuntimeError(f'Stream contains no samples: {index_filename}.')
             stream_per_shard += [stream_id] * len(stream_shards)
-            # Includes the size of raw (decompressed) and zip (compressed) shard files.
-            self.max_shard_size_across_all_streams = max(self.max_shard_size_across_all_streams,
-                                                         stream_shards[0].get_max_size())
             self.shard_offset_per_stream[stream_id] = len(self.shards)
             self.shards_per_stream[stream_id] = len(stream_shards)
             self.sample_offset_per_stream[stream_id] = self.num_samples
@@ -423,7 +419,10 @@ class StreamingDataset(Array, IterableDataset):
             if self.cache_limit <= min_cache_usage:
                 raise ValueError(f'Minimum cache usage ({min_cache_usage} bytes) is larger than ' +
                                  f'the cache limit ({self.cache_limit} bytes). Please raise ' +
-                                 f'`cache_limit`.')
+                                 f'`cache_limit`. Recommendation is to provide a `cache_limit` ' +
+                                 f'as high as possible to avoid thrashing.')
+            self.max_shard_size_across_all_streams = max(
+                np.array([shard.get_max_size() for shard in self.shards]))
             if self.cache_limit < 4 * self.max_shard_size_across_all_streams:
                 raise ValueError(f'Cache limit ({self.cache_limit} bytes) is too low. ' +
                                  f'Increase the `cache_limit` to at-least four times the ' +


### PR DESCRIPTION
## Description of changes:
- If `cache_limit` is lower than a shard file size or lower than a few shard files sizes, raise an exception to raise a cache_limit. This is more of a better user experience. Hard to see a practical use-case where the cache_limit is this much low.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:
#417 

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
