### PR TITLE
Remove torchtext

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -212,7 +212,6 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'torch': ('https://pytorch.org/docs/stable/', None),
     'torchmetrics': ('https://torchmetrics.readthedocs.io/en/latest/', None),
-    'torchtext': ('https://pytorch.org/text/stable/', None),
     'torchvision': ('https://pytorch.org/vision/stable/', None),
     'transformers': ('https://huggingface.co/docs/transformers/master/en/', None),
 }

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ install_requires = [
     'paramiko>=2.11.0,<4',
     'python-snappy>=0.6.1,<1',
     'torch>=1.10,<3',
-    'torchtext>=0.10',
     'torchvision>=0.10',
     'tqdm>=4.64.0,<5',
     'transformers>=4.21.3,<5',
@@ -81,6 +80,7 @@ extra_deps['dev'] = [
 ]
 
 extra_deps['docs'] = [
+    'torchtext>=0.10',
     'GitPython==3.1.34',
     'docutils==0.18.1',
     'furo==2023.7.26',

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,6 @@ extra_deps['dev'] = [
 ]
 
 extra_deps['docs'] = [
-    'torchtext>=0.10',
     'GitPython==3.1.34',
     'docutils==0.18.1',
     'furo==2023.7.26',


### PR DESCRIPTION
## Description of changes:

Move torchtext to docs as it is only used by docs
<img width="598" alt="image" src="https://github.com/mosaicml/streaming/assets/17102158/471e1dcf-1f95-485b-986b-730406970cf3">

This is causing issues with torch nightly