### PR TITLE
Fix deadlock

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -11,7 +11,7 @@ from concurrent.futures import ThreadPoolExecutor, wait
 from concurrent.futures._base import Future
 from enum import IntEnum
 from math import ceil
-from threading import Event, Lock, _register_atexit
+from threading import Event, Lock, _register_atexit  # pyright: ignore
 from time import sleep, time_ns
 from typing import Any, Dict, Iterator, Optional, Sequence, Tuple, Union
 

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -6,12 +6,13 @@
 import json
 import logging
 import os
+import sys
 import warnings
 from concurrent.futures import ThreadPoolExecutor, wait
 from concurrent.futures._base import Future
 from enum import IntEnum
 from math import ceil
-from threading import Event, Lock, _register_atexit  # pyright: ignore
+from threading import Event, Lock
 from time import sleep, time_ns
 from typing import Any, Dict, Iterator, Optional, Sequence, Tuple, Union
 
@@ -103,7 +104,12 @@ class _Iterator:
         self._state = 0
         self._num_exited = 0
 
-        _register_atexit(self.non_blocking_exit)
+        if sys.version_info[1] <= 8:
+            import atexit
+            atexit.register(self.non_blocking_exit)
+        else:
+            from threading import _register_atexit  # pyright: ignore
+            _register_atexit(self.non_blocking_exit)
 
     def non_blocking_exit(self) -> None:
         """Signal threads to exit without blocking.

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -104,7 +104,14 @@ class _Iterator:
         self._state = 0
         self._num_exited = 0
 
-        if sys.version_info[1] <= 8:
+        # python will attempt to join all threads on shutdown.
+        # Here, we register a call to self.non_blocking_exit to run
+        # at shutdown to prevent a deadlock.
+        # In python version >=3.9 this can be accomplished via
+        # threading._register_atexit but not with the atexit module.
+        # In older python versions, the atexit module can be used, and
+        # threading._register_atexit does not exist.
+        if sys.version_info[1] <= 8:  # check if python version <=3.8
             import atexit
             atexit.register(self.non_blocking_exit)
         else:


### PR DESCRIPTION
## Description of changes:

Add a hook that runs at process exit telling the worker threads in StreamingDataset to exit.
This prevents these threads from blocking process exit.

pyright does not like using the "private" method `threading._register_atexit`, but we cannot use the regular `atexit` module because it would run after the deadlock. So there is a pyright ignore directive added.

## Issue #386

- Fixes #386

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
