### PR TITLE
tag shared and temp files with username

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -3,6 +3,7 @@
 
 """A mid-epoch-resumable streaming/caching pytorch IterableDataset."""
 
+import getpass
 import json
 import logging
 import os
@@ -495,7 +496,7 @@ class StreamingDataset(Array, IterableDataset):
         ]
         self._shm_prefix_int, self._locals_shm = get_shm_prefix(streams_local, streams_remote,
                                                                 world)
-        self._filelock_root = os.path.join(os.path.sep, 'tmp', 'streaming')
+        self._filelock_root = os.path.join(os.path.sep, 'tmp', getpass.getuser(), 'streaming')
         os.makedirs(self._filelock_root, exist_ok=True)
 
         # Create the shared memory-backed barrier, without its lock, which is unpickleable.

--- a/streaming/base/shared/prefix.py
+++ b/streaming/base/shared/prefix.py
@@ -7,6 +7,7 @@ The prefix is used by all workers using this StreamingDataset of this training j
 prevent shared resources like shared memory from colliding.
 """
 
+import getpass
 from collections import Counter
 from time import sleep
 from typing import Iterator, List, Tuple, Union
@@ -41,7 +42,7 @@ def _get_path(prefix_int: int, name: str) -> str:
     Returns:
         str: Unique shared memory name.
     """
-    return f'{prefix_int:06}_{name}'
+    return f'{getpass.getuser()}_{prefix_int:06}_{name}'
 
 
 def _pack_locals(dirnames: List[str], prefix_int: int) -> bytes:


### PR DESCRIPTION
## Description of changes:
1. Change StreamingDataset to make a temporary directory in `tmp/<username>/streaming` rather than `tmp/streaming`. 
2. Change the shared memory prefix to <username>_<old_prefix>

These changes partition shared resources on a per-user basis to prevent permissions errors when multiple users are working on the same system.
<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #429 
- Fixes #429 
<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
