### PR TITLE
changed choose to epoch_size in stream proportion docstring

### DIFF
--- a/streaming/base/stream.py
+++ b/streaming/base/stream.py
@@ -70,7 +70,7 @@ class Stream:
             proportion of the total combined dataset that consists of this sub-dataset. If
             using proportions, all sub-datasets provided together to the StreamingDataset init must
             define their proportions. The total combined number of samples is either the
-            StreamingDataset argument "choose" if provided, or kept the same total size as the
+            StreamingDataset argument "epoch_size" if provided, or kept the same total size as the
             underlying data if not. If provided, must be non-negative. Defaults to ``None``.
         repeat (float, optional): How much to upsample or downsample this sub-dataset, as a
             multipler on the number of samples. If provided, must be non-negative. Defaults to


### PR DESCRIPTION
## Description of changes:
The docstring for `Stream`, under the `proportion` argument, said that the total number of samples from all streams would be set by the `choose` arg of `StreamingDataset`. A community member correctly pointed out that this should be the `epoch_size` arg instead. This fixes that.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:
https://github.com/mosaicml/streaming/issues/431

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [x] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
