### PR TITLE
Add py1e warning when Shuffle block size is smaller than shard size

### DIFF
--- a/streaming/base/shuffle/py1e.py
+++ b/streaming/base/shuffle/py1e.py
@@ -116,12 +116,6 @@ def get_shuffle_py1e(shard_sizes: NDArray[np.int64],
             # Update sample offset for the next shard.
             cn_sample_offset += span_size
 
-        # If warn_user is true, this means the block size for shifts was smaller than a span size.
-        # This will result in no shuffling being done on that span aka shard part, so warn user.
-        if warn_user:
-            warnings.warn('Shuffle block size was smaller than shard size for some shards. This \
-                          will result in these shards not being shuffled with other shards. Set \
-                          shuffle_block_size to a larger value for a higher quality shuffle.')
         # Get incides that would sort the sample_positions array.
         sort_indices = np.argsort(sample_positions)
 
@@ -132,5 +126,12 @@ def get_shuffle_py1e(shard_sizes: NDArray[np.int64],
         ids[offset:offset + num_cn_samples] = cn_samples
 
         offset += num_cn_samples
+
+    # If warn_user is true, this means the block size for shifts was smaller than a span size.
+    # This will result in no shuffling being done on that span aka shard part, so warn user.
+    if warn_user:
+        warnings.warn('Shuffle block size was smaller than shard size for some shards. This \
+                        will result in these shards not being shuffled with other shards. Set \
+                        shuffle_block_size to a larger value for a higher quality shuffle.')
 
     return ids

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -538,7 +538,7 @@ def test_py1e_shuffle_block_warning(local_remote_dir: Any, batch_size: int, size
 
     with pytest.warns(UserWarning, match=f'Shuffle block size was smaller than shard size*'):
         for _ in dataloader:
-            print('yo')
+            pass
 
 
 @pytest.mark.parametrize('batch_size', [128])

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -510,6 +510,37 @@ def test_dataloader_mid_epoch_exit(local_remote_dir: Tuple[str, str], num_sample
     assert result == 0
 
 
+@pytest.mark.parametrize('batch_size', [4])
+@pytest.mark.parametrize('size_limit', [256, 512])
+@pytest.mark.parametrize('seed', [1111])
+@pytest.mark.parametrize('shuffle', [True])
+@pytest.mark.parametrize('shuffle_block_size', [50, 100])
+@pytest.mark.usefixtures('local_remote_dir')
+def test_py1e_shuffle_block_warning(local_remote_dir: Any, batch_size: int, size_limit: int,
+                                    seed: int, shuffle: bool, shuffle_block_size: int):
+    remote_dir, local_dir = local_remote_dir
+    # Here, size_limit is in bytes. Each SequenceDataset sample is around 10 bytes, but the header
+    # will also take up some space.
+    convert_to_mds(out_root=remote_dir,
+                   dataset_name='sequencedataset',
+                   num_samples=1000,
+                   size_limit=(size_limit * 10) + 1000)
+
+    dataset = StreamingDataset(local=local_dir,
+                               remote=remote_dir,
+                               shuffle=shuffle,
+                               batch_size=batch_size,
+                               num_canonical_nodes=1,
+                               shuffle_seed=seed,
+                               shuffle_algo='py1e',
+                               shuffle_block_size=shuffle_block_size)
+    dataloader = DataLoader(dataset=dataset, batch_size=batch_size)
+
+    with pytest.warns(UserWarning, match=f'Shuffle block size was smaller than shard size*'):
+        for _ in dataloader:
+            print('yo')
+
+
 @pytest.mark.parametrize('batch_size', [128])
 @pytest.mark.parametrize('drop_last', [False, True])
 @pytest.mark.parametrize('shuffle', [False, True])


### PR DESCRIPTION
## Description of changes:
Previously, when shuffle block size was less than the span size aka shard part size, the run would crash at [this line](https://github.com/mosaicml/streaming/blob/6b638518294f7338f7bb54e9bb529bfad8e5fa50/streaming/base/shuffle/py1e.py#L102) with `ValueError: high - low < 0` because the new shard range would not be defined. Instead, when this is the case, we now set the shard range extension to 0, meaning the shard range stays the same, so the shard is not shuffled with other neighboring shards at all. Because this is likely not the intended behavior, we warn the user when this happens as well. 

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
