### PR TITLE
Better default values for StreamingDataset args

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -47,11 +47,12 @@ jobs:
         id: tests
         run: |
           set -ex
-          pytest --splits 8 --group 1 --cov-fail-under=10
-          pytest --splits 8 --group 2 --cov-fail-under=10
-          pytest --splits 8 --group 3 --cov-fail-under=10
-          pytest --splits 8 --group 4 --cov-fail-under=10
-          pytest --splits 8 --group 5 --cov-fail-under=10
-          pytest --splits 8 --group 6 --cov-fail-under=10
-          pytest --splits 8 --group 7 --cov-fail-under=10
-          pytest --splits 8 --group 8 --cov-fail-under=10
+          pytest --splits 9 --group 1 --cov-fail-under=10
+          pytest --splits 9 --group 2 --cov-fail-under=10
+          pytest --splits 9 --group 3 --cov-fail-under=10
+          pytest --splits 9 --group 4 --cov-fail-under=10
+          pytest --splits 9 --group 5 --cov-fail-under=10
+          pytest --splits 9 --group 6 --cov-fail-under=10
+          pytest --splits 9 --group 7 --cov-fail-under=10
+          pytest --splits 9 --group 8 --cov-fail-under=10
+          pytest --splits 9 --group 9 --cov-fail-under=10

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -47,12 +47,13 @@ jobs:
         id: tests
         run: |
           set -ex
-          pytest --splits 9 --group 1 --cov-fail-under=10
-          pytest --splits 9 --group 2 --cov-fail-under=10
-          pytest --splits 9 --group 3 --cov-fail-under=10
-          pytest --splits 9 --group 4 --cov-fail-under=10
-          pytest --splits 9 --group 5 --cov-fail-under=10
-          pytest --splits 9 --group 6 --cov-fail-under=10
-          pytest --splits 9 --group 7 --cov-fail-under=10
-          pytest --splits 9 --group 8 --cov-fail-under=10
-          pytest --splits 9 --group 9 --cov-fail-under=10
+          pytest --splits 10 --group 1 --cov-fail-under=10
+          pytest --splits 10 --group 2 --cov-fail-under=10
+          pytest --splits 10 --group 3 --cov-fail-under=10
+          pytest --splits 10 --group 4 --cov-fail-under=10
+          pytest --splits 10 --group 5 --cov-fail-under=10
+          pytest --splits 10 --group 6 --cov-fail-under=10
+          pytest --splits 10 --group 7 --cov-fail-under=10
+          pytest --splits 10 --group 8 --cov-fail-under=10
+          pytest --splits 10 --group 9 --cov-fail-under=10
+          pytest --splits 10 --group 10 --cov-fail-under=10

--- a/streaming/base/batching/per_stream.py
+++ b/streaming/base/batching/per_stream.py
@@ -63,7 +63,9 @@ def generate_work_per_stream_batching(dataset: StreamingDataset, world: World, e
             # same as the ratio of the stream's samples to overall samples.
             # This ensures that the overall training shuffle block size is still approximately
             # equal to what is set by the user, and allows for reasoning about cache_limit as well.
-            assert isinstance(dataset.shuffle_block_size, int)
+            if not isinstance(dataset.shuffle_block_size, int):
+                raise TypeError(f'Dataset `shuffle_block_size` must be an integer. ' +
+                                f'Got {dataset.shuffle_block_size} instead.')
             shuffle_block_portion = int(dataset.shuffle_block_size * stream.proportion)
             stream_shuffle = get_shuffle(dataset.shuffle_algo, shuffle_units,
                                          dataset.num_canonical_nodes, dataset.shuffle_seed, epoch,

--- a/streaming/base/batching/per_stream.py
+++ b/streaming/base/batching/per_stream.py
@@ -65,7 +65,7 @@ def generate_work_per_stream_batching(dataset: StreamingDataset, world: World, e
             # equal to what is set by the user, and allows for reasoning about cache_limit as well.
             if not isinstance(dataset.shuffle_block_size, int):
                 raise TypeError(f'Dataset `shuffle_block_size` must be an integer. ' +
-                                f'Got {dataset.shuffle_block_size} instead.')
+                                f'Got {type(dataset.shuffle_block_size)} instead.')
             shuffle_block_portion = int(dataset.shuffle_block_size * stream.proportion)
             stream_shuffle = get_shuffle(dataset.shuffle_algo, shuffle_units,
                                          dataset.num_canonical_nodes, dataset.shuffle_seed, epoch,

--- a/streaming/base/batching/per_stream.py
+++ b/streaming/base/batching/per_stream.py
@@ -63,6 +63,7 @@ def generate_work_per_stream_batching(dataset: StreamingDataset, world: World, e
             # same as the ratio of the stream's samples to overall samples.
             # This ensures that the overall training shuffle block size is still approximately
             # equal to what is set by the user, and allows for reasoning about cache_limit as well.
+            assert isinstance(dataset.shuffle_block_size, int)
             shuffle_block_portion = int(dataset.shuffle_block_size * stream.proportion)
             stream_shuffle = get_shuffle(dataset.shuffle_algo, shuffle_units,
                                          dataset.num_canonical_nodes, dataset.shuffle_seed, epoch,

--- a/streaming/base/batching/random.py
+++ b/streaming/base/batching/random.py
@@ -59,7 +59,7 @@ def generate_work_random_batching(dataset: StreamingDataset, world: World, epoch
     if dataset.shuffle:
         if not isinstance(dataset.shuffle_block_size, int):
             raise TypeError(f'Dataset `shuffle_block_size` must be an integer. ' +
-                            f'Got {dataset.shuffle_block_size} instead.')
+                            f'Got {type(dataset.shuffle_block_size)} instead.')
         shuffle = get_shuffle(dataset.shuffle_algo, shuffle_units, dataset.num_canonical_nodes,
                               dataset.shuffle_seed, epoch, dataset.shuffle_block_size)
         big_ids = np.where(big_ids != -1, shuffle[big_ids], -1)

--- a/streaming/base/batching/random.py
+++ b/streaming/base/batching/random.py
@@ -57,7 +57,9 @@ def generate_work_random_batching(dataset: StreamingDataset, world: World, epoch
 
     # If we need to shuffle, shuffle in a node-aware and *underlying* shard-aware way.
     if dataset.shuffle:
-        assert isinstance(dataset.shuffle_block_size, int)
+        if not isinstance(dataset.shuffle_block_size, int):
+            raise TypeError(f'Dataset `shuffle_block_size` must be an integer. ' +
+                            f'Got {dataset.shuffle_block_size} instead.')
         shuffle = get_shuffle(dataset.shuffle_algo, shuffle_units, dataset.num_canonical_nodes,
                               dataset.shuffle_seed, epoch, dataset.shuffle_block_size)
         big_ids = np.where(big_ids != -1, shuffle[big_ids], -1)

--- a/streaming/base/batching/random.py
+++ b/streaming/base/batching/random.py
@@ -57,6 +57,7 @@ def generate_work_random_batching(dataset: StreamingDataset, world: World, epoch
 
     # If we need to shuffle, shuffle in a node-aware and *underlying* shard-aware way.
     if dataset.shuffle:
+        assert isinstance(dataset.shuffle_block_size, int)
         shuffle = get_shuffle(dataset.shuffle_algo, shuffle_units, dataset.num_canonical_nodes,
                               dataset.shuffle_seed, epoch, dataset.shuffle_block_size)
         big_ids = np.where(big_ids != -1, shuffle[big_ids], -1)

--- a/streaming/base/batching/stratified.py
+++ b/streaming/base/batching/stratified.py
@@ -74,6 +74,7 @@ def generate_work_stratified_batching(dataset: StreamingDataset, world: World, e
             # same as the ratio of the stream's samples to overall samples.
             # This ensures that the overall training shuffle block size is still approximately
             # equal to what is set by the user, and allows for reasoning about cache_limit as well.
+            assert isinstance(dataset.shuffle_block_size, int)
             shuffle_block_portion = int(dataset.shuffle_block_size * stream.proportion)
             stream_shuffle = get_shuffle(dataset.shuffle_algo, shuffle_units,
                                          dataset.num_canonical_nodes, dataset.shuffle_seed, epoch,

--- a/streaming/base/batching/stratified.py
+++ b/streaming/base/batching/stratified.py
@@ -74,7 +74,9 @@ def generate_work_stratified_batching(dataset: StreamingDataset, world: World, e
             # same as the ratio of the stream's samples to overall samples.
             # This ensures that the overall training shuffle block size is still approximately
             # equal to what is set by the user, and allows for reasoning about cache_limit as well.
-            assert isinstance(dataset.shuffle_block_size, int)
+            if not isinstance(dataset.shuffle_block_size, int):
+                raise TypeError(f'Dataset `shuffle_block_size` must be an integer. ' +
+                    f'Got {dataset.shuffle_block_size} instead.')
             shuffle_block_portion = int(dataset.shuffle_block_size * stream.proportion)
             stream_shuffle = get_shuffle(dataset.shuffle_algo, shuffle_units,
                                          dataset.num_canonical_nodes, dataset.shuffle_seed, epoch,

--- a/streaming/base/batching/stratified.py
+++ b/streaming/base/batching/stratified.py
@@ -76,7 +76,7 @@ def generate_work_stratified_batching(dataset: StreamingDataset, world: World, e
             # equal to what is set by the user, and allows for reasoning about cache_limit as well.
             if not isinstance(dataset.shuffle_block_size, int):
                 raise TypeError(f'Dataset `shuffle_block_size` must be an integer. ' +
-                    f'Got {dataset.shuffle_block_size} instead.')
+                                f'Got {type(dataset.shuffle_block_size)} instead.')
             shuffle_block_portion = int(dataset.shuffle_block_size * stream.proportion)
             stream_shuffle = get_shuffle(dataset.shuffle_algo, shuffle_units,
                                          dataset.num_canonical_nodes, dataset.shuffle_seed, epoch,

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -265,9 +265,7 @@ class StreamingDataset(Array, IterableDataset):
             of current sample. Workers will attempt to download ahead by this many samples during,
             but not before, training. Recommendation is to provide a value greater than per device
             batch size to ensure at-least per device batch size number of samples cached locally.
-            If ``None``, its value gets derived using per device batch size and number of
-            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
-            Defaults to ``None``.
+            If ``None``, its value is set to ``8 * batch_size``. Defaults to ``None``.
         cache_limit (Union[int, str], optional): Maximum size in bytes of this StreamingDataset's
             shard cache. Before downloading a shard, the least recently used resident shard(s)
             may be evicted (deleted from the local cache) in order to stay under the limit.
@@ -285,8 +283,8 @@ class StreamingDataset(Array, IterableDataset):
             resumption. The sample space is divided evenly according to the number of canonical
             nodes. The higher the value, the more independent non-overlapping paths the
             StreamingDataset replicas take through the shards per model replica (increasing data
-            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
-            of nodes of the initial run.
+            source diversity). Defaults to ``None``, which is interpreted as the number of physical
+            nodes of the initial run.
 
             .. note::
 
@@ -296,10 +294,12 @@ class StreamingDataset(Array, IterableDataset):
             partitioned over the workers. Defaults to ``None``.
         shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to
             ``False``.
-        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py1s``.
+        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py1e``.
         shuffle_seed (int): Seed for deterministic data shuffling. Defaults to ``9176``.
-        shuffle_block_size (int): Unit of shuffle. A canonical node's samples are split into blocks
-            of this size, and samples within each block are shuffled. Defaults to ``1 << 18``.
+        shuffle_block_size (int, optional): Unit of shuffle. A canonical node's samples are split
+            into blocks of this size, and samples within each block are shuffled. If ``None``, its
+            value is calculated as ``max(4_000_000 // num_canonical_nodes), 1 << 18)``. Defaults to
+            ``None``.
         batching_method (str): Which batching method to use, either ``random``, ``stratified``, or
             ``per_stream``. Defaults to ``random``.
     """
@@ -323,9 +323,9 @@ class StreamingDataset(Array, IterableDataset):
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None,
                  shuffle: bool = False,
-                 shuffle_algo: str = 'py1s',
+                 shuffle_algo: str = 'py1e',
                  shuffle_seed: int = 9176,
-                 shuffle_block_size: int = 1 << 18,
+                 shuffle_block_size: Optional[int] = None,
                  batching_method: str = 'random') -> None:
         # Global arguments (which do not live in Streams).
         self.predownload = predownload
@@ -377,12 +377,15 @@ class StreamingDataset(Array, IterableDataset):
             raise ValueError(f'`shuffle_seed` must be a non-negative integer, but got: ' +
                              f'{self.shuffle_seed}.')
 
-        # Check that predownload is at least per device batch size.
+        # Check that predownload is at least per device batch size, and set it if currently None.
         if self.predownload is not None and self.batch_size is not None and \
             self.predownload < self.batch_size:
             warnings.warn(f'predownload < batch_size ({self.predownload} < {self.batch_size}).' +
                           f'This may result in slower batch time. Recommendation is to set ' +
                           f'predownload to at-least batch_size.')
+        elif self.predownload is None:
+            self.predownload = 8 * self.batch_size if self.batch_size is not None else 64
+
         # Convert epoch size from string to int, if needed. Cannot be negative.
         epoch_size_value = None
         if epoch_size:
@@ -632,12 +635,11 @@ class StreamingDataset(Array, IterableDataset):
         """
         return self.length
 
-    def _set_predownload(self) -> None:
-        """Set the predownload value which is per number of workers."""
-        if self.predownload is None:
-            self.predownload = max(
-                self.batch_size, 256 * self.batch_size // self.num_canonical_nodes
-            ) if self.batch_size is not None and self.num_canonical_nodes is not None else 512
+    def _set_shuffle_block_size(self):
+        """Set the shuffle block size value."""
+        if self.shuffle_block_size is None:
+            self.shuffle_block_size = max(4_000_000 // self.num_canonical_nodes, 1 << 18) \
+                if self.num_canonical_nodes is not None else 1 << 18
 
     def _resume(self, world: World, epoch: int) -> Tuple[int, int]:
         """Either resume from checkpoint or start at the beginning.
@@ -656,8 +658,11 @@ class StreamingDataset(Array, IterableDataset):
         except FileNotFoundError:
             # There is nothing to resume.
             if not self.num_canonical_nodes:
-                self.num_canonical_nodes = world.num_nodes * 64
-            self._set_predownload()
+                if self.shuffle_algo in ['py1s', 'py2s']:
+                    self.num_canonical_nodes = 64 * world.num_nodes
+                else:
+                    self.num_canonical_nodes = world.num_nodes
+            self._set_shuffle_block_size()
             return epoch, 0
 
         # SharedMemory buffers may contain additional null bytes at the end.
@@ -669,8 +674,11 @@ class StreamingDataset(Array, IterableDataset):
         # Check if the resume state is stale.
         if obj['epoch'] < epoch:
             if not self.num_canonical_nodes:
-                self.num_canonical_nodes = world.num_nodes * 64
-            self._set_predownload()
+                if self.shuffle_algo in ['py1s', 'py2s']:
+                    self.num_canonical_nodes = 64 * world.num_nodes
+                else:
+                    self.num_canonical_nodes = world.num_nodes
+            self._set_shuffle_block_size()
             return epoch, 0
 
         # Load the correct resumption meta data.
@@ -678,7 +686,7 @@ class StreamingDataset(Array, IterableDataset):
         sample_in_epoch = obj['sample_in_epoch']
         self.num_canonical_nodes = obj['num_canonical_nodes']
         self.shuffle_seed = obj['shuffle_seed']
-        self._set_predownload()
+        self._set_shuffle_block_size()
 
         return epoch, sample_in_epoch
 

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -283,8 +283,9 @@ class StreamingDataset(Array, IterableDataset):
             resumption. The sample space is divided evenly according to the number of canonical
             nodes. The higher the value, the more independent non-overlapping paths the
             StreamingDataset replicas take through the shards per model replica (increasing data
-            source diversity). Defaults to ``None``, which is interpreted as the number of physical
-            nodes of the initial run.
+            source diversity). If ``None``, this is interpreted as 64 times the number of physical
+            nodes of the initial run if ``shuffle_algo`` is ``py1s`` or ``py2s``, and simply the
+            number of physical nodes of the initial run otherwise. Defaults to ``None``.
 
             .. note::
 

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -278,7 +278,7 @@ class StreamingDataset(Array, IterableDataset):
             how many samples to pick from the same shard at a time (``1`` for evenly balanced
             across shards, ``1000`` to pick 1000 samples from the same shard at a time, etc).
             Defaults to ``1``.
-        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
+        partition_algo (str): Which partitioning algorithm to use. Defaults to ``relaxed``.
         num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
             resumption. The sample space is divided evenly according to the number of canonical
             nodes. The higher the value, the more independent non-overlapping paths the
@@ -319,7 +319,7 @@ class StreamingDataset(Array, IterableDataset):
                  cache_limit: Optional[Union[int, str]] = None,
                  sampling_method: str = 'balanced',
                  sampling_granularity: int = 1,
-                 partition_algo: str = 'orig',
+                 partition_algo: str = 'relaxed',
                  num_canonical_nodes: Optional[int] = None,
                  batch_size: Optional[int] = None,
                  shuffle: bool = False,

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -749,12 +749,12 @@ class StreamingDataset(Array, IterableDataset):
         else:
             sample_in_epoch = offset + num_samples
 
-        # If `self.initial_physical_nodes` is None, we are running for the first time, so we set 
+        # If `self.initial_physical_nodes` is None, we are running for the first time, so we set
         # initial_physical_nodes to the current number of physical nodes. Otherwise, we persist
         # initial_physical_nodes as the value loaded and set from the resumption state.
         initial_physical_nodes = world.num_nodes if self.initial_physical_nodes is None \
             else self.initial_physical_nodes
-        
+
         return {
             'epoch': epoch,
             'sample_in_epoch': sample_in_epoch,

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -382,7 +382,7 @@ class StreamingDataset(Array, IterableDataset):
             raise ValueError(f'`shuffle_seed` must be a non-negative integer, but got: ' +
                              f'{self.shuffle_seed}.')
 
-        # Check that predownload is at least per device batch size, and set it if currently None.
+        # Check that predownload is at least per device batch size, and set it if currently `None`.
         if self.predownload is not None and self.batch_size is not None and \
             self.predownload < self.batch_size:
             warnings.warn(f'predownload < batch_size ({self.predownload} < {self.batch_size}).' +

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -11,6 +11,7 @@ import pytest
 from torch.utils.data import DataLoader
 
 from streaming.base import Stream, StreamingDataLoader, StreamingDataset
+from streaming.base.util import clean_stale_shared_memory
 from tests.common.utils import convert_to_mds
 
 
@@ -761,6 +762,8 @@ def test_streamingdataloader_mid_epoch_resumption(local_remote_dir: Any, batch_s
 
     del dataloader
     del dataset
+
+    clean_stale_shared_memory()
 
     dataset = StreamingDataset(local=local_dir,
                                remote=remote_dir,


### PR DESCRIPTION
## Description of changes:
Adding better defaults to `StreamingDataset`. This will help towards making sure StreamingDataset just works for most cases out of the box, giving good quality shuffles without degrading throughput and sacrificing resumption. This depends on the `relaxed` partitioning algo being merged as well (#476).

Testing:
Multi-stream deterministic resumption tests successfully ran -- see below:
* Yellow: Full 300 batches on 1 node, NCN = 4.
* Light Blue: First 100 batches on 1 node, NCN = 4.
* Green: Middle 100 batches on 2 nodes, NCN = 4.
* Purple: Last 100 batches on 4 nodes, NCN = 4.
<img width="938" alt="Screenshot 2023-10-22 at 1 04 21 PM" src="https://github.com/mosaicml/streaming/assets/28932043/aaf07c25-66ad-40dc-a38b-79dee60a53fe">

Summary of Changes:
* `predownload` defaults to 8x device batch size
* `partition_algo` defaults to `relaxed`
* `num_canonical_nodes` defaults to the 64 * number of physical nodes of the run only when using `py1s` or `py2s` shuffling. In all other cases, it defaults to the number of physical nodes of the run. `relaxed` partitioning takes care of resumption cases.
* `shuffle_algo` defaults to `py1e`. This better balances downloads and gives good shuffle quality.
* `shuffle_block_size` defaults to 4 million / `num_canonical_nodes` or 262144 == 1<<18, whichever one is greater. This value was selected based on the results of shuffle quality experiments shown below, where a shuffle strength of 4 million samples (the brown dot) gave comparable train loss stdev and batch composition stdev to stronger shuffles but with less downloads:
![shuffle_strength_vs_batch_composition_std](https://github.com/mosaicml/streaming/assets/28932043/3396db0d-f737-4e75-b465-d943d8ea7f99)
![shuffle_strength_vs_loss_deviation_std](https://github.com/mosaicml/streaming/assets/28932043/2c6f8397-9f52-41ad-adb7-b0f3ad8ec430)

Defaults will be propagated and changed as appropriate in diffusion and llm-foundry repos in conjunction with this PR and (#476)

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
