### PR TITLE
Fix for CVE-2023-47248

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ extra_deps = {}
 
 extra_deps['dev'] = [
     'datasets>=2.4.0,<3',
+    'pyarrow>14.0.0',
     'docformatter>=1.4',
     'jupyter==1.0.0',
     'pre-commit>=2.18.1,<4',


### PR DESCRIPTION
## Description of changes:
* Fixe for CVE-2023-47248: https://www.openwall.com/lists/oss-security/2023/11/08/7
* Explicitly install pyarrow>14.0.0
* PyArrow was originally installed by datasets package, latest version does not contain PyArrow update
* Called out by the Databricks DevSec team