### PR TITLE
Moved local directory creation and existence check from CloudUploader to Writer class

### DIFF
--- a/streaming/base/format/base/writer.py
+++ b/streaming/base/format/base/writer.py
@@ -103,7 +103,8 @@ class Writer(ABC):
 
         # Validate keyword arguments
         invalid_kwargs = [
-            arg for arg in kwargs.keys() if arg not in ('progress_bar', 'max_workers', 'retry')
+            arg for arg in kwargs.keys()
+            if arg not in ('progress_bar', 'max_workers', 'retry', 'exist_ok')
         ]
         if invalid_kwargs:
             raise ValueError(f'Invalid Writer argument(s): {invalid_kwargs} ')

--- a/streaming/base/format/json/writer.py
+++ b/streaming/base/format/json/writer.py
@@ -45,6 +45,11 @@ class JSONWriter(SplitWriter):
             max_workers (int): Maximum number of threads used to upload output dataset files in
                 parallel to a remote location. One thread is responsible for uploading one shard
                 file to a remote location. Default to ``min(32, (os.cpu_count() or 1) + 4)``.
+            retry (int): Number of times to retry uploading a file to a remote location.
+                Default to ``2``.
+            exist_ok (bool): If the local directory exists and not empty, whether to overwrite
+                the content or raise an error. `False` raises an error. `True` overwrites the
+                content. Defaults to `False`.
     """
 
     format = 'json'

--- a/streaming/base/format/mds/writer.py
+++ b/streaming/base/format/mds/writer.py
@@ -45,6 +45,11 @@ class MDSWriter(JointWriter):
             max_workers (int): Maximum number of threads used to upload output dataset files in
                 parallel to a remote location. One thread is responsible for uploading one shard
                 file to a remote location. Default to ``min(32, (os.cpu_count() or 1) + 4)``.
+            retry (int): Number of times to retry uploading a file to a remote location.
+                Default to ``2``.
+            exist_ok (bool): If the local directory exists and not empty, whether to overwrite
+                the content or raise an error. `False` raises an error. `True` overwrites the
+                content. Defaults to `False`.
     """
 
     format = 'mds'

--- a/streaming/base/format/xsv/writer.py
+++ b/streaming/base/format/xsv/writer.py
@@ -46,6 +46,11 @@ class XSVWriter(SplitWriter):
             max_workers (int): Maximum number of threads used to upload output dataset files in
                 parallel to a remote location. One thread is responsible for uploading one shard
                 file to a remote location. Default to ``min(32, (os.cpu_count() or 1) + 4)``.
+            retry (int): Number of times to retry uploading a file to a remote location.
+                Default to ``2``.
+            exist_ok (bool): If the local directory exists and not empty, whether to overwrite
+                the content or raise an error. `False` raises an error. `True` overwrites the
+                content. Defaults to `False`.
     """
 
     format = 'xsv'
@@ -164,6 +169,11 @@ class CSVWriter(XSVWriter):
             max_workers (int): Maximum number of threads used to upload output dataset files in
                 parallel to a remote location. One thread is responsible for uploading one shard
                 file to a remote location. Default to ``min(32, (os.cpu_count() or 1) + 4)``.
+            retry (int): Number of times to retry uploading a file to a remote location.
+                Default to ``2``.
+            exist_ok (bool): If the local directory exists and not empty, whether to overwrite
+                the content or raise an error. `False` raises an error. `True` overwrites the
+                content. Defaults to `False`.
     """
 
     format = 'csv'
@@ -230,6 +240,11 @@ class TSVWriter(XSVWriter):
             max_workers (int): Maximum number of threads used to upload output dataset files in
                 parallel to a remote location. One thread is responsible for uploading one shard
                 file to a remote location. Default to ``min(32, (os.cpu_count() or 1) + 4)``.
+            retry (int): Number of times to retry uploading a file to a remote location.
+                Default to ``2``.
+            exist_ok (bool): If the local directory exists and not empty, whether to overwrite
+                the content or raise an error. `False` raises an error. `True` overwrites the
+                content. Defaults to `False`.
     """
 
     format = 'tsv'

--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -57,8 +57,7 @@ class CloudUploader:
             out: Union[str, Tuple[str, str]],
             keep_local: bool = False,
             progress_bar: bool = False,
-            retry: int = 2,
-            exist_ok: bool = False) -> Any:
+            retry: int = 2) -> Any:
         """Instantiate a cloud provider uploader or a local uploader based on remote path.
 
         Args:
@@ -75,8 +74,6 @@ class CloudUploader:
             progress_bar (bool): Display TQDM progress bars for uploading output dataset files to
                 a remote location. Default to ``False``.
             retry (int): Number of times to retry uploading a file. Defaults to ``2``.
-            exist_ok (bool): When exist_ok = False, raise error if the local part of ``out`` already
-                exists and has contents. Defaults to ``False``.
 
         Returns:
             CloudUploader: An instance of sub-class.
@@ -89,8 +86,8 @@ class CloudUploader:
             prefix = os.path.join(path.parts[0], path.parts[1])
             if prefix == 'dbfs:/Volumes':
                 provider_prefix = prefix
-        return getattr(sys.modules[__name__],
-                       UPLOADERS[provider_prefix])(out, keep_local, progress_bar, retry, exist_ok)
+        return getattr(sys.modules[__name__], UPLOADERS[provider_prefix])(out, keep_local,
+                                                                          progress_bar, retry)
 
     def _validate(self, out: Union[str, Tuple[str, str]]) -> None:
         """Validate the `out` argument.
@@ -124,8 +121,7 @@ class CloudUploader:
                  out: Union[str, Tuple[str, str]],
                  keep_local: bool = False,
                  progress_bar: bool = False,
-                 retry: int = 2,
-                 exist_ok: bool = False) -> None:
+                 retry: int = 2) -> None:
         """Initialize and validate local and remote path.
 
         Args:
@@ -142,8 +138,6 @@ class CloudUploader:
             progress_bar (bool): Display TQDM progress bars for uploading output dataset files to
                 a remote location. Default to ``False``.
             retry (int): Number of times to retry uploading a file. Defaults to ``2``.
-            exist_ok (bool): When exist_ok = False, raise error if the local part of ``out`` already
-                exists and has contents. Defaults to ``False``.
 
         Raises:
             FileExistsError: Local directory must be empty.
@@ -165,16 +159,6 @@ class CloudUploader:
         else:
             self.local = out[0]
             self.remote = out[1]
-
-        if os.path.exists(self.local) and len(os.listdir(self.local)) != 0:
-            if not exist_ok:
-                raise FileExistsError(f'Directory is not empty: {self.local}')
-            else:
-                logger.warning(
-                    f'Directory {self.local} exists and not empty. But continue to mkdir since exist_ok is set to be True.'
-                )
-
-        os.makedirs(self.local, exist_ok=True)
 
     def upload_file(self, filename: str):
         """Upload file from local instance to remote instance.
@@ -225,17 +209,14 @@ class S3Uploader(CloudUploader):
         progress_bar (bool): Display TQDM progress bars for uploading output dataset files to
             a remote location. Default to ``False``.
         retry (int): Number of times to retry uploading a file. Defaults to ``2``.
-        exist_ok (bool): When exist_ok = False, raise error if the local part of ``out`` already
-            exists and has contents. Defaults to ``False``.
     """
 
     def __init__(self,
                  out: Union[str, Tuple[str, str]],
                  keep_local: bool = False,
                  progress_bar: bool = False,
-                 retry: int = 2,
-                 exist_ok: bool = False) -> None:
-        super().__init__(out, keep_local, progress_bar, retry, exist_ok)
+                 retry: int = 2) -> None:
+        super().__init__(out, keep_local, progress_bar, retry)
 
         import boto3
         from botocore.config import Config
@@ -346,17 +327,14 @@ class GCSUploader(CloudUploader):
         progress_bar (bool): Display TQDM progress bars for uploading output dataset files to
             a remote location. Default to ``False``.
         retry (int): Number of times to retry uploading a file. Defaults to ``2``.
-        exist_ok (bool): When exist_ok = False, raise error if the local part of ``out`` already
-            exists and has contents. Defaults to ``False``.
     """
 
     def __init__(self,
                  out: Union[str, Tuple[str, str]],
                  keep_local: bool = False,
                  progress_bar: bool = False,
-                 retry: int = 2,
-                 exist_ok: bool = False) -> None:
-        super().__init__(out, keep_local, progress_bar, retry, exist_ok)
+                 retry: int = 2) -> None:
+        super().__init__(out, keep_local, progress_bar, retry)
         if 'GCS_KEY' in os.environ and 'GCS_SECRET' in os.environ:
             import boto3
 
@@ -494,17 +472,14 @@ class OCIUploader(CloudUploader):
         progress_bar (bool): Display TQDM progress bars for uploading output dataset files to
             a remote location. Default to ``False``.
         retry (int): Number of times to retry uploading a file. Defaults to ``2``.
-        exist_ok (bool): When exist_ok = False, raise error if the local part of ``out`` already
-            exists and has contents. Defaults to ``False``.
     """
 
     def __init__(self,
                  out: Union[str, Tuple[str, str]],
                  keep_local: bool = False,
                  progress_bar: bool = False,
-                 retry: int = 2,
-                 exist_ok: bool = False) -> None:
-        super().__init__(out, keep_local, progress_bar, retry, exist_ok)
+                 retry: int = 2) -> None:
+        super().__init__(out, keep_local, progress_bar, retry)
 
         import oci
 
@@ -631,17 +606,14 @@ class AzureUploader(CloudUploader):
         progress_bar (bool): Display TQDM progress bars for uploading output dataset files to
             a remote location. Default to ``False``.
         retry (int): Number of times to retry uploading a file. Defaults to ``2``.
-        exist_ok (bool): When exist_ok = False, raise error if the local part of ``out`` already
-            exists and has contents. Defaults to ``False``.
     """
 
     def __init__(self,
                  out: Union[str, Tuple[str, str]],
                  keep_local: bool = False,
                  progress_bar: bool = False,
-                 retry: int = 2,
-                 exist_ok: bool = False) -> None:
-        super().__init__(out, keep_local, progress_bar, retry, exist_ok)
+                 retry: int = 2) -> None:
+        super().__init__(out, keep_local, progress_bar, retry)
 
         from azure.storage.blob import BlobServiceClient
 
@@ -719,17 +691,14 @@ class AzureDataLakeUploader(CloudUploader):
         progress_bar (bool): Display TQDM progress bars for uploading output dataset files to
             a remote location. Default to ``False``.
         retry (int): Number of times to retry uploading a file. Defaults to ``2``.
-        exist_ok (bool): When exist_ok = False, raise error if the local part of ``out`` already
-            exists and has contents. Defaults to ``False``.
     """
 
     def __init__(self,
                  out: Union[str, Tuple[str, str]],
                  keep_local: bool = False,
                  progress_bar: bool = False,
-                 retry: int = 2,
-                 exist_ok: bool = False) -> None:
-        super().__init__(out, keep_local, progress_bar, retry, exist_ok)
+                 retry: int = 2) -> None:
+        super().__init__(out, keep_local, progress_bar, retry)
 
         from azure.storage.filedatalake import DataLakeServiceClient
 
@@ -804,17 +773,14 @@ class DatabricksUploader(CloudUploader):
         progress_bar (bool): Display TQDM progress bars for uploading output dataset files to
             a remote location. Default to ``False``.
         retry (int): Number of times to retry uploading a file. Defaults to ``2``.
-        exist_ok (bool): When exist_ok = False, raise error if the local part of ``out`` already
-            exists and has contents. Defaults to ``False``.
     """
 
     def __init__(self,
                  out: Union[str, Tuple[str, str]],
                  keep_local: bool = False,
                  progress_bar: bool = False,
-                 retry: int = 2,
-                 exist_ok: bool = False) -> None:
-        super().__init__(out, keep_local, progress_bar, retry, exist_ok)
+                 retry: int = 2) -> None:
+        super().__init__(out, keep_local, progress_bar, retry)
         self.client = self._create_workspace_client()
 
     def _create_workspace_client(self):
@@ -843,17 +809,14 @@ class DatabricksUnityCatalogUploader(DatabricksUploader):
         progress_bar (bool): Display TQDM progress bars for uploading output dataset files to
             a remote location. Default to ``False``.
         retry (int): Number of times to retry uploading a file. Defaults to ``2``.
-        exist_ok (bool): When exist_ok = False, raise error if the local part of ``out`` already
-            exists and has contents. Defaults to ``False``.
     """
 
     def __init__(self,
                  out: Union[str, Tuple[str, str]],
                  keep_local: bool = False,
                  progress_bar: bool = False,
-                 retry: int = 2,
-                 exist_ok: bool = False) -> None:
-        super().__init__(out, keep_local, progress_bar, retry, exist_ok)
+                 retry: int = 2) -> None:
+        super().__init__(out, keep_local, progress_bar, retry)
 
     def upload_file(self, filename: str):
         """Upload file from local instance to Databricks Unity Catalog.
@@ -892,17 +855,14 @@ class DBFSUploader(DatabricksUploader):
         progress_bar (bool): Display TQDM progress bars for uploading output dataset files to
             a remote location. Default to ``False``.
         retry (int): Number of times to retry uploading a file. Defaults to ``2``.
-        exist_ok (bool): When exist_ok = False, raise error if the local part of ``out`` already
-            exists and has contents. Defaults to ``False``.
     """
 
     def __init__(self,
                  out: Union[str, Tuple[str, str]],
                  keep_local: bool = False,
                  progress_bar: bool = False,
-                 retry: int = 2,
-                 exist_ok: bool = False) -> None:
-        super().__init__(out, keep_local, progress_bar, retry, exist_ok)
+                 retry: int = 2) -> None:
+        super().__init__(out, keep_local, progress_bar, retry)
         self.dbfs_path = self.remote.lstrip('dbfs:')  # pyright: ignore
         self.check_folder_exists()
 
@@ -962,17 +922,14 @@ class LocalUploader(CloudUploader):
         progress_bar (bool): Display TQDM progress bars for uploading output dataset files to
             a remote location. Default to ``False``.
         retry (int): Number of times to retry uploading a file. Defaults to ``2``.
-        exist_ok (bool): When exist_ok = False, raise error if the local part of ``out`` already
-            exists and has contents. Defaults to ``False``.
     """
 
     def __init__(self,
                  out: Union[str, Tuple[str, str]],
                  keep_local: bool = False,
                  progress_bar: bool = False,
-                 retry: int = 2,
-                 exist_ok: bool = False) -> None:
-        super().__init__(out, keep_local, progress_bar, retry, exist_ok)
+                 retry: int = 2) -> None:
+        super().__init__(out, keep_local, progress_bar, retry)
         # Create remote directory if it doesn't exist
         if self.remote:
             os.makedirs(self.remote, exist_ok=True)

--- a/streaming/base/util.py
+++ b/streaming/base/util.py
@@ -284,7 +284,7 @@ def _merge_index_from_list(index_file_urls: List[Union[str, Tuple[str, str]]],
     # This is the index json file name, e.g., it is index.json as of 0.6.0
     index_basename = get_index_basename()
 
-    cu = CloudUploader.get(out, keep_local=True, exist_ok=True)
+    cu = CloudUploader.get(out, keep_local=True)
 
     # Remove duplicates, and strip '/' from right if any
     index_file_urls = list(OrderedDict.fromkeys(index_file_urls))
@@ -394,10 +394,10 @@ def _merge_index_from_root(out: Union[str, Tuple[str, str]],
         logger.warning('No MDS dataset folder specified, no index merged')
         return
 
-    cu = CloudUploader.get(out, exist_ok=True, keep_local=True)
+    cu = CloudUploader.get(out, keep_local=True)
 
     local_index_files = []
-    cl = CloudUploader.get(cu.local, exist_ok=True, keep_local=True)
+    cl = CloudUploader.get(cu.local, keep_local=True)
     for file in cl.list_objects():
         if file.endswith('.json') and not_merged_index(file, cu.local):
             local_index_files.append(file)

--- a/streaming/base/util.py
+++ b/streaming/base/util.py
@@ -297,7 +297,7 @@ def _merge_index_from_list(index_file_urls: List[Union[str, Tuple[str, str]]],
 
     # Prepare a temp folder to download index.json from remote if necessary. Removed in the end.
     with tempfile.TemporaryDirectory() as temp_root:
-        logging.warning(f'A temporary folder {temp_root} is created to store index files')
+        logging.debug(f'A temporary folder {temp_root} is created to store index files')
 
         # Copy files to a temporary directory. Download if necessary
         partitions = []

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -80,21 +80,6 @@ class TestCloudUploader:
         with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = CloudUploader.get(out=out)
 
-    # def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
-    #     with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
-    #         local, _ = local_remote_dir
-    #         os.makedirs(local, exist_ok=True)
-    #         local_file_path = os.path.join(local, 'file.txt')
-    #         # Creating an empty file at specified location
-    #         with open(local_file_path, 'w') as _:
-    #             pass
-    #         _ = CloudUploader.get(out=local)
-
-    # def test_local_directory_is_created(self, local_remote_dir: Tuple[str, str]):
-    #     local, _ = local_remote_dir
-    #     _ = CloudUploader(out=local)
-    #     assert os.path.exists(local)
-
     def test_delete_local_file(self, local_remote_dir: Tuple[str, str]):
         local, _ = local_remote_dir
         os.makedirs(local, exist_ok=True)
@@ -142,16 +127,6 @@ class TestS3Uploader:
     def test_invalid_remote_list(self, out: Any):
         with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = S3Uploader(out=out)
-
-    # def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
-    #     with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
-    #         local, _ = local_remote_dir
-    #         os.makedirs(local, exist_ok=True)
-    #         local_file_path = os.path.join(local, 'file.txt')
-    #         # Creating an empty file at specified location
-    #         with open(local_file_path, 'w') as _:
-    #             pass
-    #         _ = S3Uploader(out=local)
 
     @pytest.mark.usefixtures('s3_client', 's3_test')
     def test_upload_file(self, local_remote_dir: Tuple[str, str]):
@@ -278,17 +253,6 @@ class TestGCSUploader:
         with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = GCSUploader(out=out)
 
-    # @pytest.mark.usefixtures('gcs_hmac_credentials')
-    # def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
-    #     with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
-    #         local, _ = local_remote_dir
-    #         os.makedirs(local, exist_ok=True)
-    #         local_file_path = os.path.join(local, 'file.txt')
-    #         # Creating an empty file at specified location
-    #         with open(local_file_path, 'w') as _:
-    #             pass
-    #         _ = GCSUploader(out=local)
-
     @pytest.mark.usefixtures('gcs_hmac_client', 'gcs_test')
     def test_upload_file(self, local_remote_dir: Tuple[str, str]):
         with tempfile.NamedTemporaryFile(delete=True, suffix='.txt') as tmp:
@@ -386,16 +350,6 @@ class TestAzureUploader:
         with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = AzureUploader(out=out)
 
-    # def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
-    #     with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
-    #         local, _ = local_remote_dir
-    #         os.makedirs(local, exist_ok=True)
-    #         local_file_path = os.path.join(local, 'file.txt')
-    #         # Creating an empty file at specified location
-    #         with open(local_file_path, 'w') as _:
-    #             pass
-    #         _ = AzureUploader(out=local)
-
 
 class TestAzureDataLakeUploader:
 
@@ -419,16 +373,6 @@ class TestAzureDataLakeUploader:
         with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = AzureDataLakeUploader(out=out)
 
-    # def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
-    #     with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
-    #         local, _ = local_remote_dir
-    #         os.makedirs(local, exist_ok=True)
-    #         local_file_path = os.path.join(local, 'file.txt')
-    #         # Creating an empty file at specified location
-    #         with open(local_file_path, 'w') as _:
-    #             pass
-    #         _ = AzureDataLakeUploader(out=local)
-
 
 class TestDatabricksUnityCatalogUploader:
 
@@ -448,19 +392,6 @@ class TestDatabricksUnityCatalogUploader:
         with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = DatabricksUnityCatalogUploader(out=out)
 
-    # @patch('streaming.base.storage.upload.DatabricksUploader._create_workspace_client')
-    # def test_local_directory_is_empty(self, mock_create_client: Mock,
-    #                                   local_remote_dir: Tuple[str, str]):
-    #     mock_create_client.side_effect = None
-    #     with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
-    #         local, _ = local_remote_dir
-    #         os.makedirs(local, exist_ok=True)
-    #         local_file_path = os.path.join(local, 'file.txt')
-    #         # Creating an empty file at specified location
-    #         with open(local_file_path, 'w') as _:
-    #             pass
-    #         _ = DatabricksUnityCatalogUploader(out=local)
-
 
 class TestDBFSUploader:
 
@@ -478,19 +409,6 @@ class TestDBFSUploader:
         mock_create_client.side_effect = None
         with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = DBFSUploader(out=out)
-
-    # @patch('streaming.base.storage.upload.DatabricksUploader._create_workspace_client')
-    # def test_local_directory_is_empty(self, mock_create_client: Mock,
-    #                                   local_remote_dir: Tuple[str, str]):
-    #     with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
-    #         mock_create_client.side_effect = None
-    #         local, _ = local_remote_dir
-    #         os.makedirs(local, exist_ok=True)
-    #         local_file_path = os.path.join(local, 'file.txt')
-    #         # Creating an empty file at specified location
-    #         with open(local_file_path, 'w') as _:
-    #             pass
-    #         _ = DBFSUploader(out=local)
 
 
 class TestLocalUploader:

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -80,23 +80,24 @@ class TestCloudUploader:
         with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = CloudUploader.get(out=out)
 
-    def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
-        with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
-            local, _ = local_remote_dir
-            os.makedirs(local, exist_ok=True)
-            local_file_path = os.path.join(local, 'file.txt')
-            # Creating an empty file at specified location
-            with open(local_file_path, 'w') as _:
-                pass
-            _ = CloudUploader.get(out=local)
+    # def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
+    #     with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
+    #         local, _ = local_remote_dir
+    #         os.makedirs(local, exist_ok=True)
+    #         local_file_path = os.path.join(local, 'file.txt')
+    #         # Creating an empty file at specified location
+    #         with open(local_file_path, 'w') as _:
+    #             pass
+    #         _ = CloudUploader.get(out=local)
 
-    def test_local_directory_is_created(self, local_remote_dir: Tuple[str, str]):
-        local, _ = local_remote_dir
-        _ = CloudUploader(out=local)
-        assert os.path.exists(local)
+    # def test_local_directory_is_created(self, local_remote_dir: Tuple[str, str]):
+    #     local, _ = local_remote_dir
+    #     _ = CloudUploader(out=local)
+    #     assert os.path.exists(local)
 
     def test_delete_local_file(self, local_remote_dir: Tuple[str, str]):
         local, _ = local_remote_dir
+        os.makedirs(local, exist_ok=True)
         local_file_path = os.path.join(local, 'file.txt')
         cw = CloudUploader.get(out=local)
         # Creating an empty file at specified location
@@ -117,7 +118,7 @@ class TestCloudUploader:
     def test_list_objects_from_local_gets_called(self, mocked_requests: Mock,
                                                  remote_local_dir: Any):
         mock_remote_dir, _ = remote_local_dir()
-        cu = CloudUploader.get(mock_remote_dir, exist_ok=True, keep_local=True)
+        cu = CloudUploader.get(mock_remote_dir, keep_local=True)
         cu.list_objects()
         mocked_requests.assert_called_once()
 
@@ -142,21 +143,22 @@ class TestS3Uploader:
         with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = S3Uploader(out=out)
 
-    def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
-        with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
-            local, _ = local_remote_dir
-            os.makedirs(local, exist_ok=True)
-            local_file_path = os.path.join(local, 'file.txt')
-            # Creating an empty file at specified location
-            with open(local_file_path, 'w') as _:
-                pass
-            _ = S3Uploader(out=local)
+    # def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
+    #     with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
+    #         local, _ = local_remote_dir
+    #         os.makedirs(local, exist_ok=True)
+    #         local_file_path = os.path.join(local, 'file.txt')
+    #         # Creating an empty file at specified location
+    #         with open(local_file_path, 'w') as _:
+    #             pass
+    #         _ = S3Uploader(out=local)
 
     @pytest.mark.usefixtures('s3_client', 's3_test')
     def test_upload_file(self, local_remote_dir: Tuple[str, str]):
         with tempfile.NamedTemporaryFile(delete=True, suffix='.txt') as tmp:
             filename = tmp.name.split(os.sep)[-1]
             local, _ = local_remote_dir
+            os.makedirs(local, exist_ok=True)
             remote = 's3://streaming-test-bucket/path'
             local_file_path = os.path.join(local, filename)
             s3w = S3Uploader(out=(local, remote))
@@ -170,6 +172,7 @@ class TestS3Uploader:
         with tempfile.NamedTemporaryFile(delete=True, suffix='.txt') as tmp:
             filename = tmp.name.split(os.sep)[-1]
             local, _ = local_remote_dir
+            os.makedirs(local, exist_ok=True)
             remote = 's3://streaming-test-bucket/path'
             local_file_path = os.path.join(local, filename)
             s3w = S3Uploader(out=(local, remote))
@@ -194,14 +197,14 @@ class TestS3Uploader:
             client = boto3.client('s3', region_name='us-east-1')
             client.put_object(Bucket=MY_BUCKET, Key=os.path.join(MY_PREFIX, file_name), Body='')
 
-            cu = CloudUploader.get(mock_remote_dir, exist_ok=True, keep_local=True)
+            cu = CloudUploader.get(mock_remote_dir, keep_local=True)
             objs = cu.list_objects(mock_remote_dir)
             assert isinstance(objs, list)
 
     @pytest.mark.usefixtures('s3_client', 's3_test', 'remote_local_dir')
     def test_clienterror_exception(self, remote_local_dir: Any):
         mock_remote_dir, _ = remote_local_dir(cloud_prefix='s3://')
-        cu = CloudUploader.get(mock_remote_dir, exist_ok=True, keep_local=True)
+        cu = CloudUploader.get(mock_remote_dir, keep_local=True)
         objs = cu.list_objects()
         if objs:
             assert (len(objs) == 0)
@@ -210,7 +213,7 @@ class TestS3Uploader:
     def test_invalid_cloud_prefix(self, remote_local_dir: Any):
         with pytest.raises(ValueError):
             mock_remote_dir, _ = remote_local_dir(cloud_prefix='s9://')
-            cu = CloudUploader.get(mock_remote_dir, exist_ok=True, keep_local=True)
+            cu = CloudUploader.get(mock_remote_dir, keep_local=True)
             _ = cu.list_objects()
 
     @pytest.mark.usefixtures('s3_client', 's3_test')
@@ -218,6 +221,7 @@ class TestS3Uploader:
         with tempfile.NamedTemporaryFile(delete=True, suffix='.txt') as tmp:
             filename = tmp.name.split(os.sep)[-1]
             local, _ = local_remote_dir
+            os.makedirs(local, exist_ok=True)
             remote = 's3://streaming-test-bucket/path'
             local_file_path = os.path.join(local, filename)
             s3w = S3Uploader(out=(local, remote))
@@ -274,22 +278,23 @@ class TestGCSUploader:
         with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = GCSUploader(out=out)
 
-    @pytest.mark.usefixtures('gcs_hmac_credentials')
-    def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
-        with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
-            local, _ = local_remote_dir
-            os.makedirs(local, exist_ok=True)
-            local_file_path = os.path.join(local, 'file.txt')
-            # Creating an empty file at specified location
-            with open(local_file_path, 'w') as _:
-                pass
-            _ = GCSUploader(out=local)
+    # @pytest.mark.usefixtures('gcs_hmac_credentials')
+    # def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
+    #     with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
+    #         local, _ = local_remote_dir
+    #         os.makedirs(local, exist_ok=True)
+    #         local_file_path = os.path.join(local, 'file.txt')
+    #         # Creating an empty file at specified location
+    #         with open(local_file_path, 'w') as _:
+    #             pass
+    #         _ = GCSUploader(out=local)
 
     @pytest.mark.usefixtures('gcs_hmac_client', 'gcs_test')
     def test_upload_file(self, local_remote_dir: Tuple[str, str]):
         with tempfile.NamedTemporaryFile(delete=True, suffix='.txt') as tmp:
             filename = tmp.name.split(os.sep)[-1]
             local, _ = local_remote_dir
+            os.makedirs(local, exist_ok=True)
             remote = 'gs://streaming-test-bucket/path'
             local_file_path = os.path.join(local, filename)
             gcsw = GCSUploader(out=(local, remote))
@@ -349,14 +354,14 @@ class TestGCSUploader:
     def test_invalid_cloud_prefix(self, remote_local_dir: Any):
         with pytest.raises(ValueError):
             mock_remote_dir, _ = remote_local_dir(cloud_prefix='gs9://')
-            cu = CloudUploader.get(mock_remote_dir, exist_ok=True, keep_local=True)
+            cu = CloudUploader.get(mock_remote_dir, keep_local=True)
             _ = cu.list_objects()
 
     def test_no_credentials_error(self, remote_local_dir: Any):
         """Ensure we raise a value error correctly if we have no credentials available."""
         with pytest.raises(ValueError):
             mock_remote_dir, _ = remote_local_dir(cloud_prefix='gs://')
-            cu = CloudUploader.get(mock_remote_dir, exist_ok=True, keep_local=True)
+            cu = CloudUploader.get(mock_remote_dir, keep_local=True)
             _ = cu.list_objects()
 
 
@@ -381,15 +386,15 @@ class TestAzureUploader:
         with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = AzureUploader(out=out)
 
-    def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
-        with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
-            local, _ = local_remote_dir
-            os.makedirs(local, exist_ok=True)
-            local_file_path = os.path.join(local, 'file.txt')
-            # Creating an empty file at specified location
-            with open(local_file_path, 'w') as _:
-                pass
-            _ = AzureUploader(out=local)
+    # def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
+    #     with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
+    #         local, _ = local_remote_dir
+    #         os.makedirs(local, exist_ok=True)
+    #         local_file_path = os.path.join(local, 'file.txt')
+    #         # Creating an empty file at specified location
+    #         with open(local_file_path, 'w') as _:
+    #             pass
+    #         _ = AzureUploader(out=local)
 
 
 class TestAzureDataLakeUploader:
@@ -414,15 +419,15 @@ class TestAzureDataLakeUploader:
         with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = AzureDataLakeUploader(out=out)
 
-    def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
-        with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
-            local, _ = local_remote_dir
-            os.makedirs(local, exist_ok=True)
-            local_file_path = os.path.join(local, 'file.txt')
-            # Creating an empty file at specified location
-            with open(local_file_path, 'w') as _:
-                pass
-            _ = AzureDataLakeUploader(out=local)
+    # def test_local_directory_is_empty(self, local_remote_dir: Tuple[str, str]):
+    #     with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
+    #         local, _ = local_remote_dir
+    #         os.makedirs(local, exist_ok=True)
+    #         local_file_path = os.path.join(local, 'file.txt')
+    #         # Creating an empty file at specified location
+    #         with open(local_file_path, 'w') as _:
+    #             pass
+    #         _ = AzureDataLakeUploader(out=local)
 
 
 class TestDatabricksUnityCatalogUploader:
@@ -443,18 +448,18 @@ class TestDatabricksUnityCatalogUploader:
         with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = DatabricksUnityCatalogUploader(out=out)
 
-    @patch('streaming.base.storage.upload.DatabricksUploader._create_workspace_client')
-    def test_local_directory_is_empty(self, mock_create_client: Mock,
-                                      local_remote_dir: Tuple[str, str]):
-        mock_create_client.side_effect = None
-        with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
-            local, _ = local_remote_dir
-            os.makedirs(local, exist_ok=True)
-            local_file_path = os.path.join(local, 'file.txt')
-            # Creating an empty file at specified location
-            with open(local_file_path, 'w') as _:
-                pass
-            _ = DatabricksUnityCatalogUploader(out=local)
+    # @patch('streaming.base.storage.upload.DatabricksUploader._create_workspace_client')
+    # def test_local_directory_is_empty(self, mock_create_client: Mock,
+    #                                   local_remote_dir: Tuple[str, str]):
+    #     mock_create_client.side_effect = None
+    #     with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
+    #         local, _ = local_remote_dir
+    #         os.makedirs(local, exist_ok=True)
+    #         local_file_path = os.path.join(local, 'file.txt')
+    #         # Creating an empty file at specified location
+    #         with open(local_file_path, 'w') as _:
+    #             pass
+    #         _ = DatabricksUnityCatalogUploader(out=local)
 
 
 class TestDBFSUploader:
@@ -474,24 +479,25 @@ class TestDBFSUploader:
         with pytest.raises(ValueError, match=f'Invalid Cloud provider prefix.*'):
             _ = DBFSUploader(out=out)
 
-    @patch('streaming.base.storage.upload.DatabricksUploader._create_workspace_client')
-    def test_local_directory_is_empty(self, mock_create_client: Mock,
-                                      local_remote_dir: Tuple[str, str]):
-        with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
-            mock_create_client.side_effect = None
-            local, _ = local_remote_dir
-            os.makedirs(local, exist_ok=True)
-            local_file_path = os.path.join(local, 'file.txt')
-            # Creating an empty file at specified location
-            with open(local_file_path, 'w') as _:
-                pass
-            _ = DBFSUploader(out=local)
+    # @patch('streaming.base.storage.upload.DatabricksUploader._create_workspace_client')
+    # def test_local_directory_is_empty(self, mock_create_client: Mock,
+    #                                   local_remote_dir: Tuple[str, str]):
+    #     with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
+    #         mock_create_client.side_effect = None
+    #         local, _ = local_remote_dir
+    #         os.makedirs(local, exist_ok=True)
+    #         local_file_path = os.path.join(local, 'file.txt')
+    #         # Creating an empty file at specified location
+    #         with open(local_file_path, 'w') as _:
+    #             pass
+    #         _ = DBFSUploader(out=local)
 
 
 class TestLocalUploader:
 
     def test_upload_file(self, local_remote_dir: Tuple[str, str]):
         local, remote = local_remote_dir
+        os.makedirs(local, exist_ok=True)
         filename = 'file.txt'
         local_file_path = os.path.join(local, filename)
         remote_file_path = os.path.join(remote, filename)
@@ -511,6 +517,7 @@ class TestLocalUploader:
 
     def test_upload_file_remote_none(self, local_remote_dir: Tuple[str, str]):
         local, remote = local_remote_dir
+        os.makedirs(local, exist_ok=True)
         filename = 'file.txt'
         local_file_path = os.path.join(local, filename)
         remote_file_path = os.path.join(remote, filename)
@@ -523,6 +530,7 @@ class TestLocalUploader:
 
     def test_upload_file_from_local_to_remote(self, local_remote_dir: Tuple[str, str]):
         local, remote = local_remote_dir
+        os.makedirs(local, exist_ok=True)
         filename = 'file.txt'
         local_file_path = os.path.join(local, filename)
         remote_file_path = os.path.join(remote, filename)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -137,13 +137,13 @@ def integrity_check(out: Union[str, Tuple[str, str]],
 
     def get_expected(mds_root: str):
         n_shard_files = 0
-        cu = CloudUploader.get(mds_root, exist_ok=True, keep_local=True)
+        cu = CloudUploader.get(mds_root, keep_local=True)
         for o in cu.list_objects():
             if o.endswith('.mds'):
                 n_shard_files += 1
         return n_shard_files
 
-    cu = CloudUploader.get(out, keep_local=True, exist_ok=True)
+    cu = CloudUploader.get(out, keep_local=True)
 
     with tempfile.TemporaryDirectory() as temp_dir:
         if cu.remote:
@@ -210,7 +210,7 @@ def test_merge_index_from_list_local(local_remote_dir: Tuple[str, str], keep_loc
     mds_kwargs = {'out': mds_out, 'columns': {'id': 'int', 'name': 'str'}, 'keep_local': True}
     dataframeToMDS(df, merge_index=False, mds_kwargs=mds_kwargs)
 
-    local_cu = CloudUploader.get(local, exist_ok=True, keep_local=True)
+    local_cu = CloudUploader.get(local, keep_local=True)
     local_index_files = [
         o for o in local_cu.list_objects() if o.endswith('.json') and not_merged_index(o, local)
     ]

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -256,3 +256,28 @@ class TestXSVWriter:
         # Ensure sample iterator is deterministic
         for before, after in zip(dataset, mds_dataset):
             assert before == after
+
+
+def test_dir_exist_and_non_empty(local_remote_dir: Tuple[str, str]):
+    local, _ = local_remote_dir
+    os.makedirs(local, exist_ok=True)
+    local_file_path = os.path.join(local, 'file.txt')
+    # Creating an empty file at specified location
+    with open(local_file_path, 'w') as _:
+        pass
+    columns = {'tokens': 'bytes'}
+    with pytest.raises(FileExistsError, match=f'Directory is not empty.*'):
+        _ = MDSWriter(out=local, columns=columns)
+
+
+def test_dir_exist_and_non_empty_and_overwrite(caplog: Any, local_remote_dir: Tuple[str, str]):
+    caplog.set_level(logging.WARNING)
+    local, _ = local_remote_dir
+    os.makedirs(local, exist_ok=True)
+    local_file_path = os.path.join(local, 'file.txt')
+    # Creating an empty file at specified location
+    with open(local_file_path, 'w') as _:
+        pass
+    columns = {'tokens': 'bytes'}
+    _ = MDSWriter(out=local, columns=columns, exist_ok=True)
+    assert 'exists and not empty since you' in caplog.text


### PR DESCRIPTION
## Description of changes:
- Moved local directory creation and existence check from CloudUploader to Writer class

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
