### PR TITLE
Dataset kwargs switchover.

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -3,10 +3,12 @@ name: Installation
 on:
   push:
     branches:
+      - dev
       - main
       - release/*
   pull_request:
     branches:
+      - dev
       - main
       - release/*
   workflow_dispatch: {}

--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -3,10 +3,12 @@ name: Linting
 on:
   push:
     branches:
+      - dev
       - main
       - release/*
   pull_request:
     branches:
+      - dev
       - main
       - release/*
   workflow_call:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -3,10 +3,12 @@ name: Test
 on:
   push:
     branches:
+      - dev
       - main
       - release/*
   pull_request:
     branches:
+      - dev
       - main
       - release/*
   workflow_call:

--- a/examples/multimodal/webvid/read.py
+++ b/examples/multimodal/webvid/read.py
@@ -5,7 +5,7 @@
 
 import os
 from time import sleep
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from streaming import StreamingDataset
 from streaming.dataset import TICK, _Iterator
@@ -18,57 +18,11 @@ class StreamingInsideWebVid(StreamingDataset):
     Videos are stored "inside" the shards, as is typically done.
 
     Args:
-        remote (str, optional): Remote path or directory to download the dataset from. If ``None``,
-            its data must exist locally. StreamingDataset uses either ``streams`` or
-            ``remote``/``local``. Defaults to ``None``.
-        local (str, optional): Local working directory to download shards to. This is where shards
-            are cached while they are being used. Uses a temp directory if not set.
-            StreamingDataset uses either ``streams`` or ``remote``/``local``. Defaults to ``None``.
-        split (str, optional): Which dataset split to use, if any. If provided, we stream from/to
-            the ``split`` subdirs of  ``remote`` and ``local``. Defaults to ``None``.
-        download_retry (int): Number of download re-attempts before giving up. Defaults to ``2``.
-        download_timeout (float): Number of seconds to wait for a shard to download before raising
-            an exception. Defaults to ``60``.
-        validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
-            shards. Defaults to ``None``.
-        keep_zip (bool): Whether to keep or delete the compressed form when decompressing
-            downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
-            ``False``.
-        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
-            streams. If ``None``, takes its value from the total number of underlying samples.
-            Provide this field if you are weighting streams relatively to target a larger or
-            smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download per worker in advance
-            of current sample. Workers will attempt to download ahead by this many samples during,
-            but not before, training. Recommendation is to provide a value greater than per device
-            batch size to ensure at-least per device batch size number of samples cached locally.
-            If ``None``, its value gets derived using per device batch size and number of
-            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
-            Defaults to ``None``.
-        cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
-            Before downloading a shard, the least recently used resident shard(s) may be evicted
-            (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
-            disable shard eviction. Defaults to ``None``.
-        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
-        num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. The sample space is divided evenly according to the number of canonical
-            nodes. The higher the value, the more independent non-overlapping paths the
-            StreamingDataset replicas take through the shards per model replica (increasing data
-            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
-            of nodes of the initial run.
-
-            .. note::
-
-                For sequential sample ordering, set ``shuffle`` to ``False`` and
-                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
-        batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
-            partitioned over the workers. Defaults to ``None``.
-        shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to
-            ``False``.
-        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py1s``.
-        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
-        shuffle_block_size (int): Unit of shuffle. Defaults to ``1 << 18``.
+        **kwargs (Dict[str, Any]): Keyword arguments.
     """
+
+    def __init__(self, **kwargs: Dict[str, Any]) -> None:
+        super().__init__(**kwargs)
 
     def get_item(self, idx: int) -> Any:
         """Get the sample at the index.
@@ -91,101 +45,18 @@ class StreamingOutsideGIWebVid(StreamingDataset):
     get_item ("GI"), when samples are requested by the dataloader.
 
     Args:
-        remote (str, optional): Remote path or directory to download the dataset from. If ``None``,
-            its data must exist locally. StreamingDataset uses either ``streams`` or
-            ``remote``/``local``. Defaults to ``None``.
-        local (str, optional): Local working directory to download shards to. This is where shards
-            are cached while they are being used. Uses a temp directory if not set.
-            StreamingDataset uses either ``streams`` or ``remote``/``local``. Defaults to ``None``.
-        split (str, optional): Which dataset split to use, if any. If provided, we stream from/to
-            the ``split`` subdirs of  ``remote`` and ``local``. Defaults to ``None``.
-        download_retry (int): Number of download re-attempts before giving up. Defaults to ``2``.
-        download_timeout (float): Number of seconds to wait for a shard to download before raising
-            an exception. Defaults to ``60``.
-        validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
-            shards. Defaults to ``None``.
-        keep_zip (bool): Whether to keep or delete the compressed form when decompressing
-            downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
-            ``False``.
-        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
-            streams. If ``None``, takes its value from the total number of underlying samples.
-            Provide this field if you are weighting streams relatively to target a larger or
-            smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download per worker in advance
-            of current sample. Workers will attempt to download ahead by this many samples during,
-            but not before, training. Recommendation is to provide a value greater than per device
-            batch size to ensure at-least per device batch size number of samples cached locally.
-            If ``None``, its value gets derived using per device batch size and number of
-            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
-            Defaults to ``None``.
-        cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
-            Before downloading a shard, the least recently used resident shard(s) may be evicted
-            (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
-            disable shard eviction. Defaults to ``None``.
-        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
-        num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. The sample space is divided evenly according to the number of canonical
-            nodes. The higher the value, the more independent non-overlapping paths the
-            StreamingDataset replicas take through the shards per model replica (increasing data
-            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
-            of nodes of the initial run.
-
-            .. note::
-
-                For sequential sample ordering, set ``shuffle`` to ``False`` and
-                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
-        batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
-            partitioned over the workers. Defaults to ``None``.
-        shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to
-            ``False``.
-        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py1s``.
-        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
-        shuffle_block_size (int): Unit of shuffle. Defaults to ``1 << 18``.
         extra_local (str, optional): Base destination of extra local sample downloads.
         extra_remote (str, optional): Base source of extra remote sample downloads.
+        **kwargs (Dict[str, Any]): Keyword arguments.
     """
 
     def __init__(self,
-                 *,
-                 remote: Optional[str] = None,
-                 local: Optional[str] = None,
-                 split: Optional[str] = None,
-                 download_retry: int = 2,
-                 download_timeout: float = 60,
-                 validate_hash: Optional[str] = None,
-                 keep_zip: bool = False,
-                 epoch_size: Optional[int] = None,
-                 predownload: Optional[int] = None,
-                 cache_limit: Optional[int] = None,
-                 partition_algo: str = 'orig',
-                 num_canonical_nodes: Optional[int] = None,
-                 batch_size: Optional[int] = None,
-                 shuffle: bool = False,
-                 shuffle_algo: str = 'py1s',
-                 shuffle_seed: int = 9176,
-                 shuffle_block_size: int = 1 << 18,
                  extra_local: Optional[str] = None,
-                 extra_remote: Optional[str] = None) -> None:
-        super().__init__(remote=remote,
-                         local=local,
-                         split=split,
-                         download_retry=download_retry,
-                         download_timeout=download_timeout,
-                         validate_hash=validate_hash,
-                         keep_zip=keep_zip,
-                         epoch_size=epoch_size,
-                         predownload=predownload,
-                         cache_limit=cache_limit,
-                         partition_algo=partition_algo,
-                         num_canonical_nodes=num_canonical_nodes,
-                         batch_size=batch_size,
-                         shuffle=shuffle,
-                         shuffle_algo=shuffle_algo,
-                         shuffle_seed=shuffle_seed,
-                         shuffle_block_size=shuffle_block_size)
-
+                 extra_remote: Optional[str] = None,
+                 **kwargs: Dict[str, Any]) -> None:
+        super().__init__(**kwargs)
         # Videos are stored outside of their shards here.
-        self.download_timeout = download_timeout
+        self.download_timeout = self.streams[0].download_timeout
         self.extra_local = extra_local
         self.extra_remote = extra_remote
 
@@ -222,101 +93,18 @@ class StreamingOutsideDTWebVid(StreamingDataset):
     _download_thread ("DT"), when the download thread prefetches the sample.
 
     Args:
-        remote (str, optional): Remote path or directory to download the dataset from. If ``None``,
-            its data must exist locally. StreamingDataset uses either ``streams`` or
-            ``remote``/``local``. Defaults to ``None``.
-        local (str, optional): Local working directory to download shards to. This is where shards
-            are cached while they are being used. Uses a temp directory if not set.
-            StreamingDataset uses either ``streams`` or ``remote``/``local``. Defaults to ``None``.
-        split (str, optional): Which dataset split to use, if any. If provided, we stream from/to
-            the ``split`` subdirs of  ``remote`` and ``local``. Defaults to ``None``.
-        download_retry (int): Number of download re-attempts before giving up. Defaults to ``2``.
-        download_timeout (float): Number of seconds to wait for a shard to download before raising
-            an exception. Defaults to ``60``.
-        validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
-            shards. Defaults to ``None``.
-        keep_zip (bool): Whether to keep or delete the compressed form when decompressing
-            downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
-            ``False``.
-        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
-            streams. If ``None``, takes its value from the total number of underlying samples.
-            Provide this field if you are weighting streams relatively to target a larger or
-            smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download per worker in advance
-            of current sample. Workers will attempt to download ahead by this many samples during,
-            but not before, training. Recommendation is to provide a value greater than per device
-            batch size to ensure at-least per device batch size number of samples cached locally.
-            If ``None``, its value gets derived using per device batch size and number of
-            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
-            Defaults to ``None``.
-        cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
-            Before downloading a shard, the least recently used resident shard(s) may be evicted
-            (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
-            disable shard eviction. Defaults to ``None``.
-        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
-        num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. The sample space is divided evenly according to the number of canonical
-            nodes. The higher the value, the more independent non-overlapping paths the
-            StreamingDataset replicas take through the shards per model replica (increasing data
-            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
-            of nodes of the initial run.
-
-            .. note::
-
-                For sequential sample ordering, set ``shuffle`` to ``False`` and
-                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
-        batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
-            partitioned over the workers. Defaults to ``None``.
-        shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to
-            ``False``.
-        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py1s``.
-        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
-        shuffle_block_size (int): Unit of shuffle. Defaults to ``1 << 18``.
         extra_local (str, optional): Base destination of extra local sample downloads.
         extra_remote (str, optional): Base source of extra remote sample downloads.
+        **kwargs (Dict[str, Any]): Keyword arguments.
     """
 
     def __init__(self,
-                 *,
-                 remote: Optional[str] = None,
-                 local: Optional[str] = None,
-                 split: Optional[str] = None,
-                 download_retry: int = 2,
-                 download_timeout: float = 60,
-                 validate_hash: Optional[str] = None,
-                 keep_zip: bool = False,
-                 epoch_size: Optional[int] = None,
-                 predownload: Optional[int] = None,
-                 cache_limit: Optional[int] = None,
-                 partition_algo: str = 'orig',
-                 num_canonical_nodes: Optional[int] = None,
-                 batch_size: Optional[int] = None,
-                 shuffle: bool = False,
-                 shuffle_algo: str = 'py1s',
-                 shuffle_seed: int = 9176,
-                 shuffle_block_size: int = 1 << 18,
                  extra_local: Optional[str] = None,
-                 extra_remote: Optional[str] = None) -> None:
-        super().__init__(remote=remote,
-                         local=local,
-                         split=split,
-                         download_retry=download_retry,
-                         download_timeout=download_timeout,
-                         validate_hash=validate_hash,
-                         keep_zip=keep_zip,
-                         epoch_size=epoch_size,
-                         predownload=predownload,
-                         cache_limit=cache_limit,
-                         partition_algo=partition_algo,
-                         num_canonical_nodes=num_canonical_nodes,
-                         batch_size=batch_size,
-                         shuffle=shuffle,
-                         shuffle_algo=shuffle_algo,
-                         shuffle_seed=shuffle_seed,
-                         shuffle_block_size=shuffle_block_size)
-
+                 extra_remote: Optional[str] = None,
+                 **kwargs: Dict[str, Any]) -> None:
+        super().__init__(**kwargs)
         # Videos are stored outside of their shards here.
-        self.download_timeout = download_timeout
+        self.download_timeout = self.streams[0].download_timeout
         self.extra_local = extra_local
         self.extra_remote = extra_remote
 

--- a/examples/text/c4/read.py
+++ b/examples/text/c4/read.py
@@ -7,7 +7,7 @@ This dataset is a colossal, cleaned version of Common Crawl's web crawl corpus a
 the `Common Crawl <https://commoncrawl.org>`_ dataset.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from transformers.models.auto.tokenization_auto import AutoTokenizer
 
@@ -20,104 +20,19 @@ class StreamingC4(StreamingDataset):
     """Implementation of the C4 (Colossal Cleaned Common Crawl) dataset using StreamingDataset.
 
     Args:
-        remote (str, optional): Remote path or directory to download the dataset from. If ``None``,
-            its data must exist locally. StreamingDataset uses either ``streams`` or
-            ``remote``/``local``. Defaults to ``None``.
-        local (str, optional): Local working directory to download shards to. This is where shards
-            are cached while they are being used. Uses a temp directory if not set.
-            StreamingDataset uses either ``streams`` or ``remote``/``local``. Defaults to ``None``.
-        split (str, optional): Which dataset split to use, if any. If provided, we stream from/to
-            the ``split`` subdirs of  ``remote`` and ``local``. Defaults to ``None``.
-        download_retry (int): Number of download re-attempts before giving up. Defaults to ``2``.
-        download_timeout (float): Number of seconds to wait for a shard to download before raising
-            an exception. Defaults to ``60``.
-        validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
-            shards. Defaults to ``None``.
-        keep_zip (bool): Whether to keep or delete the compressed form when decompressing
-            downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
-            ``False``.
-        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
-            streams. If ``None``, takes its value from the total number of underlying samples.
-            Provide this field if you are weighting streams relatively to target a larger or
-            smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download per worker in advance
-            of current sample. Workers will attempt to download ahead by this many samples during,
-            but not before, training. Recommendation is to provide a value greater than per device
-            batch size to ensure at-least per device batch size number of samples cached locally.
-            If ``None``, its value gets derived using per device batch size and number of
-            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
-            Defaults to ``None``.
-        cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
-            Before downloading a shard, the least recently used resident shard(s) may be evicted
-            (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
-            disable shard eviction. Defaults to ``None``.
-        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
-        num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. The sample space is divided evenly according to the number of canonical
-            nodes. The higher the value, the more independent non-overlapping paths the
-            StreamingDataset replicas take through the shards per model replica (increasing data
-            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
-            of nodes of the initial run.
-
-            .. note::
-
-                For sequential sample ordering, set ``shuffle`` to ``False`` and
-                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
-        batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
-            partitioned over the workers. Defaults to ``None``.
-        shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to
-            ``False``.
-        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py1s``.
-        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
-        shuffle_block_size (int): Unit of shuffle. Defaults to ``1 << 18``.
         tokenizer_name (str): The name of the HuggingFace tokenizer to use to tokenize samples.
         max_seq_len (int): The max sequence length of each token sample.
         group_method (str): How to group text samples into token samples. Currently only supporting
             ``'truncate'``.
+        **kwargs (Dict[str, Any]): Keyword arguments.
     """
 
-    def __init__(self,
-                 *,
-                 remote: Optional[str] = None,
-                 local: Optional[str] = None,
-                 split: Optional[str] = None,
-                 download_retry: int = 2,
-                 download_timeout: float = 60,
-                 validate_hash: Optional[str] = None,
-                 keep_zip: bool = False,
-                 epoch_size: Optional[int] = None,
-                 predownload: Optional[int] = None,
-                 cache_limit: Optional[int] = None,
-                 partition_algo: str = 'orig',
-                 num_canonical_nodes: Optional[int] = None,
-                 batch_size: Optional[int] = None,
-                 shuffle: bool = False,
-                 shuffle_algo: str = 'py1s',
-                 shuffle_seed: int = 9176,
-                 shuffle_block_size: int = 1 << 18,
-                 tokenizer_name: str,
-                 max_seq_len: int,
-                 group_method: str) -> None:
+    def __init__(self, *, tokenizer_name: str, max_seq_len: int, group_method: str,
+                 **kwargs: Dict[str, Any]) -> None:
         if group_method not in {'truncate'}:
             raise ValueError(f"group_method='{group_method}' must be one of {'truncate'}.")
 
-        super().__init__(remote=remote,
-                         local=local,
-                         split=split,
-                         download_retry=download_retry,
-                         download_timeout=download_timeout,
-                         validate_hash=validate_hash,
-                         keep_zip=keep_zip,
-                         epoch_size=epoch_size,
-                         predownload=predownload,
-                         cache_limit=cache_limit,
-                         partition_algo=partition_algo,
-                         num_canonical_nodes=num_canonical_nodes,
-                         batch_size=batch_size,
-                         shuffle=shuffle,
-                         shuffle_algo=shuffle_algo,
-                         shuffle_seed=shuffle_seed,
-                         shuffle_block_size=shuffle_block_size)
+        super().__init__(**kwargs)
 
         self.tokenizer_name = tokenizer_name
         self.max_seq_len = max_seq_len

--- a/examples/text/enwiki_txt/read.py
+++ b/examples/text/enwiki_txt/read.py
@@ -3,7 +3,7 @@
 
 """English Wikipedia 2020-01-01 streaming dataset."""
 
-from typing import Any, Optional
+from typing import Any, Dict
 
 import numpy as np
 
@@ -16,94 +16,11 @@ class StreamingEnWiki(StreamingDataset):
     """Implementation of the English Wikipedia 2020-01-01 streaming dataset.
 
     Args:
-        remote (str, optional): Remote path or directory to download the dataset from. If ``None``,
-            its data must exist locally. StreamingDataset uses either ``streams`` or
-            ``remote``/``local``. Defaults to ``None``.
-        local (str, optional): Local working directory to download shards to. This is where shards
-            are cached while they are being used. Uses a temp directory if not set.
-            StreamingDataset uses either ``streams`` or ``remote``/``local``. Defaults to ``None``.
-        split (str, optional): Which dataset split to use, if any. If provided, we stream from/to
-            the ``split`` subdirs of  ``remote`` and ``local``. Defaults to ``None``.
-        download_retry (int): Number of download re-attempts before giving up. Defaults to ``2``.
-        download_timeout (float): Number of seconds to wait for a shard to download before raising
-            an exception. Defaults to ``60``.
-        validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
-            shards. Defaults to ``None``.
-        keep_zip (bool): Whether to keep or delete the compressed form when decompressing
-            downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
-            ``False``.
-        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
-            streams. If ``None``, takes its value from the total number of underlying samples.
-            Provide this field if you are weighting streams relatively to target a larger or
-            smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download per worker in advance
-            of current sample. Workers will attempt to download ahead by this many samples during,
-            but not before, training. Recommendation is to provide a value greater than per device
-            batch size to ensure at-least per device batch size number of samples cached locally.
-            If ``None``, its value gets derived using per device batch size and number of
-            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
-            Defaults to ``None``.
-        cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
-            Before downloading a shard, the least recently used resident shard(s) may be evicted
-            (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
-            disable shard eviction. Defaults to ``None``.
-        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
-        num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. The sample space is divided evenly according to the number of canonical
-            nodes. The higher the value, the more independent non-overlapping paths the
-            StreamingDataset replicas take through the shards per model replica (increasing data
-            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
-            of nodes of the initial run.
-
-            .. note::
-
-                For sequential sample ordering, set ``shuffle`` to ``False`` and
-                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
-        batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
-            partitioned over the workers. Defaults to ``None``.
-        shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to
-            ``False``.
-        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py1s``.
-        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
-        shuffle_block_size (int): Unit of shuffle. Defaults to ``1 << 18``.
+        **kwargs (Dict[str, Any]): Keyword arguments.
     """
 
-    def __init__(self,
-                 *,
-                 remote: Optional[str] = None,
-                 local: Optional[str] = None,
-                 split: Optional[str] = None,
-                 download_retry: int = 2,
-                 download_timeout: float = 60,
-                 validate_hash: Optional[str] = None,
-                 keep_zip: bool = False,
-                 epoch_size: Optional[int] = None,
-                 predownload: Optional[int] = None,
-                 cache_limit: Optional[int] = None,
-                 partition_algo: str = 'orig',
-                 num_canonical_nodes: Optional[int] = None,
-                 batch_size: Optional[int] = None,
-                 shuffle: bool = False,
-                 shuffle_algo: str = 'py1s',
-                 shuffle_seed: int = 9176,
-                 shuffle_block_size: int = 1 << 18) -> None:
-        super().__init__(remote=remote,
-                         local=local,
-                         split=split,
-                         download_retry=download_retry,
-                         download_timeout=download_timeout,
-                         validate_hash=validate_hash,
-                         keep_zip=keep_zip,
-                         epoch_size=epoch_size,
-                         predownload=predownload,
-                         cache_limit=cache_limit,
-                         partition_algo=partition_algo,
-                         num_canonical_nodes=num_canonical_nodes,
-                         batch_size=batch_size,
-                         shuffle=shuffle,
-                         shuffle_algo=shuffle_algo,
-                         shuffle_seed=shuffle_seed,
-                         shuffle_block_size=shuffle_block_size)
+    def __init__(self, **kwargs: Dict[str, Any]) -> None:
+        super().__init__(**kwargs)
         self.field_dtypes = {
             'input_ids': np.int32,
             'input_mask': np.int32,

--- a/examples/text/pile/read.py
+++ b/examples/text/pile/read.py
@@ -7,7 +7,7 @@ The Pile is a 825 GiB diverse, open source language modelling data set that cons
 high-quality datasets combined together.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from transformers.models.auto.tokenization_auto import AutoTokenizer
 
@@ -20,104 +20,19 @@ class StreamingPile(StreamingDataset):
     """Implementation of the the Pile using StreamingDataset.
 
     Args:
-        remote (str, optional): Remote path or directory to download the dataset from. If ``None``,
-            its data must exist locally. StreamingDataset uses either ``streams`` or
-            ``remote``/``local``. Defaults to ``None``.
-        local (str, optional): Local working directory to download shards to. This is where shards
-            are cached while they are being used. Uses a temp directory if not set.
-            StreamingDataset uses either ``streams`` or ``remote``/``local``. Defaults to ``None``.
-        split (str, optional): Which dataset split to use, if any. If provided, we stream from/to
-            the ``split`` subdirs of  ``remote`` and ``local``. Defaults to ``None``.
-        download_retry (int): Number of download re-attempts before giving up. Defaults to ``2``.
-        download_timeout (float): Number of seconds to wait for a shard to download before raising
-            an exception. Defaults to ``60``.
-        validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
-            shards. Defaults to ``None``.
-        keep_zip (bool): Whether to keep or delete the compressed form when decompressing
-            downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
-            ``False``.
-        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
-            streams. If ``None``, takes its value from the total number of underlying samples.
-            Provide this field if you are weighting streams relatively to target a larger or
-            smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download per worker in advance
-            of current sample. Workers will attempt to download ahead by this many samples during,
-            but not before, training. Recommendation is to provide a value greater than per device
-            batch size to ensure at-least per device batch size number of samples cached locally.
-            If ``None``, its value gets derived using per device batch size and number of
-            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
-            Defaults to ``None``.
-        cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
-            Before downloading a shard, the least recently used resident shard(s) may be evicted
-            (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
-            disable shard eviction. Defaults to ``None``.
-        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
-        num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. The sample space is divided evenly according to the number of canonical
-            nodes. The higher the value, the more independent non-overlapping paths the
-            StreamingDataset replicas take through the shards per model replica (increasing data
-            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
-            of nodes of the initial run.
-
-            .. note::
-
-                For sequential sample ordering, set ``shuffle`` to ``False`` and
-                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
-        batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
-            partitioned over the workers. Defaults to ``None``.
-        shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to
-            ``False``.
-        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py1s``.
-        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
-        shuffle_block_size (int): Unit of shuffle. Defaults to ``1 << 18``.
         tokenizer_name (str): The name of the HuggingFace tokenizer to use to tokenize samples.
         max_seq_len (int): The max sequence length of each token sample.
         group_method (str): How to group text samples into token samples. Currently only supporting
             ``'truncate'``.
+        **kwargs (Dict[str, Any]): Keyword arguments.
     """
 
-    def __init__(self,
-                 *,
-                 remote: Optional[str] = None,
-                 local: Optional[str] = None,
-                 split: Optional[str] = None,
-                 download_retry: int = 2,
-                 download_timeout: float = 60,
-                 validate_hash: Optional[str] = None,
-                 keep_zip: bool = False,
-                 epoch_size: Optional[int] = None,
-                 predownload: Optional[int] = None,
-                 cache_limit: Optional[int] = None,
-                 partition_algo: str = 'orig',
-                 num_canonical_nodes: Optional[int] = None,
-                 batch_size: Optional[int] = None,
-                 shuffle: bool = False,
-                 shuffle_algo: str = 'py1s',
-                 shuffle_seed: int = 9176,
-                 shuffle_block_size: int = 1 << 18,
-                 tokenizer_name: str,
-                 max_seq_len: int,
-                 group_method: str) -> None:
-        if group_method not in ['truncate']:
-            raise ValueError(f'Only group_method="truncate" is supported at this time.')
+    def __init__(self, *, tokenizer_name: str, max_seq_len: int, group_method: str,
+                 **kwargs: Dict[str, Any]) -> None:
+        if group_method not in {'truncate'}:
+            raise ValueError(f"group_method='{group_method}' must be one of {'truncate'}.")
 
-        super().__init__(remote=remote,
-                         local=local,
-                         split=split,
-                         download_retry=download_retry,
-                         download_timeout=download_timeout,
-                         validate_hash=validate_hash,
-                         keep_zip=keep_zip,
-                         epoch_size=epoch_size,
-                         predownload=predownload,
-                         cache_limit=cache_limit,
-                         partition_algo=partition_algo,
-                         num_canonical_nodes=num_canonical_nodes,
-                         batch_size=batch_size,
-                         shuffle=shuffle,
-                         shuffle_algo=shuffle_algo,
-                         shuffle_seed=shuffle_seed,
-                         shuffle_block_size=shuffle_block_size)
+        super().__init__(**kwargs)
 
         self.tokenizer_name = tokenizer_name
         self.max_seq_len = max_seq_len
@@ -140,9 +55,7 @@ class StreamingPile(StreamingDataset):
             padding = 'max_length'
             max_length = self.max_seq_len
         else:
-            truncation = False
-            padding = False
-            max_length = None
+            raise ValueError(f'Got unknown group_method={self.group_method}.')
         return self.tokenizer(text_sample['text'],
                               truncation=truncation,
                               padding=padding,

--- a/examples/vision/ade20k/read.py
+++ b/examples/vision/ade20k/read.py
@@ -24,7 +24,7 @@ class StreamingADE20K(StreamingDataset):
             transformed version. Defaults to ``None``.
         target_transform (callable, optional): A function/transform that takes in the target and
             transforms it. Defaults to ``None``.
-        kwargs (Dict[str, Any]): Keyword arguments.
+        **kwargs (Dict[str, Any]): Keyword arguments.
     """
 
     def __init__(self,

--- a/examples/vision/ade20k/read.py
+++ b/examples/vision/ade20k/read.py
@@ -18,11 +18,11 @@ class StreamingADE20K(StreamingDataset):
     """Implementation of the ADE20K dataset using StreamingDataset.
 
     Args:
-        joint_transform (callable, optional): A function/transforms that takes in an image and a
+        joint_transform (Callable, optional): A function/transforms that takes in an image and a
             target  and returns the transformed versions of both. Defaults to ``None``.
-        transform (callable, optional): A function/transform that takes in an image and returns a
+        transform (Callable, optional): A function/transform that takes in an image and returns a
             transformed version. Defaults to ``None``.
-        target_transform (callable, optional): A function/transform that takes in the target and
+        target_transform (Callable, optional): A function/transform that takes in the target and
             transforms it. Defaults to ``None``.
         **kwargs (Dict[str, Any]): Keyword arguments.
     """

--- a/examples/vision/ade20k/read.py
+++ b/examples/vision/ade20k/read.py
@@ -7,7 +7,7 @@ Please refer to the `ADE20K dataset <https://groups.csail.mit.edu/vision/dataset
 more details about this dataset.
 """
 
-from typing import Any, Callable, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
 from streaming import StreamingDataset
 
@@ -18,103 +18,22 @@ class StreamingADE20K(StreamingDataset):
     """Implementation of the ADE20K dataset using StreamingDataset.
 
     Args:
-        remote (str, optional): Remote path or directory to download the dataset from. If ``None``,
-            its data must exist locally. StreamingDataset uses either ``streams`` or
-            ``remote``/``local``. Defaults to ``None``.
-        local (str, optional): Local working directory to download shards to. This is where shards
-            are cached while they are being used. Uses a temp directory if not set.
-            StreamingDataset uses either ``streams`` or ``remote``/``local``. Defaults to ``None``.
-        split (str, optional): Which dataset split to use, if any. If provided, we stream from/to
-            the ``split`` subdirs of  ``remote`` and ``local``. Defaults to ``None``.
-        download_retry (int): Number of download re-attempts before giving up. Defaults to ``2``.
-        download_timeout (float): Number of seconds to wait for a shard to download before raising
-            an exception. Defaults to ``60``.
-        validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
-            shards. Defaults to ``None``.
-        keep_zip (bool): Whether to keep or delete the compressed form when decompressing
-            downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
-            ``False``.
-        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
-            streams. If ``None``, takes its value from the total number of underlying samples.
-            Provide this field if you are weighting streams relatively to target a larger or
-            smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download per worker in advance
-            of current sample. Workers will attempt to download ahead by this many samples during,
-            but not before, training. Recommendation is to provide a value greater than per device
-            batch size to ensure at-least per device batch size number of samples cached locally.
-            If ``None``, its value gets derived using per device batch size and number of
-            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
-            Defaults to ``None``.
-        cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
-            Before downloading a shard, the least recently used resident shard(s) may be evicted
-            (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
-            disable shard eviction. Defaults to ``None``.
-        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
-        num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. The sample space is divided evenly according to the number of canonical
-            nodes. The higher the value, the more independent non-overlapping paths the
-            StreamingDataset replicas take through the shards per model replica (increasing data
-            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
-            of nodes of the initial run.
-
-            .. note::
-
-                For sequential sample ordering, set ``shuffle`` to ``False`` and
-                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
-        batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
-            partitioned over the workers. Defaults to ``None``.
-        shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to
-            ``False``.
-        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py1s``.
-        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
-        shuffle_block_size (int): Unit of shuffle. Defaults to ``1 << 18``.
         joint_transform (callable, optional): A function/transforms that takes in an image and a
             target  and returns the transformed versions of both. Defaults to ``None``.
         transform (callable, optional): A function/transform that takes in an image and returns a
             transformed version. Defaults to ``None``.
         target_transform (callable, optional): A function/transform that takes in the target and
             transforms it. Defaults to ``None``.
+        kwargs (Dict[str, Any]): Keyword arguments.
     """
 
     def __init__(self,
                  *,
-                 remote: Optional[str] = None,
-                 local: Optional[str] = None,
-                 split: Optional[str] = None,
-                 download_retry: int = 2,
-                 download_timeout: float = 60,
-                 validate_hash: Optional[str] = None,
-                 keep_zip: bool = False,
-                 epoch_size: Optional[int] = None,
-                 predownload: Optional[int] = None,
-                 partition_algo: str = 'orig',
-                 cache_limit: Optional[int] = None,
-                 num_canonical_nodes: Optional[int] = None,
-                 batch_size: Optional[int] = None,
-                 shuffle: bool = False,
-                 shuffle_algo: str = 'py1s',
-                 shuffle_seed: int = 9176,
-                 shuffle_block_size: int = 1 << 18,
                  joint_transform: Optional[Callable] = None,
                  transform: Optional[Callable] = None,
-                 target_transform: Optional[Callable] = None) -> None:
-        super().__init__(remote=remote,
-                         local=local,
-                         split=split,
-                         download_retry=download_retry,
-                         download_timeout=download_timeout,
-                         validate_hash=validate_hash,
-                         keep_zip=keep_zip,
-                         epoch_size=epoch_size,
-                         predownload=predownload,
-                         cache_limit=cache_limit,
-                         partition_algo=partition_algo,
-                         num_canonical_nodes=num_canonical_nodes,
-                         batch_size=batch_size,
-                         shuffle=shuffle,
-                         shuffle_algo=shuffle_algo,
-                         shuffle_seed=shuffle_seed,
-                         shuffle_block_size=shuffle_block_size)
+                 target_transform: Optional[Callable] = None,
+                 **kwargs: Dict[str, Any]) -> None:
+        super().__init__(**kwargs)
         self.joint_transform = joint_transform
         self.transform = transform
         self.target_transform = target_transform

--- a/examples/vision/cifar10/read.py
+++ b/examples/vision/cifar10/read.py
@@ -18,7 +18,7 @@ class StreamingCIFAR10(StreamingVisionDataset):
     """Implementation of the CIFAR-10 dataset using StreamingDataset.
 
     Args:
-        kwargs (Dict[str, Any]): Keyword arguments.
+        **kwargs (Dict[str, Any]): Keyword arguments.
     """
 
     def __init__(self, **kwargs: Dict[str, Any]) -> None:

--- a/examples/vision/cifar10/read.py
+++ b/examples/vision/cifar10/read.py
@@ -7,6 +7,8 @@ It is one of the most widely used datasets for machine learning research. Please
 `CIFAR-10 Dataset <https://www.cs.toronto.edu/~kriz/cifar.html>`_ for more details.
 """
 
+from typing import Any, Dict
+
 from streaming.vision import StreamingVisionDataset
 
 __all__ = ['StreamingCIFAR10']
@@ -16,58 +18,8 @@ class StreamingCIFAR10(StreamingVisionDataset):
     """Implementation of the CIFAR-10 dataset using StreamingDataset.
 
     Args:
-        remote (str, optional): Remote path or directory to download the dataset from. If ``None``,
-            its data must exist locally. StreamingDataset uses either ``streams`` or
-            ``remote``/``local``. Defaults to ``None``.
-        local (str, optional): Local working directory to download shards to. This is where shards
-            are cached while they are being used. Uses a temp directory if not set.
-            StreamingDataset uses either ``streams`` or ``remote``/``local``. Defaults to ``None``.
-        split (str, optional): Which dataset split to use, if any. If provided, we stream from/to
-            the ``split`` subdirs of  ``remote`` and ``local``. Defaults to ``None``.
-        download_retry (int): Number of download re-attempts before giving up. Defaults to ``2``.
-        download_timeout (float): Number of seconds to wait for a shard to download before raising
-            an exception. Defaults to ``60``.
-        validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
-            shards. Defaults to ``None``.
-        keep_zip (bool): Whether to keep or delete the compressed form when decompressing
-            downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
-            ``False``.
-        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
-            streams. If ``None``, takes its value from the total number of underlying samples.
-            Provide this field if you are weighting streams relatively to target a larger or
-            smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download per worker in advance
-            of current sample. Workers will attempt to download ahead by this many samples during,
-            but not before, training. Recommendation is to provide a value greater than per device
-            batch size to ensure at-least per device batch size number of samples cached locally.
-            If ``None``, its value gets derived using per device batch size and number of
-            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
-            Defaults to ``None``.
-        cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
-            Before downloading a shard, the least recently used resident shard(s) may be evicted
-            (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
-            disable shard eviction. Defaults to ``None``.
-        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
-        num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. The sample space is divided evenly according to the number of canonical
-            nodes. The higher the value, the more independent non-overlapping paths the
-            StreamingDataset replicas take through the shards per model replica (increasing data
-            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
-            of nodes of the initial run.
-
-            .. note::
-
-                For sequential sample ordering, set ``shuffle`` to ``False`` and
-                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
-        batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
-            partitioned over the workers. Defaults to ``None``.
-        shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to
-            ``False``.
-        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py1s``.
-        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
-        shuffle_block_size (int): Unit of shuffle. Defaults to ``1 << 18``.
-        transform (callable, optional): A function/transform that takes in an image and returns a
-            transformed version. Defaults to ``None``.
-        target_transform (callable, optional): A function/transform that takes in a target and
-            returns a transformed version. Defaults to ``None``.
+        kwargs (Dict[str, Any]): Keyword arguments.
     """
+
+    def __init__(self, **kwargs: Dict[str, Any]) -> None:
+        super().__init__(**kwargs)

--- a/examples/vision/coco/read.py
+++ b/examples/vision/coco/read.py
@@ -7,7 +7,7 @@ COCO is a large-scale object detection, segmentation, and captioning dataset. Pl
 `COCO dataset <https://cocodataset.org>`_ for more details.
 """
 
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Dict, Optional
 
 from streaming import StreamingDataset
 
@@ -18,97 +18,13 @@ class StreamingCOCO(StreamingDataset):
     """Implementation of the COCO dataset using StreamingDataset.
 
     Args:
-        remote (str, optional): Remote path or directory to download the dataset from. If ``None``,
-            its data must exist locally. StreamingDataset uses either ``streams`` or
-            ``remote``/``local``. Defaults to ``None``.
-        local (str, optional): Local working directory to download shards to. This is where shards
-            are cached while they are being used. Uses a temp directory if not set.
-            StreamingDataset uses either ``streams`` or ``remote``/``local``. Defaults to ``None``.
-        split (str, optional): Which dataset split to use, if any. If provided, we stream from/to
-            the ``split`` subdirs of  ``remote`` and ``local``. Defaults to ``None``.
-        download_retry (int): Number of download re-attempts before giving up. Defaults to ``2``.
-        download_timeout (float): Number of seconds to wait for a shard to download before raising
-            an exception. Defaults to ``60``.
-        validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
-            shards. Defaults to ``None``.
-        keep_zip (bool): Whether to keep or delete the compressed form when decompressing
-            downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
-            ``False``.
-        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
-            streams. If ``None``, takes its value from the total number of underlying samples.
-            Provide this field if you are weighting streams relatively to target a larger or
-            smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download per worker in advance
-            of current sample. Workers will attempt to download ahead by this many samples during,
-            but not before, training. Recommendation is to provide a value greater than per device
-            batch size to ensure at-least per device batch size number of samples cached locally.
-            If ``None``, its value gets derived using per device batch size and number of
-            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
-            Defaults to ``None``.
-        cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
-            Before downloading a shard, the least recently used resident shard(s) may be evicted
-            (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
-            disable shard eviction. Defaults to ``None``.
-        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
-        num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. The sample space is divided evenly according to the number of canonical
-            nodes. The higher the value, the more independent non-overlapping paths the
-            StreamingDataset replicas take through the shards per model replica (increasing data
-            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
-            of nodes of the initial run.
-
-            .. note::
-
-                For sequential sample ordering, set ``shuffle`` to ``False`` and
-                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
-        batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
-            partitioned over the workers. Defaults to ``None``.
-        shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to
-            ``False``.
-        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py1s``.
-        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
-        shuffle_block_size (int): Unit of shuffle. Defaults to ``1 << 18``.
-        transform (callable, optional): A function/transform that takes in an image and bboxes and
-            returns a transformed version. Defaults to ``None``.
+        transform (callable, optional): A function/transform that takes in an image and returns a
+            transformed version. Defaults to ``None``.
+        kwargs (Dict[str, Any]): Keyword arguments.
     """
 
-    def __init__(self,
-                 *,
-                 remote: Optional[str] = None,
-                 local: Optional[str] = None,
-                 split: Optional[str] = None,
-                 download_retry: int = 2,
-                 download_timeout: float = 60,
-                 validate_hash: Optional[str] = None,
-                 keep_zip: bool = False,
-                 epoch_size: Optional[int] = None,
-                 predownload: Optional[int] = None,
-                 partition_algo: str = 'orig',
-                 cache_limit: Optional[int] = None,
-                 num_canonical_nodes: Optional[int] = None,
-                 batch_size: Optional[int] = None,
-                 shuffle: bool = False,
-                 shuffle_algo: str = 'py1s',
-                 shuffle_seed: int = 9176,
-                 shuffle_block_size: int = 1 << 18,
-                 transform: Optional[Callable] = None) -> None:
-        super().__init__(remote=remote,
-                         local=local,
-                         split=split,
-                         download_retry=download_retry,
-                         download_timeout=download_timeout,
-                         validate_hash=validate_hash,
-                         keep_zip=keep_zip,
-                         epoch_size=epoch_size,
-                         predownload=predownload,
-                         cache_limit=cache_limit,
-                         partition_algo=partition_algo,
-                         num_canonical_nodes=num_canonical_nodes,
-                         batch_size=batch_size,
-                         shuffle=shuffle,
-                         shuffle_algo=shuffle_algo,
-                         shuffle_seed=shuffle_seed,
-                         shuffle_block_size=shuffle_block_size)
+    def __init__(self, *, transform: Optional[Callable] = None, **kwargs: Dict[str, Any]) -> None:
+        super().__init__(**kwargs)
         self.transform = transform
 
     def get_item(self, idx: int) -> Any:

--- a/examples/vision/coco/read.py
+++ b/examples/vision/coco/read.py
@@ -18,7 +18,7 @@ class StreamingCOCO(StreamingDataset):
     """Implementation of the COCO dataset using StreamingDataset.
 
     Args:
-        transform (callable, optional): A function/transform that takes in an image and returns a
+        transform (Callable, optional): A function/transform that takes in an image and returns a
             transformed version. Defaults to ``None``.
         **kwargs (Dict[str, Any]): Keyword arguments.
     """

--- a/examples/vision/coco/read.py
+++ b/examples/vision/coco/read.py
@@ -20,7 +20,7 @@ class StreamingCOCO(StreamingDataset):
     Args:
         transform (callable, optional): A function/transform that takes in an image and returns a
             transformed version. Defaults to ``None``.
-        kwargs (Dict[str, Any]): Keyword arguments.
+        **kwargs (Dict[str, Any]): Keyword arguments.
     """
 
     def __init__(self, *, transform: Optional[Callable] = None, **kwargs: Dict[str, Any]) -> None:

--- a/examples/vision/imagenet/read.py
+++ b/examples/vision/imagenet/read.py
@@ -18,7 +18,7 @@ class StreamingImageNet(StreamingVisionDataset):
     """Implementation of the ImageNet dataset using StreamingDataset.
 
     Args:
-        kwargs (Dict[str, Any]): Keyword arguments.
+        **kwargs (Dict[str, Any]): Keyword arguments.
     """
 
     def __init__(self, **kwargs: Dict[str, Any]) -> None:

--- a/examples/vision/imagenet/read.py
+++ b/examples/vision/imagenet/read.py
@@ -7,6 +7,8 @@ The most widely used dataset for Image Classification algorithms. Please refer t
 2012 Classification Dataset <http://image-net.org/>`_ for more details.
 """
 
+from typing import Any, Dict
+
 from streaming.vision import StreamingVisionDataset
 
 __all__ = ['StreamingImageNet']
@@ -16,58 +18,8 @@ class StreamingImageNet(StreamingVisionDataset):
     """Implementation of the ImageNet dataset using StreamingDataset.
 
     Args:
-        remote (str, optional): Remote path or directory to download the dataset from. If ``None``,
-            its data must exist locally. StreamingDataset uses either ``streams`` or
-            ``remote``/``local``. Defaults to ``None``.
-        local (str, optional): Local working directory to download shards to. This is where shards
-            are cached while they are being used. Uses a temp directory if not set.
-            StreamingDataset uses either ``streams`` or ``remote``/``local``. Defaults to ``None``.
-        split (str, optional): Which dataset split to use, if any. If provided, we stream from/to
-            the ``split`` subdirs of  ``remote`` and ``local``. Defaults to ``None``.
-        download_retry (int): Number of download re-attempts before giving up. Defaults to ``2``.
-        download_timeout (float): Number of seconds to wait for a shard to download before raising
-            an exception. Defaults to ``60``.
-        validate_hash (str, optional): Optional hash or checksum algorithm to use to validate
-            shards. Defaults to ``None``.
-        keep_zip (bool): Whether to keep or delete the compressed form when decompressing
-            downloaded shards. If ``False``, keep iff remote is local or no remote. Defaults to
-            ``False``.
-        epoch_size (int, optional): Number of samples to draw per epoch balanced across all
-            streams. If ``None``, takes its value from the total number of underlying samples.
-            Provide this field if you are weighting streams relatively to target a larger or
-            smaller epoch size. Defaults to ``None``.
-        predownload (int, optional): Target number of samples to download per worker in advance
-            of current sample. Workers will attempt to download ahead by this many samples during,
-            but not before, training. Recommendation is to provide a value greater than per device
-            batch size to ensure at-least per device batch size number of samples cached locally.
-            If ``None``, its value gets derived using per device batch size and number of
-            canonical nodes ``max(batch_size, 256 * batch_size // num_canonical_nodes)``.
-            Defaults to ``None``.
-        cache_limit (int, optional): Maximum size in bytes of this StreamingDataset's shard cache.
-            Before downloading a shard, the least recently used resident shard(s) may be evicted
-            (deleted from the local cache) in order to stay under the limit. Set to ``None`` to
-            disable shard eviction. Defaults to ``None``.
-        partition_algo (str): Which partitioning algorithm to use. Defaults to ``orig``.
-        num_canonical_nodes (int, optional): Canonical number of nodes for shuffling with
-            resumption. The sample space is divided evenly according to the number of canonical
-            nodes. The higher the value, the more independent non-overlapping paths the
-            StreamingDataset replicas take through the shards per model replica (increasing data
-            source diversity). Defaults to ``None``, which is interpreted as 64 times the number
-            of nodes of the initial run.
-
-            .. note::
-
-                For sequential sample ordering, set ``shuffle`` to ``False`` and
-                ``num_canonical_nodes`` to the number of physical nodes of the initial run.
-        batch_size (int, optional): Batch size of its DataLoader, which affects how the dataset is
-            partitioned over the workers. Defaults to ``None``.
-        shuffle (bool): Whether to iterate over the samples in randomized order. Defaults to
-            ``False``.
-        shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py1s``.
-        shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
-        shuffle_block_size (int): Unit of shuffle. Defaults to ``1 << 18``.
-        transform (callable, optional): A function/transform that takes in an image and returns a
-            transformed version. Defaults to ``None``.
-        target_transform (callable, optional): A function/transform that takes in a target and
-            returns a transformed version. Defaults to ``None``.
+        kwargs (Dict[str, Any]): Keyword arguments.
     """
+
+    def __init__(self, **kwargs: Dict[str, Any]) -> None:
+        super().__init__(**kwargs)

--- a/streaming/vision.py
+++ b/streaming/vision.py
@@ -55,11 +55,11 @@ class StreamingVisionDataset(StreamingDataset, VisionDataset):
     """A streaming, iterable, torchvision VisionDataset.
 
     Args:
-        transforms (callable, optional): A function/transforms that takes in an image and a label
+        transforms (Callable, optional): A function/transforms that takes in an image and a label
             and returns the transformed versions of both. Defaults to ``None``.
-        transform (callable, optional): A function/transform that takes in an image and returns a
+        transform (Callable, optional): A function/transform that takes in an image and returns a
             transformed version. Defaults to ``None``.
-        target_transform (callable, optional): A function/transform that takes in a target and
+        target_transform (Callable, optional): A function/transform that takes in a target and
             returns a transformed version. Defaults to ``None``.
         **kwargs (Dict[str, Any]): Keyword arguments.
     """


### PR DESCRIPTION
Switch all the example dataset arguments to kwargs for the ones that are merely passed through to StreamingDataset.