### PR TITLE
Add benchmarking suite for all backends and formats

### DIFF
--- a/benchmarks/backends/datagen.py
+++ b/benchmarks/backends/datagen.py
@@ -1,0 +1,204 @@
+# Copyright 2023 MosaicML Streaming authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate a synthetic dataset."""
+
+from typing import Dict, List, Tuple, TypeVar
+
+import numpy as np
+from numpy.random import Generator
+from tqdm import tqdm
+
+__all__ = ['generate']
+
+
+def _generate_int(rng: Generator,
+                  pos_prob: float = 0.75,
+                  low: int = -1_000_000_000,
+                  high: int = 1_000_000_000) -> int:
+    """Pick a random integer to say in words.
+
+    This is a synthetic dataset whose random numbers need to be distinct, deterministic given a
+    seed, and little else. We choose a distribution that seems the most pleasing to us.
+
+    Properties:
+      * About 80% positive and 20% negative.
+      * Magnitude of up to a billion on either side of zero.
+      * Strongly skewed toward the origin, i.e. chosen uniformly across base-10 digit lengths (at
+        least until running out of integers of that length anyway).
+
+    Args:
+        rng (Generator): NumPy random number generator.
+        pos_prob (float): Probability of output being positive. Defaults to ``0.75``.
+        low (int): Minimum of output range. Must be negative. Defaults to ``-1_000_000_000``.
+        high (int): Maximum of output range. Must be positive. Defaults to ``1_000_000_000``.
+    """
+    if not 0 <= pos_prob <= 1:
+        raise ValueError(f'Invalid positive probability ``pos_prob``: 0 <= {pos_prob} <= 1.')
+
+    if not low < 0 < high:
+        raise ValueError(f'Invalid sampling range ``low`` and/or ``high``: {low} < 0 < {high}.')
+
+    is_pos = rng.uniform() < pos_prob
+    max_digits = np.log10(high) if is_pos else np.log10(-low)
+    exponent = rng.uniform(0, max_digits)
+    magnitude = int(10**exponent)
+    sign = is_pos * 2 - 1
+    return sign * magnitude
+
+
+def _generate_ints(count: int,
+                   seed: int = 0x1337,
+                   pos_prob: float = 0.75,
+                   low: int = -1_000_000_000,
+                   high: int = 1_000_000_000,
+                   show_progress: bool = True) -> List[int]:
+    """Sample until we have the given number of distinct integers.
+
+    Args:
+        count (int): How many samples to draw.
+        seed (int): Seed for the random number generator. Defaults to ``0x1337``.
+        pos_prob (float): Probability of output being positive. Defaults to ``0.75``.
+        low (int): Minimum of output range. Must be negative. Defaults to ``-1_000_000_000``.
+        high (int): Maximum of output range. Must be positive. Defaults to ``1_000_000_000``.
+        show_progress (bool): Whether to display a progress bar. Defaults to ``True``.
+
+    Returns:
+        List[int]: The integers that were drawn.
+    """
+    rng = np.random.default_rng(seed)
+    nums = set()
+    progress_bar = tqdm(total=count, leave=False) if show_progress else None
+    while len(nums) < count:
+        num = _generate_int(rng)
+        if num in nums:
+            continue
+
+        nums.add(num)
+        if progress_bar:
+            progress_bar.update(1)
+    if progress_bar:
+        progress_bar.close()
+
+    nums = sorted(nums)
+    rng.shuffle(nums)
+    return nums
+
+
+_ones = ('zero one two three four five six seven eight nine ten eleven twelve thirteen fourteen '
+         'fifteen sixteen seventeen eighteen nineteen').split()
+
+_tens = 'twenty thirty forty fifty sixty seventy eighty ninety'.split()
+
+
+def _int_to_words(num: int) -> List[str]:
+    """Say an integer as a list of words.
+
+    Args:
+        num (int): The integer.
+
+    Returns:
+        List[str]: The integer as a list of words.
+    """
+    if num < 0:
+        return ['negative'] + _int_to_words(-num)
+    elif num <= 19:
+        return [_ones[num]]
+    elif num < 100:
+        tens = [_tens[num // 10 - 2]]
+        ones = [_ones[num % 10]] if num % 10 else []
+        return tens + ones
+    elif num < 1_000:
+        hundreds = [_ones[num // 100], 'hundred']
+        etc = _int_to_words(num % 100) if num % 100 else []
+        return hundreds + etc
+    elif num < 1_000_000:
+        thousands = _int_to_words(num // 1_000) + ['thousand']
+        etc = _int_to_words(num % 1_000) if num % 1_000 else []
+        return thousands + etc
+    elif num < 1_000_000_000:
+        millions = _int_to_words(num // 1_000_000) + ['million']
+        etc = _int_to_words(num % 1_000_000) if num % 1_000_000 else []
+        return millions + etc
+    else:
+        raise ValueError('Integer out of range: -1,000,000,000 < {num} < +1,000,000,000.')
+
+
+def _int_to_text(num: int) -> str:
+    """Say an integer as text.
+
+    Args:
+        num (int): The integer.
+
+    Returns:
+        str: The integer as text.
+    """
+    words = _int_to_words(num)
+    return ' '.join(words)
+
+
+T = TypeVar('T')
+
+
+def _split(items: List[T], sizes: List[int]) -> List[List[T]]:
+    """Divide the given items across the splits given by their sizes.
+
+    Args:
+        items (List[Any]): The items to divide across the spans.
+        sizes (List[int]): Number of items per split.
+
+    Returns:
+        List[List[Any]]: Each split of items.
+    """
+    total = sum(sizes)
+    if len(items) != total:
+        raise ValueError(f'Number of items must match the combined size of the splits: ' +
+                         f'{len(items)} items vs splits of size {sizes} = {total}.')
+
+    splits = []
+    begin = 0
+    for size in sizes:
+        split = items[begin:begin + size]
+        splits.append(split)
+        begin += size
+
+    return splits
+
+
+def generate(split2size: Dict[str, int],
+             seed: int = 0x1337,
+             pos_prob: float = 0.75,
+             low: int = -1_000_000_000,
+             high: int = 1_000_000_000,
+             show_progress: bool = True) -> Dict[str, Tuple[List[int], List[str]]]:
+    """Generate a dataset, made of splits, to be saved in different forms for comparison.
+
+    Args:
+        split2size (Dict[str, int]): Mapping of split name to size in samples.
+        seed (int): Seed for the random number generator. Defaults to ``0x1337``.
+        pos_prob (float): Probability of output being positive. Defaults to ``0.75``.
+        low (int): Minimum of output range. Must be negative. Defaults to ``-1_000_000_000``.
+        high (int): Maximum of output range. Must be positive. Defaults to ``1_000_000_000``.
+        show_progress (bool): Whether to show a progress bar. Defaults to ``True``.
+
+    Returns:
+        Dict[str, Tuple[List[int], List[str]]]: Mapping of split name to nums and texts.
+    """
+    split_sizes = []
+    total = 0
+    for split in sorted(split2size):
+        size = split2size[split]
+        split_sizes.append(size)
+        total += size
+
+    nums = _generate_ints(total, seed, low, high, show_progress)
+    nums_per_split = _split(nums, split_sizes)
+
+    texts = list(map(_int_to_text, nums))
+    texts_per_split = _split(texts, split_sizes)
+
+    dataset = {}
+    for index, split in enumerate(sorted(split2size)):
+        dataset[split] = nums_per_split[index], texts_per_split[index]
+
+    return dataset

--- a/benchmarks/backends/plot.py
+++ b/benchmarks/backends/plot.py
@@ -1,0 +1,90 @@
+# Copyright 2023 MosaicML Streaming authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Plot dataset iteration time."""
+
+import json
+from argparse import ArgumentParser, Namespace
+
+import numpy as np
+from matplotlib import pyplot as plt
+
+
+def _parse_args() -> Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        Namespace: Command-line arguments.
+    """
+    args = ArgumentParser()
+    args.add_argument('--stats', type=str, default='data/backends/stats.json')
+    args.add_argument('--plot', type=str, default='data/backends/plot.png')
+    return args.parse_args()
+
+
+def main(args: Namespace) -> None:
+    """Randomly iterate over a Parquet dataset with Streaming.
+
+    Args:
+        args (Namespace): Command-line arguments.
+    """
+    streaming_colors = {
+        'csv': '#c00',
+        'jsonl': '#a00',
+        'mds': '#800',
+    }
+
+    parquet_colors = {
+        'native': 'green',
+        'cold': 'blue',
+        'warm': 'red',
+    }
+
+    lance_take_counts = 2**np.arange(11)
+    lance_colors = '#730', '#840', '#950', '#a60', '#b70', '#c80', '#d90', '#ea0', '#fb1', \
+        '#fc4', '#fd7'
+    lance_colors = dict(zip(map(str, lance_take_counts), lance_colors))
+
+    colors = {
+        'streaming': streaming_colors,
+        'parquet': parquet_colors,
+        'lance': lance_colors,
+    }
+
+    stats = json.load(open(args.stats))
+
+    plt.rc('legend', fontsize=5)
+    plt.title('Throughput')
+    plt.xlabel('Seconds')
+    plt.ylabel('Samples')
+    line_width = 0.75
+
+    for backend in sorted(colors):
+        keys = sorted(colors[backend])
+        if backend == 'lance':
+            keys = sorted(map(int, keys))
+            keys = list(map(str, keys))
+        for key in keys:
+            for ordering in ['seq', 'rand']:
+                color = colors[backend][key]
+                try:
+                    obj = stats[backend][key][ordering]
+                except:
+                    continue
+                times = np.array(obj['times']) / 1e9
+                line_style = '-' if ordering == 'seq' else ':'
+                label = obj['label']
+                plt.plot(times,
+                         np.arange(len(times)),
+                         c=color,
+                         ls=line_style,
+                         lw=line_width,
+                         label=label)
+
+    plt.legend()
+    plt.grid(which='major', ls='--', c='#ddd')
+    plt.savefig(args.plot, dpi=600)
+
+
+if __name__ == '__main__':
+    main(_parse_args())

--- a/benchmarks/backends/read.py
+++ b/benchmarks/backends/read.py
@@ -274,6 +274,15 @@ def _bench_streaming_rand(dataset: StreamingDataset, show_progress: bool,
 
 
 def _to_dict(label: str, times: NDArray[np.float64]) -> Dict[str, Any]:
+    """Convert a label and sample latencies ndarray into an interpretable JSON dict.
+
+    Args:
+        label (str): Name of this run.
+        times (NDArray[np.float64]): Sample access times ndarray.
+
+    Returns:
+        Dict[str, Any]: JSON dict of interpretable metadata.
+    """
     rate = int(len(times) / times[-1])
     label = f'{label}: {rate:,}/s'
     print(label)
@@ -285,8 +294,19 @@ def _to_dict(label: str, times: NDArray[np.float64]) -> Dict[str, Any]:
 
 
 def _bench_streaming_format(data_root: str, shard_format: str, split: str, show_progress: bool,
-                            time_limit: float) -> \
-        Dict[str, Any]:
+                            time_limit: float) -> Dict[str, Any]:
+    """Benchmark the performance of a native Stremaing format (e.g., MDS, JSONL, CSV).
+
+    Args:
+        data_root (str): Data root directory.
+        shard_format (str): Streaming format name.
+        split (str): Split name.
+        show_progress (bool): Whether to show a progress bar.
+        time_limit (float): Benchmarking cutoff time.
+
+    Returns:
+        Dict[str, Any]: Mapping of ordering name to benchmark metadata JSON dict.
+    """
     dataset_dir = os.path.join(data_root, shard_format, split)
     dataset = StreamingDataset(local=dataset_dir)
 
@@ -301,6 +321,17 @@ def _bench_streaming_format(data_root: str, shard_format: str, split: str, show_
 
 def _bench_streaming(data_root: str, split: str, show_progress: bool,
                      time_limit: float) -> Dict[str, Any]:
+    """Benchmark the performance of all native Streaming formats.
+
+    Args:
+        data_root (str): Data root directory.
+        split (str): Split name.
+        show_progress (bool): Whether to show a progress bar.
+        time_limit (float): Benchmarking cutoff time.
+
+    Returns:
+        Dict[str, Any]: Mapping of format to ordering to benchmark metadata JSON dict.
+    """
     mds = _bench_streaming_format(data_root, 'mds', split, show_progress, time_limit)
     csv = _bench_streaming_format(data_root, 'csv', split, show_progress, time_limit)
     jsonl = _bench_streaming_format(data_root, 'jsonl', split, show_progress, time_limit)
@@ -309,6 +340,18 @@ def _bench_streaming(data_root: str, split: str, show_progress: bool,
 
 def _bench_parquet(data_root: str, split: str, parquet_suffix: str, show_progress: bool,
                    time_limit: float) -> Dict[str, Any]:
+    """Benchmark the performance of Parquet and Streaming Parquet.
+
+    Args:
+        data_root (str): Data root directory.
+        split (str): Split name.
+        parquet_suffix (str): Parquet filename suffix.
+        show_progress (bool): Whether to show a progress bar.
+        time_limit (float): Benchmarking cutoff time.
+
+    Returns:
+        Dict[str, Any]: Mapping of benchmark name to ordering to benchmark metadata JSON dict.
+    """
     dataset_dir = os.path.join(data_root, 'parquet', split)
 
     times = _bench_parquet_seq(dataset_dir, parquet_suffix, show_progress, time_limit)
@@ -338,6 +381,18 @@ def _bench_parquet(data_root: str, split: str, parquet_suffix: str, show_progres
 
 def _bench_lance(data_root: str, split: str, show_progress: bool, time_limit: float,
                  pow_interval: int) -> Dict[str, Any]:
+    """Benchmark the performance of Lance and, someday, Streaming Lance.
+
+    Args:
+        data_root (str): Data root directory.
+        split (str): Split name.
+        show_progress (bool): Whether to show a progress bar.
+        time_limit (float): Benchmarking cutoff time.
+        pow_interval (int): Take count exponent interval. Must be either ``2`` or ``4``.
+
+    Returns:
+        Dict[str, Any]: Mapping of take count to ordering to benchmark metadata JSON dict.
+    """
     if pow_interval == 4:
         take_counts = 1, 4, 16, 64, 256, 1024
     elif pow_interval == 2:

--- a/benchmarks/backends/read.py
+++ b/benchmarks/backends/read.py
@@ -1,0 +1,385 @@
+# Copyright 2023 MosaicML Streaming authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark dataset iteration time."""
+
+import json
+import os
+from argparse import ArgumentParser, Namespace
+from time import time
+from typing import Any, Dict, Iterator, List, Tuple
+
+import lance
+import numpy as np
+from lance import LanceDataset
+from numpy.typing import NDArray
+from pyarrow import parquet as pq
+from pyarrow.parquet import ParquetFile
+from tqdm import tqdm, trange
+
+from streaming import StreamingDataset
+
+
+def _parse_args() -> Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        Namespace: Command-line arguments.
+    """
+    args = ArgumentParser()
+    args.add_argument('--data_root', type=str, default='data/backends/gold/')
+    args.add_argument('--split', type=str, default='medium')
+    args.add_argument('--lance_pow_interval', type=int, default=4)
+    args.add_argument('--parquet_suffix', type=str, default='.parquet')
+    args.add_argument('--progress_bar', type=int, default=1)
+    args.add_argument('--time_limit', type=float, default=180)
+    args.add_argument('--out', type=str, default='data/backends/stats.json')
+    return args.parse_args()
+
+
+def _bench_lance_seq(dataset: LanceDataset, take_count: int, show_progress: bool,
+                     time_limit: float) -> NDArray[np.float64]:
+    """Benchmark iterating a Lance dataset in sequential order.
+
+    Args:
+        dataset (LanceDataset): The Lance dataset to iterate.
+        take_count (int): How many samples to take per sequential access.
+        show_progress (bool): Whether to show a progress bar.
+        time_limit (float): Benchmarking cutoff time.
+
+    Returns:
+        NDArray[np.float64]: Time taken to process that many dataset samples.
+    """
+    num_samples = dataset.count_rows()
+    if num_samples % take_count:
+        raise ValueError(f'`num_samples` ({num_samples}) must be divisible by `take_count` ' +
+                         f'({take_count}).')
+    num_batches = num_samples // take_count
+    shape = num_batches, take_count
+    times = np.zeros(shape, np.float64)
+    sample, = dataset.head(1).to_pylist()
+    columns = sorted(sample)
+    each_batch = enumerate(dataset.to_batches(columns=columns, batch_size=take_count))
+    if show_progress:
+        each_batch = tqdm(each_batch, total=num_batches, leave=False)
+    t0 = time()
+    for i, samples in each_batch:
+        samples.to_pylist()
+        assert len(samples) == take_count
+        if num_batches < i:  # ???
+            break
+        times[i] = t = time() - t0
+        if time_limit <= t:
+            times = times[:i]
+            break
+    return times.flatten()
+
+
+def _bench_lance_rand(dataset: LanceDataset, take_count: int, show_progress: bool,
+                      time_limit: float) -> NDArray[np.float64]:
+    """Benchmark iterating a Lance dataset in random order.
+
+    Args:
+        dataset (LanceDataset): The Lance dataset to iterate.
+        take_count (int): How many samples to take per random access.
+        show_progress (bool): Whether to show a progress bar.
+        time_limit (float): Benchmarking cutoff time.
+
+    Returns:
+        NDArray[np.float64]: Time taken to process that many dataset samples.
+    """
+    num_samples = dataset.count_rows()
+    if num_samples % take_count:
+        raise ValueError(f'`num_samples` ({num_samples}) must be divisible by `take_count` ' +
+                         f'({take_count}).')
+    shape = num_samples // take_count, take_count
+    times = np.zeros(shape, np.float64)
+    batches = np.random.permutation(num_samples).reshape(shape)
+    if show_progress:
+        batches = tqdm(batches, leave=False)
+    t0 = time()
+    for i, sample_ids in enumerate(batches):
+        dataset.take(sample_ids).to_pylist()
+        times[i] = t = time() - t0
+        if time_limit <= t:
+            times = times[:i]
+            break
+    return times.flatten()
+
+
+def _each_parquet(dataset_root: str, parquet_suffix: str) -> Iterator[str]:
+    """Iteracte over each Parquet shard file of the dataset in order.
+
+    Args:
+        dataset_root (str): Dataset root directory.
+        parquet_suffix (str): Parquet shard file suffix.
+
+    Returns:
+        Iterator[str]: Each Parquet shard file.
+    """
+    ret = []
+    for parent, _, file_basenames in os.walk(dataset_root):
+        file_basenames = filter(lambda basename: basename.endswith(parquet_suffix), file_basenames)
+        ret += [os.path.join(parent, basename) for basename in file_basenames]
+    yield from sorted(ret)
+
+
+def _get_parquet_mapping(dataset_dir: str, parquet_suffix: str) -> \
+        Tuple[List[str], NDArray[np.int64]]:
+    """Get a mapping of sample ID to (shard ID, relative sample ID within that shard).
+
+    Args:
+        dataset_dir (str): Parquet dataset directory.
+        parquet_suffix (str): Parquet shard file suffix.
+
+    Returns:
+        Tuple[List[str], NDArray[np.int64]]: Filenames and mapping.
+    """
+    filenames = list(_each_parquet(dataset_dir, parquet_suffix))
+    mapping = []
+    for file_id, filename in enumerate(filenames):
+        file = ParquetFile(filename)
+        mapping += list(zip([file_id] * file.metadata.num_rows, range(file.metadata.num_rows)))
+    mapping = np.array(mapping)
+    return filenames, mapping
+
+
+def _bench_parquet_seq(dataset_dir: str, parquet_suffix: str, show_progress: bool,
+                       time_limit: float) -> NDArray[np.float64]:
+    """Benchmark iterating a StreamingDataset in sequential order.
+
+    Args:
+        dataset_dir (str): Parquet dataset directory.
+        parquet_suffix (str): Parquet shard file suffix.
+        show_progress (bool): Whether to show a progress bar.
+        time_limit (float): Benchmarking cutoff time.
+
+    Returns:
+        NDArray[np.float64]: Time taken to process that many dataset samples.
+    """
+    filenames, mapping = _get_parquet_mapping(dataset_dir, parquet_suffix)
+    num_samples = len(mapping)
+    times = np.zeros(num_samples, np.float64)
+    progress_bar = tqdm(total=num_samples, leave=False) if show_progress else None
+    i = 0
+    t0 = time()
+    for filename in filenames:
+        table = pq.read_table(filename)
+        for _ in table.to_pylist():
+            times[i] = t = time() - t0
+            if time_limit <= t:
+                return times[:i]
+            i += 1
+            if progress_bar:
+                progress_bar.update(1)
+    return times
+
+
+def _bench_parquet_rand(dataset_dir: str, parquet_suffix: str, show_progress: bool,
+                        time_limit: float) -> NDArray[np.float64]:
+    """Benchmark iterating a StreamingDataset in random order.
+
+    Args:
+        dataset_dir (str): Parquet dataset directory.
+        parquet_suffix (str): Parquet shard file suffix.
+        show_progress (bool): Whether to show a progress bar.
+        time_limit (float): Benchmarking cutoff time.
+
+    Returns:
+        NDArray[np.float64]: Time taken to process that many dataset samples.
+    """
+    filenames, mapping = _get_parquet_mapping(dataset_dir, parquet_suffix)
+    num_samples = len(mapping)
+    indices = np.random.permutation(num_samples)
+    times = np.zeros(num_samples, np.float64)
+    progress_bar = tqdm(total=num_samples, leave=False) if show_progress else None
+    t0 = time()
+    for i, sample_id in enumerate(indices):
+        file_id, shard_sample_id = mapping[sample_id]
+        filename = filenames[file_id]
+        table = pq.read_table(filename)
+        shard_samples = table.to_pylist()
+        shard_samples[shard_sample_id]
+        times[i] = t = time() - t0
+        if progress_bar:
+            progress_bar.update(1)
+        if time_limit <= t:
+            times = times[:i]
+            break
+    return times
+
+
+def _clear_mds_files(dataset_root: str) -> None:  # pyright: ignore
+    """Clear the intermediate MDS shard files.
+
+    Args:
+        dataset_root (str): Dataset root directoyr.
+    """
+    for parent, _, file_basenames in os.walk(dataset_root):
+        for basename in file_basenames:
+            if basename.endswith('.mds'):
+                filename = os.path.join(parent, basename)
+                os.remove(filename)
+
+
+def _bench_streaming_seq(dataset: StreamingDataset, show_progress: bool,
+                         time_limit: float) -> NDArray[np.float64]:
+    """Benchmark iterating a StreamingDataset in sequential order.
+
+    Args:
+        dataset (StreamingDataset): The streaming dataset to iterate.
+        show_progress (bool): Whether to show a progress bar.
+        time_limit (float): Benchmarking cutoff time.
+
+    Returns:
+        NDArray[np.float64]: Time taken to process that many dataset samples.
+    """
+    times = np.zeros(dataset.num_samples, np.float64)
+    xrange = trange(dataset.num_samples, leave=False) if show_progress else \
+        range(dataset.num_samples)
+    t0 = time()
+    for i in xrange:
+        dataset[i]
+        times[i] = t = time() - t0
+        if time_limit <= t:
+            times = times[:i]
+            break
+    return times
+
+
+def _bench_streaming_rand(dataset: StreamingDataset, show_progress: bool,
+                          time_limit: float) -> NDArray[np.float64]:
+    """Benchmark iterating a StreamingDataset in random order.
+
+    Args:
+        dataset (StreamingDataset): The streaming dataset to iterate.
+        show_progress (bool): Whether to show a progress bar.
+        time_limit (float): Benchmarking cutoff time.
+
+    Returns:
+        NDArray[np.float64]: Time taken to process that many dataset samples.
+    """
+    indices = np.random.permutation(dataset.num_samples)
+    times = np.zeros(dataset.num_samples)
+    if show_progress:
+        indices = tqdm(indices, leave=False)
+    t0 = time()
+    for i, sample_id in enumerate(indices):
+        dataset[sample_id]
+        times[i] = t = time() - t0
+        if time_limit <= t:
+            times = times[:i]
+            break
+    return times
+
+
+def _to_dict(label: str, times: NDArray[np.float64]) -> Dict[str, Any]:
+    rate = int(len(times) / times[-1])
+    label = f'{label}: {rate:,}/s'
+    print(label)
+    return {
+        'label': label,
+        'rate': rate,
+        'times': (times * 1e9).astype(np.int64).tolist(),
+    }
+
+
+def _bench_streaming_format(data_root: str, shard_format: str, split: str, show_progress: bool,
+                            time_limit: float) -> \
+        Dict[str, Any]:
+    dataset_dir = os.path.join(data_root, shard_format, split)
+    dataset = StreamingDataset(local=dataset_dir)
+
+    times = _bench_streaming_seq(dataset, show_progress, time_limit)
+    seq = _to_dict(f'Streaming {shard_format.upper()} seq', times)
+
+    times = _bench_streaming_rand(dataset, show_progress, time_limit)
+    rand = _to_dict(f'Streaming {shard_format.upper()} rand', times)
+
+    return {'seq': seq, 'rand': rand}
+
+
+def _bench_streaming(data_root: str, split: str, show_progress: bool,
+                     time_limit: float) -> Dict[str, Any]:
+    mds = _bench_streaming_format(data_root, 'mds', split, show_progress, time_limit)
+    csv = _bench_streaming_format(data_root, 'csv', split, show_progress, time_limit)
+    jsonl = _bench_streaming_format(data_root, 'jsonl', split, show_progress, time_limit)
+    return {'mds': mds, 'csv': csv, 'jsonl': jsonl}
+
+
+def _bench_parquet(data_root: str, split: str, parquet_suffix: str, show_progress: bool,
+                   time_limit: float) -> Dict[str, Any]:
+    dataset_dir = os.path.join(data_root, 'parquet', split)
+
+    times = _bench_parquet_seq(dataset_dir, parquet_suffix, show_progress, time_limit)
+    seq = _to_dict('Parquet seq (in mem)', times)
+    times = _bench_parquet_rand(dataset_dir, parquet_suffix, show_progress, time_limit)
+    rand = _to_dict('Parquet rand (in mem)', times)
+    native = {'seq': seq, 'rand': rand}
+    """
+    streaming_dataset = StreamingDataset(local=dataset_dir)
+
+    times = _bench_streaming_seq(streaming_dataset, show_progress, time_limit)
+    seq = _to_dict('Streaming Parquet seq (cold)', times)
+    _clear_mds_files(dataset_dir)
+    times = _bench_streaming_rand(streaming_dataset, show_progress, time_limit)
+    rand = _to_dict('Streaming Parquet rand (cold)', times)
+    cold = {'seq': seq, 'rand': rand}
+
+    times = _bench_streaming_seq(streaming_dataset, show_progress, time_limit)
+    seq = _to_dict('Streaming Parquet seq (cached)', times)
+    times = _bench_streaming_rand(streaming_dataset, show_progress, time_limit)
+    rand = _to_dict('Streaming Parquet rand (cached)', times)
+    warm = {'seq': seq, 'rand': rand}
+    """
+
+    return {'native': native}
+
+
+def _bench_lance(data_root: str, split: str, show_progress: bool, time_limit: float,
+                 pow_interval: int) -> Dict[str, Any]:
+    if pow_interval == 4:
+        take_counts = 1, 4, 16, 64, 256, 1024
+    elif pow_interval == 2:
+        take_counts = 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024
+    else:
+        raise ValueError(f'Unsupported --lance_pow_interval: {pow_interval} (must be 2 or 4).')
+
+    dataset_dir = os.path.join(data_root, 'lance', split)
+    lance_dataset = lance.dataset(dataset_dir)
+
+    ret = {}
+
+    for take_count in take_counts:
+        times = _bench_lance_seq(lance_dataset, take_count, show_progress, time_limit)
+        ret[take_count] = {}
+        ret[take_count]['seq'] = _to_dict(f'Lance seq x{take_count:04}', times)
+
+    for take_count in take_counts:
+        times = _bench_lance_rand(lance_dataset, take_count, show_progress, time_limit)
+        ret[take_count]['rand'] = _to_dict(f'Lance rand x{take_count:04}', times)
+
+    return ret
+
+
+def main(args: Namespace) -> None:
+    """Randomly iterate over a Parquet dataset with Streaming.
+
+    Args:
+        args (Namespace): Command-line arguments.
+    """
+    show_progress = bool(args.progress_bar)
+
+    streaming_info = _bench_streaming(args.data_root, args.split, show_progress, args.time_limit)
+    parquet_info = _bench_parquet(args.data_root, args.split, args.parquet_suffix, show_progress,
+                                  args.time_limit)
+    lance_info = _bench_lance(args.data_root, args.split, show_progress, args.time_limit,
+                              args.lance_pow_interval)
+    info = {'streaming': streaming_info, 'parquet': parquet_info, 'lance': lance_info}
+
+    with open(args.out, 'w') as out:
+        json.dump(info, out)
+
+
+if __name__ == '__main__':
+    main(_parse_args())

--- a/benchmarks/backends/write.py
+++ b/benchmarks/backends/write.py
@@ -1,0 +1,387 @@
+# Copyright 2023 MosaicML Streaming authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate a synthetic dataset and serialize it using each Streaming format/backend."""
+
+import os
+from argparse import ArgumentParser, Namespace
+from collections import defaultdict
+from functools import partial
+from shutil import rmtree
+from time import time
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import lance
+import pyarrow as pa
+import pyspark
+import pyspark.sql
+from delta import configure_spark_with_delta_pip
+from pyarrow import parquet as pq
+from pyspark.sql.types import IntegerType, StringType, StructField, StructType
+from tqdm import tqdm
+from wurlitzer import pipes
+
+from benchmarks.backends.datagen import generate
+from streaming import CSVWriter, JSONWriter, MDSWriter
+from streaming.util.tabulation import Tabulator
+
+
+def _parse_args() -> Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        Namespace: Command-line arguments.
+    """
+    args = ArgumentParser()
+
+    # Reproducibility.
+    args.add_argument('--seed', type=int, default=1337)
+
+    # Dataset data distribution.
+    args.add_argument('--data_pos_prob', type=float, default=0.75)
+    args.add_argument('--data_low', type=int, default=-1_000_000_000)
+    args.add_argument('--data_high', type=int, default=1_000_000_000)
+
+    # Sizes of datasets splits and shards.
+    args.add_argument('--small', type=int, default=1 << 15)
+    args.add_argument('--medium', type=int, default=1 << 20)
+    args.add_argument('--large', type=int, default=1 << 25)
+    args.add_argument('--size_limit', type=int, default=1 << 23)
+    args.add_argument('--samples_per_shard', type=int, default=1 << 18)
+
+    # Outputs.
+    args.add_argument('--data_root', type=str, default='data/backends/')
+    args.add_argument('--formats', type=str, default='csv,delta,jsonl,lance,mds,parquet')
+
+    # Introspection.
+    args.add_argument('--show_progress', type=int, default=1)
+    args.add_argument('--quiet_delta', type=int, default=1)
+
+    return args.parse_args()
+
+
+def _write_csv(nums: List[int],
+               txts: List[str],
+               root: str,
+               size_limit: Optional[int],
+               show_progress: bool = True) -> None:
+    """Save the dataset in Streaming CSV form.
+
+    Args:
+        nums (List[int]): The sample numbers.
+        txts (List[str]): The sample texts.
+        root (str): Root directory.
+        size_limit (int, optional): Maximum shard size in bytes, or no limit.
+        show_progress (bool): Whether to show a progress bar while saving. Defaults to ``True``.
+    """
+    columns = {
+        'num': 'int',
+        'txt': 'str',
+    }
+    with CSVWriter(out=root, columns=columns, size_limit=size_limit) as out:
+        each_sample = zip(nums, txts)
+        if show_progress:
+            each_sample = tqdm(each_sample, total=len(nums), leave=False)
+        for num, txt in each_sample:
+            sample = {
+                'num': num,
+                'txt': txt,
+            }
+            out.write(sample)
+
+
+def _write_jsonl(nums: List[int],
+                 txts: List[str],
+                 root: str,
+                 size_limit: Optional[int],
+                 show_progress: bool = True) -> None:
+    """Save the dataset Streaming JSONL form.
+
+    Args:
+        nums (List[int]): The sample numbers.
+        txts (List[str]): The sample texts.
+        root (str): Root directory.
+        size_limit (int, optional): Maximum shard size in bytes, or no limit.
+        show_progress (bool): Whether to show a progress bar while saving. Defaults to ``True``.
+    """
+    columns = {
+        'num': 'int',
+        'txt': 'str',
+    }
+    with JSONWriter(out=root, columns=columns, size_limit=size_limit) as out:
+        each_sample = zip(nums, txts)
+        if show_progress:
+            each_sample = tqdm(each_sample, total=len(nums), leave=False)
+        for num, txt in each_sample:
+            sample = {
+                'num': num,
+                'txt': txt,
+            }
+            out.write(sample)
+
+
+def _write_mds(nums: List[int],
+               txts: List[str],
+               root: str,
+               size_limit: Optional[int],
+               show_progress: bool = True) -> None:
+    """Save the dataset in Streaming MDS form.
+
+    Args:
+        nums (List[int]): The sample numbers.
+        txts (List[str]): The sample texts.
+        root (str): Root directory.
+        size_limit (int, optional): Maximum shard size in bytes, or no limit.
+        show_progress (bool): Whether to show a progress bar while saving. Defaults to ``True``.
+    """
+    columns = {
+        'num': 'int',
+        'txt': 'str',
+    }
+    with MDSWriter(out=root, columns=columns, size_limit=size_limit) as out:
+        each_sample = zip(nums, txts)
+        if show_progress:
+            each_sample = tqdm(each_sample, total=len(nums), leave=False)
+        for num, txt in each_sample:
+            sample = {
+                'num': num,
+                'txt': txt,
+            }
+            out.write(sample)
+
+
+def _write_parquet(nums: List[int],
+                   txts: List[str],
+                   root: str,
+                   samples_per_shard: int,
+                   show_progress: bool = True) -> None:
+    """Save the dataset in Streaming MDS form.
+
+    Args:
+        nums (List[int]): The sample numbers.
+        txts (List[str]): The sample texts.
+        root (str): Root directory.
+        samples_per_shard (int): Maximum numbero of samples per shard.
+        show_progress (bool): Whether to show a progress bar while saving. Defaults to ``True``.
+    """
+    if not os.path.exists(root):
+        os.makedirs(root)
+    num_samples = len(nums)
+    num_shards = (num_samples + samples_per_shard - 1) // samples_per_shard
+    each_shard = range(num_shards)
+    if show_progress:
+        each_shard = tqdm(each_shard, total=num_shards, leave=False)
+    for i in each_shard:
+        begin = i * samples_per_shard
+        end = min(begin + samples_per_shard, num_samples)
+        shard_nums = nums[begin:end]
+        shard_txts = txts[begin:end]
+        path = os.path.join(root, f'{i:05}.parquet')
+        obj = {
+            'num': shard_nums,
+            'txt': shard_txts,
+        }
+        table = pa.Table.from_pydict(obj)
+        pq.write_table(table, path)
+
+
+def _write_delta(nums: List[int], txts: List[str], root: str, samples_per_shard: int) -> None:
+    """Save the dataset in Streaming MDS form.
+
+    Args:
+        nums (List[int]): The sample numbers.
+        txts (List[str]): The sample texts.
+        root (str): Root directory.
+        samples_per_shard (int): Maximum numbero of samples per shard.
+    """
+    builder = pyspark.sql.SparkSession.builder.appName('prolix')  # pyright: ignore
+    builder = builder.config('spark.sql.extensions', 'io.delta.sql.DeltaSparkSessionExtension')
+    builder = builder.config('spark.sql.catalog.spark_catalog',
+                             'org.apache.spark.sql.delta.catalog.DeltaCatalog')
+    spark = configure_spark_with_delta_pip(builder).getOrCreate()
+    schema = StructType([
+        StructField('num', IntegerType(), False),
+        StructField('txt', StringType(), False),
+    ])
+    samples = list(zip(nums, txts))
+    df = spark.createDataFrame(samples, schema)
+    df.write.format('delta').option('maxRecordsPerFile', samples_per_shard).save(root)
+
+
+def _do_write_delta(nums: List[int],
+                    txts: List[str],
+                    root: str,
+                    samples_per_shard: int,
+                    quietly: bool = True) -> None:
+    """Save the dataset in Streaming MDS form, possibly capturing stdout/stderr.
+
+    Args:
+        nums (List[int]): The sample numbers.
+        txts (List[str]): The sample texts.
+        root (str): Root directory.
+        samples_per_shard (int): Maximum numbero of samples per shard.
+        quietly (bool): Whether to capture the Delta logging. Defaults to ``True``.
+    """
+    write = lambda: _write_delta(nums, txts, root, samples_per_shard)
+    if quietly:
+        with pipes():
+            write()
+    else:
+        write()
+
+
+def _write_lance(nums: List[int], txts: List[str], root: str, samples_per_shard: int) -> None:
+    """Save the dataset in Lance form.
+
+    Args:
+        nums (List[int]): The sample numbers.
+        txts (List[str]): The sample texts.
+        root (str): Root directory.
+        samples_per_shard (int): Maximum numbero of samples per shard.
+    """
+    column_names = 'num', 'txt'
+    column_values = nums, txts
+    table = pa.Table.from_arrays(column_values, column_names)
+    lance.write_dataset(table, root, mode='create', max_rows_per_file=samples_per_shard)
+
+
+def _get_file_sizes(root: str) -> List[int]:
+    """Inventory what was written, collecting total files and total bytes.
+
+    Args:
+        root (str): Dataset root.
+
+    Returns:
+        Tuple[int, int]: Total files and total bytes written.
+    """
+    sizes = []
+    for parent, _, file_basenames in sorted(os.walk(root)):
+        for basename in sorted(file_basenames):
+            path = os.path.join(parent, basename)
+            size = os.stat(path).st_size
+            sizes.append(size)
+    return sizes
+
+
+def _splits_by_size(dataset: Dict[str, Tuple[List[int], List[str]]]) -> Iterable[str]:
+    """Order a dataset's splits by their size in samples, then by name.
+
+    Argxs:
+        dataset (Dict[str, Tuple[List[int], List[str]]]): Mapping of split name to split data.
+
+    Returns:
+        Iterable[str]: Ordered split names.
+    """
+    size2splits = defaultdict(list)
+    for split, (nums, _) in dataset.items():
+        size2splits[len(nums)].append(split)
+
+    splits_by_size = []
+    for size in sorted(size2splits):
+        for split in sorted(size2splits[size]):
+            splits_by_size.append(split)
+
+    return splits_by_size
+
+
+def main(args: Namespace) -> None:
+    """Generate identical datasets in various formats for performance comparison.
+
+    Args:
+        args (Namespace): Command-line arguments.
+    """
+    # Confgure the dataset writing statistics table printer.
+    table_columns = '''
+        < format 8
+        > sec 7
+        > samples 12
+        > usec/sp 8
+        > bytes 14
+        > files 6
+        > bytes/file 12
+        > max bytes/file 14
+    '''
+    table_indent = 4
+    table = Tabulator.from_conf(table_columns, table_indent * ' ')
+
+    # Normalize arguments.
+    format_names = args.formats.split(',') if args.formats else []
+    show_progress = bool(args.show_progress)
+    quiet_delta = bool(args.quiet_delta)
+
+    # Given args, now we know how to configure saving the dataset in each format.
+    format2write = {
+        'csv':
+            partial(_write_csv, size_limit=args.size_limit, show_progress=show_progress),
+        'delta':
+            partial(_do_write_delta, quietly=quiet_delta,
+                    samples_per_shard=args.samples_per_shard),
+        'jsonl':
+            partial(_write_jsonl, size_limit=args.size_limit, show_progress=show_progress),
+        'lance':
+            partial(_write_lance, samples_per_shard=args.samples_per_shard),
+        'mds':
+            partial(_write_mds, size_limit=args.size_limit, show_progress=show_progress),
+        'parquet':
+            partial(_write_parquet,
+                    samples_per_shard=args.samples_per_shard,
+                    show_progress=show_progress),
+    }
+
+    # Collect sizes of the splits to generate.
+    split2size = {
+        'small': args.small,
+        'medium': args.medium,
+        'large': args.large,
+    }
+
+    # Generate the dataset samples.
+    t0 = time()
+    dataset = generate(split2size, args.seed, args.data_pos_prob, args.data_low, args.data_high,
+                       show_progress)
+    elapsed = time() - t0
+    print(f'Generate: {elapsed:.3f} sec.')
+
+    # Wipe output directory if exists.
+    if os.path.exists(args.data_root):
+        print(f'Found directory at {args.data_root}, wiping it for reuse')
+        rmtree(args.data_root)
+
+    # Write each split in each desired formats, in order of size.
+    pretty_int = lambda num: f'{num:,}'
+    for split in _splits_by_size(dataset):
+        print()
+        print(f'Write split: {split}')
+        print(table.draw_line())
+        print(table.draw_header())
+        print(table.draw_line())
+
+        nums, txts = dataset[split]
+        for format_name in format_names:
+            split_root = os.path.join(args.data_root, 'gold', format_name, split)
+            write = format2write[format_name]
+
+            t0 = time()
+            try:
+                write(nums, txts, split_root)
+            except:
+                continue  # Getting Delta Java OOMs at gigabyte size.
+            elapsed = time() - t0
+
+            file_sizes = _get_file_sizes(split_root)
+            row = {
+                'format': format_name,
+                'sec': f'{elapsed:.3f}',
+                'samples': pretty_int(len(nums)),
+                'usec/sp': f'{1e6 * elapsed / len(nums):.3f}',
+                'bytes': pretty_int(sum(file_sizes)),
+                'files': pretty_int(len(file_sizes)),
+                'bytes/file': pretty_int(sum(file_sizes) // len(file_sizes)),
+                'max bytes/file': pretty_int(max(file_sizes)),
+            }
+            print(table.draw_row(row))
+        print(table.draw_line())
+
+
+if __name__ == '__main__':
+    main(_parse_args())

--- a/streaming/util/__init__.py
+++ b/streaming/util/__init__.py
@@ -10,9 +10,10 @@ from streaming.util.shared import clean_stale_shared_memory
 from streaming.util.shorthand import (get_list_arg, get_str2str_arg, normalize_bin_bytes,
                                       normalize_bytes, normalize_count, normalize_dec_bytes,
                                       normalize_duration)
+from streaming.util.tabulation import Tabulator
 
 __all__ = [
     'get_import_exception_message', 'redirect_imports', 'merge_index', 'retry',
     'clean_stale_shared_memory', 'get_list_arg', 'get_str2str_arg', 'normalize_dec_bytes',
-    'normalize_bin_bytes', 'normalize_bytes', 'normalize_count', 'normalize_duration'
+    'normalize_bin_bytes', 'normalize_bytes', 'normalize_count', 'normalize_duration', 'Tabulator'
 ]

--- a/streaming/util/tabulation.py
+++ b/streaming/util/tabulation.py
@@ -1,0 +1,125 @@
+# Copyright 2023 MosaicML Streaming authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Line by line text table printer."""
+
+from typing import Any, Dict, List, Optional, Tuple
+
+from typing_extensions import Self
+
+__all__ = ['Tabulator']
+
+
+class Tabulator:
+    """Line by line text table printer.
+
+    Example:
+        conf = '''
+            < format 8
+            > sec 6
+            > samples 12
+            > usec/sp 8
+            > bytes 14
+            > files 6
+            > bytes/file 12
+            > max bytes/file 14
+        '''
+        left = 4 * ' '
+        tab = Tabulator.from_conf(conf, left)
+
+    Args:
+        cols (List[Tuple[str, str, int]]: Each column config (i.e., just, name, width).
+        left (str, optional): Print this before each line (e.g., indenting). Defaults to ``None``.
+    """
+
+    def __init__(self, cols: List[Tuple[str, str, int]], left: Optional[str] = None) -> None:
+        self.cols = cols
+        self.col_justs = []
+        self.col_names = []
+        self.col_widths = []
+        for just, name, width in cols:
+            if just not in {'<', '>'}:
+                raise ValueError(f'Invalid justify (must be one of "<" or ">"): {just}.')
+
+            if not name:
+                raise ValueError('Name must be non-empty.')
+            elif width < len(name):
+                raise ValueError(f'Name is too wide for its column width: {width} vs {name}.')
+
+            if width <= 0:
+                raise ValueError(f'Width must be positive, but got: {width}.')
+
+            self.col_justs.append(just)
+            self.col_names.append(name)
+            self.col_widths.append(width)
+
+        self.left = left
+
+        self.box_chr_horiz = chr(0x2500)
+        self.box_chr_vert = chr(0x2502)
+
+    @classmethod
+    def from_conf(cls, conf: str, left: Optional[str] = None) -> Self:
+        """Initialize a Tabulator from a text table defining its columns.
+
+        Args:
+            conf (str): The table config.
+            left (str, optional): Optional string that is printed before each line (e.g., indents).
+        """
+        cols = []
+        for line in conf.strip().split('\n'):
+            words = line.split()
+
+            if len(words) < 3:
+                raise ValueError(f'Invalid col config (must be "just name width"): {line}.')
+
+            just = words[0]
+            name = ' '.join(words[1:-1])
+            width = int(words[-1])
+            cols.append((just, name, width))
+        return cls(cols, left)
+
+    def draw_row(self, row: Dict[str, Any]) -> str:
+        """Draw a row, given a mapping of column name to field value.
+
+        Args:
+            row (Dict[str, Any]): Mapping of column name to field value.
+
+        Returns:
+            str: Text line.
+        """
+        fields = []
+        for just, name, width in self.cols:
+            val = row[name]
+
+            txt = val if isinstance(val, str) else str(val)
+            if width < len(txt):
+                raise ValueError(f'Field is too wide for its column: column (just: {just}, ' +
+                                 f'name: {name}, width: {width}) vs field {txt}.')
+
+            txt = txt.ljust(width) if just == '<' else txt.rjust(width)
+            fields.append(txt)
+
+        left_txt = self.left or ''
+        fields_txt = f' {self.box_chr_vert} '.join(fields)
+        return f'{left_txt}{self.box_chr_vert} {fields_txt} {self.box_chr_vert}'
+
+    def draw_header(self) -> str:
+        """Draw a header row.
+
+        Returns:
+            str: Text line.
+        """
+        row = dict(zip(self.col_names, self.col_names))
+        return self.draw_row(row)
+
+    def draw_line(self) -> str:
+        """Draw a divider row.
+
+        Returns:
+            str: Text line.
+        """
+        seps = (self.box_chr_horiz * width for width in self.col_widths)
+        row = dict(zip(self.col_names, seps))
+        line = self.draw_row(row)
+        return line.replace(self.box_chr_vert, self.box_chr_horiz)


### PR DESCRIPTION
This benchmark serves to drive backend development, coming in the next PRs. As it is implemented, we plug it in here.

Backends in Streaming parlance are foreign systems which StreamingDataset calls out to or reads directly in order to serve samples.

```
$ time p3 -m benchmarks.backends.write
Generate: 717.963 sec.                                                                               
Found directory at data/backends/, wiping it for reuse

Write split: small
    ─ ──────── ─ ─────── ─ ──────────── ─ ──────── ─ ────────────── ─ ────── ─ ──────────── ─ ────────────── ─
    │ format   │     sec │      samples │  usec/sp │          bytes │  files │   bytes/file │ max bytes/file │
    ─ ──────── ─ ─────── ─ ──────────── ─ ──────── ─ ────────────── ─ ────── ─ ──────────── ─ ────────────── ─
    │ csv      │   1.519 │       32,768 │   46.344 │      2,926,965 │      3 │      975,655 │      2,795,297 │
    │ delta    │  14.511 │       32,768 │  442.834 │        965,066 │     66 │       14,622 │         29,836 │
    │ jsonl    │   1.186 │       32,768 │   36.192 │      3,549,499 │      3 │    1,183,166 │      3,417,881 │
    │ lance    │   0.077 │       32,768 │    2.350 │      2,983,593 │      4 │      745,898 │      2,983,041 │
    │ mds      │   0.166 │       32,768 │    5.073 │      2,982,097 │      2 │    1,491,048 │      2,981,772 │
    │ parquet  │   0.023 │       32,768 │    0.702 │      1,062,984 │      1 │    1,062,984 │      1,062,984 │
    ─ ──────── ─ ─────── ─ ──────────── ─ ──────── ─ ────────────── ─ ────── ─ ──────────── ─ ────────────── ─

Write split: medium
    ─ ──────── ─ ─────── ─ ──────────── ─ ──────── ─ ────────────── ─ ────── ─ ──────────── ─ ────────────── ─
    │ format   │     sec │      samples │  usec/sp │          bytes │  files │   bytes/file │ max bytes/file │
    ─ ──────── ─ ─────── ─ ──────────── ─ ──────── ─ ────────────── ─ ────── ─ ──────────── ─ ────────────── ─
    │ csv      │   3.610 │    1,048,576 │    3.443 │     93,686,651 │     23 │    4,073,332 │      8,388,602 │
    │ delta    │   4.098 │    1,048,576 │    3.908 │     29,391,561 │     66 │      445,326 │        912,199 │
    │ jsonl    │   6.550 │    1,048,576 │    6.247 │    113,610,514 │     29 │    3,917,603 │      8,388,579 │
    │ lance    │   0.552 │    1,048,576 │    0.526 │     95,495,604 │      7 │   13,642,229 │     23,878,871 │
    │ mds      │   4.497 │    1,048,576 │    4.289 │     95,456,073 │     13 │    7,342,774 │      8,388,608 │
    │ parquet  │   0.640 │    1,048,576 │    0.610 │     32,496,271 │      4 │    8,124,067 │      8,124,701 │
    ─ ──────── ─ ─────── ─ ──────────── ─ ──────── ─ ────────────── ─ ────── ─ ──────────── ─ ────────────── ─

Write split: large
    ─ ──────── ─ ─────── ─ ──────────── ─ ──────── ─ ────────────── ─ ────── ─ ──────────── ─ ────────────── ─
    │ format   │     sec │      samples │  usec/sp │          bytes │  files │   bytes/file │ max bytes/file │
    ─ ──────── ─ ─────── ─ ──────────── ─ ──────── ─ ────────────── ─ ────── ─ ──────────── ─ ────────────── ─
    │ csv      │  71.661 │   33,554,432 │    2.136 │  2,998,262,406 │    685 │    4,377,025 │      8,388,616 │
    │ jsonl    │ 174.832 │   33,554,432 │    5.210 │  3,635,816,298 │    837 │    4,343,866 │      8,388,608 │
    │ lance    │  14.238 │   33,554,432 │    0.424 │  3,056,134,893 │    131 │   23,329,273 │     23,891,240 │
    │ mds      │ 142.663 │   33,554,432 │    4.252 │  3,054,871,703 │    366 │    8,346,643 │      8,388,608 │
    │ parquet  │  20.720 │   33,554,432 │    0.617 │  1,039,974,715 │    128 │    8,124,802 │      8,129,982 │
    ─ ──────── ─ ─────── ─ ──────────── ─ ──────── ─ ────────────── ─ ────── ─ ──────────── ─ ────────────── ─

real    20m50.269s
user    20m1.404s
sys 0m28.315s
```
![plot](https://github.com/mosaicml/streaming/assets/2980246/eb51b278-351e-4ad0-8770-106366ab77a1)
