### PR TITLE
Logging messages from new defaults only show once per rank.

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -682,6 +682,8 @@ class StreamingDataset(Array, IterableDataset):
                 else:
                     if not self._rank_world.worker_of_rank:
                         print("\nWORKER OF RANK:", self._rank_world.worker_of_rank)
+                        print("\nWORKER:", self._rank_world.worker)
+                        print("\nWORKER OF NODE:", self._rank_world.worker_of_node)
                         logger.warning(
                             f'Because `num_canonical_nodes` was not specified, and ' +
                             f'`shuffle_algo` is {self.shuffle_algo}, it will default to ' +

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -681,15 +681,15 @@ class StreamingDataset(Array, IterableDataset):
                     self.num_canonical_nodes = 64 * world.num_nodes
                 else:
                     if not self._rank_world.worker_of_rank:
-                        print("\nWORKER OF RANK:", self._rank_world.worker_of_rank)
-                        print("\nWORKER:", self._rank_world.worker)
-                        print("\nWORKER OF NODE:", self._rank_world.worker_of_node)
+                        print("\nWORKER OF RANK:", self._rank_world.worker_of_rank, "WORKER:", self._rank_world.worker, "WORKER OF NODE:", self._rank_world.worker_of_node)
                         logger.warning(
                             f'Because `num_canonical_nodes` was not specified, and ' +
                             f'`shuffle_algo` is {self.shuffle_algo}, it will default to ' +
                             f'be equal to physical nodes. Prior to Streaming ' +
                             f'v0.7.0, `num_canonical_nodes` defaulted to 64 * physical ' +
                             f'nodes.')
+                    else:
+                        print("\nnot logging. WORKER OF RANK:", self._rank_world.worker_of_rank, "WORKER:", self._rank_world.worker, "WORKER OF NODE:", self._rank_world.worker_of_node)
                     self.num_canonical_nodes = world.num_nodes
             self._set_shuffle_block_size()
             return epoch, 0

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -681,6 +681,7 @@ class StreamingDataset(Array, IterableDataset):
                     self.num_canonical_nodes = 64 * world.num_nodes
                 else:
                     if not self._rank_world.worker_of_rank:
+                        print("\nWORKER OF RANK:", self._rank_world.worker_of_rank)
                         logger.warning(
                             f'Because `num_canonical_nodes` was not specified, and ' +
                             f'`shuffle_algo` is {self.shuffle_algo}, it will default to ' +

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -681,6 +681,7 @@ class StreamingDataset(Array, IterableDataset):
                     self.num_canonical_nodes = 64 * world.num_nodes
                 else:
                     if not world.worker_of_rank:
+                        print('yo we are here!!!!!')
                         logger.warning(
                             f'Because `num_canonical_nodes` was not specified, and ' +
                             f'`shuffle_algo` is {self.shuffle_algo}, it will default to ' +
@@ -703,7 +704,7 @@ class StreamingDataset(Array, IterableDataset):
                 if self.shuffle_algo in ['py1s', 'py2s']:
                     self.num_canonical_nodes = 64 * world.num_nodes
                 else:
-                    if not self._rank_world.worker_of_rank:
+                    if not world.worker_of_rank:
                         logger.warning(
                             f'Because `num_canonical_nodes` was not specified, and ' +
                             f'`shuffle_algo` is {self.shuffle_algo}, it will default to ' +

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -351,13 +351,6 @@ class StreamingDataset(Array, IterableDataset):
         # number of physical nodes of the initial run in the _resume function.
         self.initial_physical_nodes = None
 
-        # Initialize the World context.
-        #
-        # Beware: This information is for the per-rank process. DataLoader worker processes may see
-        # different values for these fields. We are saving the rank World here because we cannot
-        # instantiate a World inside the StreamingDataset destructor.
-        self._rank_world = world = World()
-
         # Check streams vs remote/local.
         if bool(streams) == (bool(remote) or bool(local)):
             raise ValueError(
@@ -447,6 +440,13 @@ class StreamingDataset(Array, IterableDataset):
         # Set streams.
         self.streams = streams
         self.num_streams = len(streams)
+
+        # Initialize the World context.
+        #
+        # Beware: This information is for the per-rank process. DataLoader worker processes may see
+        # different values for these fields. We are saving the rank World here because we cannot
+        # instantiate a World inside the StreamingDataset destructor.
+        self._rank_world = world = World()
 
         # Download each stream's index, load their shards, and map streams <-> shards.
         self.num_samples = 0

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -680,8 +680,8 @@ class StreamingDataset(Array, IterableDataset):
                 if self.shuffle_algo in ['py1s', 'py2s']:
                     self.num_canonical_nodes = 64 * world.num_nodes
                 else:
-                    if not self._rank_world.worker_of_rank:
-                        print("\nWORKER OF RANK:", self._rank_world.worker_of_rank, "WORKER:", self._rank_world.worker, "WORKER OF NODE:", self._rank_world.worker_of_node)
+                    if not world.worker_of_rank:
+                        print("\nWORKER OF RANK:", world.worker_of_rank, "WORKER:", world.worker, "WORKER OF NODE:", world.worker_of_node)
                         logger.warning(
                             f'Because `num_canonical_nodes` was not specified, and ' +
                             f'`shuffle_algo` is {self.shuffle_algo}, it will default to ' +
@@ -689,7 +689,7 @@ class StreamingDataset(Array, IterableDataset):
                             f'v0.7.0, `num_canonical_nodes` defaulted to 64 * physical ' +
                             f'nodes.')
                     else:
-                        print("\nnot logging. WORKER OF RANK:", self._rank_world.worker_of_rank, "WORKER:", self._rank_world.worker, "WORKER OF NODE:", self._rank_world.worker_of_node)
+                        print("\nnot logging. WORKER OF RANK:", world.worker_of_rank, "WORKER:", world.worker, "WORKER OF NODE:", world.worker_of_node)
                     self.num_canonical_nodes = world.num_nodes
             self._set_shuffle_block_size()
             return epoch, 0

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,11 +1,12 @@
 # Copyright 2023 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import math
 import os
 import shutil
 from multiprocessing import Process
-from typing import Any, Tuple
+from typing import Any, Callable, Tuple
 
 import pytest
 from torch.utils.data import DataLoader
@@ -16,32 +17,23 @@ from tests.common.utils import convert_to_mds
 
 
 @pytest.mark.usefixtures('local_remote_dir')
-def test_new_defaults_warning(local_remote_dir: Tuple[str, str],):
+def test_new_defaults_warning(local_remote_dir: Tuple[str, str], caplog: Callable):
+    caplog.set_level(logging.WARNING)
     local, remote = local_remote_dir
     convert_to_mds(out_root=remote,
                    dataset_name='sequencedataset',
-                   num_samples=300,
+                   num_samples=100,
                    size_limit=1 << 8)
 
-    with pytest.warns(UserWarning, match=f'Because `predownload` was not specified,*'):
-        # Build a StreamingDataset with new defaults. Should warn about the new defaults changes.
-        _ = StreamingDataset(local=local, remote=remote, shuffle=True)
+    # Build a StreamingDataset with new defaults. Should warn about the new defaults changes.
+    dataset = StreamingDataset(local=local, remote=remote, shuffle=True)
+    dataloader = StreamingDataLoader(dataset=dataset, batch_size=4)
+    for _ in dataloader:
+        pass
 
-    clean_stale_shared_memory()
-
-    with pytest.warns(UserWarning, match=f'Because `shuffle_block_size` was not specified,*'):
-        # Build a StreamingDataset with new defaults. Should warn about the new defaults changes.
-        for _ in StreamingDataset(local=local, remote=remote, shuffle=True):
-            pass
-
-    clean_stale_shared_memory()
-
-    with pytest.warns(UserWarning, match=f'Because `num_canonical_nodes` was not specified,*'):
-        # Build a StreamingDataset with new defaults. Should warn about the new defaults changes.
-        for _ in StreamingDataset(local=local, remote=remote, shuffle=True):
-            pass
-
-    clean_stale_shared_memory()
+    assert 'Because `predownload` was not specified,' in caplog.text
+    assert 'Because `shuffle_block_size` was not specified,' in caplog.text
+    assert 'Because `num_canonical_nodes` was not specified,' in caplog.text
 
 
 @pytest.mark.parametrize('batch_size', [4])


### PR DESCRIPTION
## Description of changes:

Previously, logging messages for the new defaults would be logged by every single dataloader worker per rank. This led to a lot of clutter in run logs. Now, they are only displayed once per rank. Before, logs looked like:
```
2023-12-18 20:12:38,916: rank0[1136][MainThread]: DEBUG: composer.trainer.trainer: Spinning the dataloaders
/usr/lib/python3/dist-packages/streaming/base/dataset.py:682: UserWarning: Because `num_canonical_nodes` was not specified, and `shuffle_algo` is py1e, it will default to be equal to physical nodes. Prior to Streaming v0.7.0, `num_canonical_nodes` defaulted to 64 * physical nodes.
  warnings.warn(f'Because `num_canonical_nodes` was not specified, and ' +
/usr/lib/python3/dist-packages/streaming/base/dataset.py:655: UserWarning: Because `shuffle_block_size` was not specified, it will default to max(4_000_000 // num_canonical_nodes, 1 << 18) if num_canonical_nodes is not None, otherwise 262144. Prior to Streaming v0.7.0, `shuffle_block_size` defaulted to 262144.
  warnings.warn(f'Because `shuffle_block_size` was not specified, it will default to ' +
/usr/lib/python3/dist-packages/streaming/base/dataset.py:682: UserWarning: Because `num_canonical_nodes` was not specified, and `shuffle_algo` is py1e, it will default to be equal to physical nodes. Prior to Streaming v0.7.0, `num_canonical_nodes` defaulted to 64 * physical nodes.
  warnings.warn(f'Because `num_canonical_nodes` was not specified, and ' +
/usr/lib/python3/dist-packages/streaming/base/dataset.py:655: UserWarning: Because `shuffle_block_size` was not specified, it will default to max(4_000_000 // num_canonical_nodes, 1 << 18) if num_canonical_nodes is not None, otherwise 262144. Prior to Streaming v0.7.0, `shuffle_block_size` defaulted to 262144.
  warnings.warn(f'Because `shuffle_block_size` was not specified, it will default to ' +
/usr/lib/python3/dist-packages/streaming/base/dataset.py:682: UserWarning: Because `num_canonical_nodes` was not specified, and `shuffle_algo` is py1e, it will default to be equal to physical nodes. Prior to Streaming v0.7.0, `num_canonical_nodes` defaulted to 64 * physical nodes.
  warnings.warn(f'Because `num_canonical_nodes` was not specified, and ' +
/usr/lib/python3/dist-packages/streaming/base/dataset.py:655: UserWarning: Because `shuffle_block_size` was not specified, it will default to max(4_000_000 // num_canonical_nodes, 1 << 18) if num_canonical_nodes is not None, otherwise 262144. Prior to Streaming v0.7.0, `shuffle_block_size` defaulted to 262144.
  warnings.warn(f'Because `shuffle_block_size` was not specified, it will default to ' +
/usr/lib/python3/dist-packages/streaming/base/dataset.py:682: UserWarning: Because `num_canonical_nodes` was not specified, and `shuffle_algo` is py1e, it will default to be equal to physical nodes. Prior to Streaming v0.7.0, `num_canonical_nodes` defaulted to 64 * physical nodes.
```
And now, they look like:
<img width="1384" alt="Screenshot 2023-12-18 at 3 21 04 PM" src="https://github.com/mosaicml/streaming/assets/28932043/0fc5319d-827f-406a-b059-e2e5908f6571">

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
