### PR TITLE
Download to temporary path from azure

### DIFF
--- a/streaming/base/storage/download.py
+++ b/streaming/base/storage/download.py
@@ -292,9 +292,11 @@ def download_from_azure(remote: str, local: str) -> None:
         credential=os.environ['AZURE_ACCOUNT_ACCESS_KEY'])
     try:
         blob_client = service.get_blob_client(container=obj.netloc, blob=obj.path.lstrip('/'))
-        with open(local, 'wb') as my_blob:
+        local_tmp = local + '.tmp'
+        with open(local_tmp, 'wb') as my_blob:
             blob_data = blob_client.download_blob()
             blob_data.readinto(my_blob)
+        os.rename(local_tmp, local)
     except ResourceNotFoundError as e:
         raise FileNotFoundError(f'Object {remote} not found.') from e
     except Exception:
@@ -324,9 +326,11 @@ def download_from_azure_datalake(remote: str, local: str) -> None:
     try:
         file_client = service.get_file_client(file_system=obj.netloc,
                                               file_path=obj.path.lstrip('/'))
-        with open(local, 'wb') as my_file:
+        local_tmp = local + '.tmp'
+        with open(local_tmp, 'wb') as my_file:
             file_data = file_client.download_file()
             file_data.readinto(my_file)
+        os.rename(local_tmp, local)
     except ResourceNotFoundError as e:
         raise FileNotFoundError(f'Object {remote} not found.') from e
     except Exception:


### PR DESCRIPTION
## Description of changes:

When downloading files from azure using `StreamingDataset`, we encountered an issue where when a shard download failed for any reason the first retry would appear to succeed, but the subsequent read from that file would cause a crash. This is because the first attempt had opened the file to write it but not cleaned it up properly, and the retry would encounter an existing but empty file at the local path, and skip downloading. 

Other object storage download implementations in the `download.py` file write to `<local path>.tmp`, then move the file to `<local path>` on completion, which avoids this issue. I have added this same pattern to the azure download methods. 

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
