### PR TITLE
Use `tempfile.gettempdir()` instead of a hardcoded temp root.

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os
 import sys
+from tempfile import gettempdir
 import warnings
 from concurrent.futures import ThreadPoolExecutor, wait
 from concurrent.futures._base import Future
@@ -512,7 +513,7 @@ class StreamingDataset(Array, IterableDataset):
         ]
         self._shm_prefix_int, self._locals_shm = get_shm_prefix(streams_local, streams_remote,
                                                                 world)
-        self._filelock_root = os.path.join(os.path.sep, 'tmp', 'streaming')
+        self._filelock_root = os.path.join(gettempdir(), 'streaming')
         os.makedirs(self._filelock_root, exist_ok=True)
 
         # Create the shared memory-backed barrier, without its lock, which is unpickleable.

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -7,12 +7,12 @@ import json
 import logging
 import os
 import sys
-from tempfile import gettempdir
 import warnings
 from concurrent.futures import ThreadPoolExecutor, wait
 from concurrent.futures._base import Future
 from enum import IntEnum
 from math import ceil
+from tempfile import gettempdir
 from threading import Event, Lock
 from time import sleep, time_ns
 from typing import Any, Dict, Iterator, Optional, Sequence, Tuple, Union


### PR DESCRIPTION
Small fix to make the StreamingDataset filelock root customizable.

```py
self._filelock_root = os.path.join(os.path.sep, 'tmp', 'streaming')
```

becomes

```py
self._filelock_root = os.path.join(gettempdir(), 'streaming')
```

Separately, there is a modernization effort underway which takes our learnings from the current shared memory-based run deconfliction and replaces it with a fully concurrency-safe rewrite using files and fnctl.