### PR TITLE
Update misplaced params of _format_remote_index_files

### DIFF
--- a/streaming/base/util.py
+++ b/streaming/base/util.py
@@ -429,7 +429,7 @@ def _merge_index_from_root(out: Union[str, Tuple[str, str]],
             local_index_files.append(file)
 
     if cu.remote:
-        remote_index_files = _format_remote_index_files(cu.list_objects(), cu.remote)
+        remote_index_files = _format_remote_index_files(cu.remote, cu.list_objects())
         if len(local_index_files) == len(remote_index_files):
             _merge_index_from_list(list(zip(local_index_files, remote_index_files)),
                                    out,


### PR DESCRIPTION
Misplaced params:
`_format_remote_index_files(cu.list_objects(), cu.remote)`

## Description of changes:

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->
A quick fix of a small bug in https://github.com/mosaicml/streaming/pull/576
`_format_remote_index_files(cu.list_objects(), cu.remote)`
should be 
`_format_remote_index_files(cu.remote, cu.list_objects())`



## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
