### PR TITLE
Change comparison in partitions to include equals

### DIFF
--- a/streaming/base/partition/orig.py
+++ b/streaming/base/partition/orig.py
@@ -81,8 +81,12 @@ def get_partitions_orig(num_samples: int,
             padding = node_ratio - overflow
     padded_samples_per_canonical_node = samples_per_canonical_node + padding
 
+    # For samples to be properly split across canonical nodes, there must be more samples than nodes.
+    # The edge case is when the number of samples is equal to the number of canonical nodes, but this only works when
+    #  there is an equal or greater number of canonical nodes than physical nodes.
+    # If these conditions are not met, an alternative sampling approach is used that leads to many repeats.
     if num_samples > num_canonical_nodes or (num_samples == num_canonical_nodes and
-                                             num_canonical_nodes > num_physical_nodes):
+                                             num_canonical_nodes >= num_physical_nodes):
         # Create the initial sample ID matrix.
         #
         # ids: (canonical nodes, padded samples per canonical node).

--- a/streaming/base/partition/orig.py
+++ b/streaming/base/partition/orig.py
@@ -81,7 +81,7 @@ def get_partitions_orig(num_samples: int,
             padding = node_ratio - overflow
     padded_samples_per_canonical_node = samples_per_canonical_node + padding
 
-    if num_samples > num_canonical_nodes:
+    if num_samples >= num_canonical_nodes:
         # Create the initial sample ID matrix.
         #
         # ids: (canonical nodes, padded samples per canonical node).

--- a/streaming/base/partition/orig.py
+++ b/streaming/base/partition/orig.py
@@ -81,7 +81,8 @@ def get_partitions_orig(num_samples: int,
             padding = node_ratio - overflow
     padded_samples_per_canonical_node = samples_per_canonical_node + padding
 
-    if num_samples >= num_canonical_nodes:
+    if num_samples > num_canonical_nodes or (num_samples == num_canonical_nodes and
+                                             num_canonical_nodes > num_physical_nodes):
         # Create the initial sample ID matrix.
         #
         # ids: (canonical nodes, padded samples per canonical node).


### PR DESCRIPTION
## Description of changes:

A warning is raised during partitioning when the number of canonical nodes is equal to the number of samples. It is my understanding that this should be valid (one sample per node), and that issues only occur when the number of samples is less than the number of canonical nodes. Apologies if my understanding is incorrect here. 

The simple fix is to the change the comparison to be `>=` rather than `>`

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
