### PR TITLE
Allow writers to overwrite existing data

### DIFF
--- a/streaming/base/format/base/writer.py
+++ b/streaming/base/format/base/writer.py
@@ -237,10 +237,6 @@ class Writer(ABC):
             'size_limit': self.size_limit
         }
 
-    def clear_local(self) -> None:
-        """Remove the local directory, allowing it to be written to."""
-        shutil.rmtree(self.local)
-
     @abstractmethod
     def flush_shard(self) -> None:
         """Flush cached samples to storage, creating a new shard."""

--- a/streaming/base/format/base/writer.py
+++ b/streaming/base/format/base/writer.py
@@ -100,7 +100,8 @@ class Writer(ABC):
 
         # Validate keyword arguments
         invalid_kwargs = [
-            arg for arg in kwargs.keys() if arg not in ('progress_bar', 'max_workers', 'retry')
+            arg for arg in kwargs.keys()
+            if arg not in ('progress_bar', 'max_workers', 'retry', 'exist_ok')
         ]
         if invalid_kwargs:
             raise ValueError(f'Invalid Writer argument(s): {invalid_kwargs} ')
@@ -117,7 +118,8 @@ class Writer(ABC):
         self.shards = []
 
         self.cloud_writer = CloudUploader.get(out, keep_local, kwargs.get('progress_bar', False),
-                                              kwargs.get('retry', 2))
+                                              kwargs.get('retry', 2),
+                                              kwargs.get('exist_ok', False))
         self.local = self.cloud_writer.local
         self.remote = self.cloud_writer.remote
         # `max_workers`: The maximum number of threads that can be executed in parallel.

--- a/streaming/base/format/base/writer.py
+++ b/streaming/base/format/base/writer.py
@@ -64,6 +64,9 @@ class Writer(ABC):
                 file to a remote location. Default to ``min(32, (os.cpu_count() or 1) + 4)``.
             retry (int): Number of times to retry uploading a file to a remote location.
                 Default to ``2``.
+            exist_ok (bool): If the local directory exists and is not empty, whether to overwrite
+                the content or raise an error. `False` raises an error. `True` deletes the
+                content and starts fresh. Defaults to `False`.
     """
 
     format: str = ''  # Name of the format (like "mds", "csv", "json", etc).

--- a/streaming/base/format/base/writer.py
+++ b/streaming/base/format/base/writer.py
@@ -120,9 +120,15 @@ class Writer(ABC):
 
         self.shards = []
 
+        # Remove local directory if requested prior to creating writer
+        local = out if isinstance(out, str) else out[0]
+        if os.path.exists(local) and kwargs.get('exist_ok', False):
+            logger.warning(
+                f'Directory {local} exists and is not empty; exist_ok is set to True so will remove contents.'
+            )
+            shutil.rmtree(local)
         self.cloud_writer = CloudUploader.get(out, keep_local, kwargs.get('progress_bar', False),
-                                              kwargs.get('retry', 2),
-                                              kwargs.get('exist_ok', False))
+                                              kwargs.get('retry', 2))
         self.local = self.cloud_writer.local
         self.remote = self.cloud_writer.remote
         # `max_workers`: The maximum number of threads that can be executed in parallel.
@@ -230,6 +236,10 @@ class Writer(ABC):
             'hashes': self.hashes,
             'size_limit': self.size_limit
         }
+
+    def clear_local(self) -> None:
+        """Remove the local directory, allowing it to be written to."""
+        shutil.rmtree(self.local)
 
     @abstractmethod
     def flush_shard(self) -> None:

--- a/streaming/base/format/json/writer.py
+++ b/streaming/base/format/json/writer.py
@@ -45,6 +45,9 @@ class JSONWriter(SplitWriter):
             max_workers (int): Maximum number of threads used to upload output dataset files in
                 parallel to a remote location. One thread is responsible for uploading one shard
                 file to a remote location. Default to ``min(32, (os.cpu_count() or 1) + 4)``.
+            exist_ok (bool): If the local directory exists and is not empty, whether to overwrite
+                the content or raise an error. `False` raises an error. `True` deletes the
+                content and starts fresh. Defaults to `False`.
     """
 
     format = 'json'

--- a/streaming/base/format/mds/writer.py
+++ b/streaming/base/format/mds/writer.py
@@ -45,6 +45,9 @@ class MDSWriter(JointWriter):
             max_workers (int): Maximum number of threads used to upload output dataset files in
                 parallel to a remote location. One thread is responsible for uploading one shard
                 file to a remote location. Default to ``min(32, (os.cpu_count() or 1) + 4)``.
+            exist_ok (bool): If the local directory exists and is not empty, whether to overwrite
+                the content or raise an error. `False` raises an error. `True` deletes the
+                content and starts fresh. Defaults to `False`.
     """
 
     format = 'mds'

--- a/streaming/base/format/xsv/writer.py
+++ b/streaming/base/format/xsv/writer.py
@@ -46,6 +46,9 @@ class XSVWriter(SplitWriter):
             max_workers (int): Maximum number of threads used to upload output dataset files in
                 parallel to a remote location. One thread is responsible for uploading one shard
                 file to a remote location. Default to ``min(32, (os.cpu_count() or 1) + 4)``.
+            exist_ok (bool): If the local directory exists and is not empty, whether to overwrite
+                the content or raise an error. `False` raises an error. `True` deletes the
+                content and starts fresh. Defaults to `False`.
     """
 
     format = 'xsv'

--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -170,8 +170,7 @@ class CloudUploader:
             if not exist_ok:
                 raise FileExistsError(
                     f'Directory is not empty: {self.local}. Set exist_ok to True to overwrite the current contents. '
-                    f'NOTE: this will delete the contents of {self.local}.'
-                )
+                    f'NOTE: this will delete the contents of {self.local}.')
             else:
                 logger.warning(
                     f'Directory {self.local} exists and is not empty; exist_ok is set to True so will remove contents.'

--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -171,8 +171,9 @@ class CloudUploader:
                 raise FileExistsError(f'Directory is not empty: {self.local}')
             else:
                 logger.warning(
-                    f'Directory {self.local} exists and not empty. But continue to mkdir since exist_ok is set to be True.'
+                    f'Directory {self.local} exists and not empty. Exist_ok is set to True so will remove contents.'
                 )
+                shutil.rmtree(self.local)
 
         os.makedirs(self.local, exist_ok=True)
 

--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -168,14 +168,11 @@ class CloudUploader:
 
         if os.path.exists(self.local) and len(os.listdir(self.local)) != 0:
             if not exist_ok:
-                raise FileExistsError(
-                    f'{self.local} not empty. Set exist_ok to True to overwrite the current contents (will delete).'
-                )
+                raise FileExistsError(f'Directory is not empty: {self.local}')
             else:
                 logger.warning(
-                    f'Directory {self.local} exists and is not empty; exist_ok is set to True so will remove contents.'
+                    f'Directory {self.local} exists and not empty. But continue to mkdir since exist_ok is set to be True.'
                 )
-                shutil.rmtree(self.local)
 
         os.makedirs(self.local, exist_ok=True)
 

--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -169,8 +169,8 @@ class CloudUploader:
         if os.path.exists(self.local) and len(os.listdir(self.local)) != 0:
             if not exist_ok:
                 raise FileExistsError(
-                    f'Directory is not empty: {self.local}. Set exist_ok to True to overwrite the current contents. '
-                    f'NOTE: this will delete the contents of {self.local}.')
+                    f'{self.local} not empty. Set exist_ok to True to overwrite the current contents (will delete).'
+                )
             else:
                 logger.warning(
                     f'Directory {self.local} exists and is not empty; exist_ok is set to True so will remove contents.'

--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -168,10 +168,13 @@ class CloudUploader:
 
         if os.path.exists(self.local) and len(os.listdir(self.local)) != 0:
             if not exist_ok:
-                raise FileExistsError(f'Directory is not empty: {self.local}')
+                raise FileExistsError(
+                    f'Directory is not empty: {self.local}. Set exist_ok to True to overwrite the current contents. '
+                    f'NOTE: this will delete the contents of {self.local}.'
+                )
             else:
                 logger.warning(
-                    f'Directory {self.local} exists and not empty. Exist_ok is set to True so will remove contents.'
+                    f'Directory {self.local} exists and is not empty; exist_ok is set to True so will remove contents.'
                 )
                 shutil.rmtree(self.local)
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -121,6 +121,34 @@ class TestMDSWriter:
         for before, after in zip(dataset, mds_dataset):
             assert before == after
 
+    def test_exist_ok(self, local_remote_dir: Tuple[str, str]) -> None:
+        num_samples = 1000
+        size_limit = 4096
+        local, _ = local_remote_dir
+        dataset = SequenceDataset(num_samples)
+        columns = dict(zip(dataset.column_names, dataset.column_encodings))
+
+        # Write entire dataset initially
+        with MDSWriter(out=local, columns=columns, size_limit=size_limit) as out:
+            for sample in dataset:
+                out.write(sample)
+        num_orig_files = len(os.listdir(local))
+
+        # Write single sample with exist_ok set to True
+        with MDSWriter(out=local, columns=columns, size_limit=size_limit, exist_ok=True) as out:
+            out.write(dataset[0])
+        num_files = len(os.listdir(local))
+
+        # Two files for single sample (index.json and one shard)
+        assert num_files == 2
+        # Should be more files generated for the entire dataset, which are then deleted as exist_ok is True
+        assert num_orig_files > num_files
+
+        # Check exception is raised when exist_ok is False and local already exists
+        with pytest.raises(FileExistsError, match='Directory is not empty'):
+            with MDSWriter(out=local, columns=columns, size_limit=size_limit) as out:
+                out.write(dataset[0])
+
 
 class TestJSONWriter:
 
@@ -176,6 +204,34 @@ class TestJSONWriter:
         # Ensure sample iterator is deterministic
         for before, after in zip(dataset, mds_dataset):
             assert before == after
+
+    def test_exist_ok(self, local_remote_dir: Tuple[str, str]) -> None:
+        num_samples = 1000
+        size_limit = 4096
+        local, _ = local_remote_dir
+        dataset = SequenceDataset(num_samples)
+        columns = dict(zip(dataset.column_names, dataset.column_encodings))
+
+        # Write entire dataset initially
+        with JSONWriter(out=local, columns=columns, size_limit=size_limit) as out:
+            for sample in dataset:
+                out.write(sample)
+        num_orig_files = len(os.listdir(local))
+
+        # Write single sample with exist_ok set to True
+        with JSONWriter(out=local, columns=columns, size_limit=size_limit, exist_ok=True) as out:
+            out.write(dataset[0])
+        num_files = len(os.listdir(local))
+
+        # Three files for single sample (index.json, one shard, and one shard metadata)
+        assert num_files == 3
+        # Should be more files generated for the entire dataset, which are then deleted as exist_ok is True
+        assert num_orig_files > num_files
+
+        # Check exception is raised when exist_ok is False and local already exists
+        with pytest.raises(FileExistsError, match='Directory is not empty'):
+            with JSONWriter(out=local, columns=columns, size_limit=size_limit) as out:
+                out.write(dataset[0])
 
 
 class TestXSVWriter:
@@ -256,3 +312,50 @@ class TestXSVWriter:
         # Ensure sample iterator is deterministic
         for before, after in zip(dataset, mds_dataset):
             assert before == after
+
+    @pytest.mark.parametrize('writer', [XSVWriter, TSVWriter, CSVWriter])
+    def test_exist_ok(self, local_remote_dir: Tuple[str, str], writer: Any) -> None:
+        num_samples = 1000
+        size_limit = 4096
+        local, _ = local_remote_dir
+        dataset = SequenceDataset(num_samples)
+        columns = dict(zip(dataset.column_names, dataset.column_encodings))
+
+        # Write entire dataset initially
+        if writer.__name__ == XSVWriter.__name__:
+            with writer(out=local, columns=columns, size_limit=size_limit, separator=',') as out:
+                for sample in dataset:
+                    out.write(sample)
+        else:
+            with writer(out=local, columns=columns, size_limit=size_limit) as out:
+                for sample in dataset:
+                    out.write(sample)
+        num_orig_files = len(os.listdir(local))
+
+        # Write single sample with exist_ok set to True
+        if writer.__name__ == XSVWriter.__name__:
+            with writer(out=local,
+                        columns=columns,
+                        size_limit=size_limit,
+                        separator=',',
+                        exist_ok=True) as out:
+                out.write(dataset[0])
+        else:
+            with writer(out=local, columns=columns, size_limit=size_limit, exist_ok=True) as out:
+                out.write(dataset[0])
+        num_files = len(os.listdir(local))
+
+        # Three files for single sample (index.json, one shard, and one shard metadata)
+        assert num_files == 3
+        # Should be more files generated for the entire dataset, which are then deleted as exist_ok is True
+        assert num_orig_files > num_files
+
+        # Check exception is raised when exist_ok is False and local already exists
+        with pytest.raises(FileExistsError, match='Directory is not empty'):
+            if writer.__name__ == XSVWriter.__name__:
+                with writer(out=local, columns=columns, size_limit=size_limit,
+                            separator=',') as out:
+                    out.write(dataset[0])
+            else:
+                with writer(out=local, columns=columns, size_limit=size_limit) as out:
+                    out.write(dataset[0])


### PR DESCRIPTION
## Description of changes:

CloudUploader has an `exist_ok` kwarg that is set to False by default.  
Writers (e.g. MDSWriter) cannot overwrite this.  

This PR makes two changes:
1. `exist_ok` can now be set by a writer.
2. If `exist_ok` is True, existing files are now deleted. This allows easy debugging when developing streaming datasets as the files do not have to be manually deleted each time the code is run.

Tests and docs updated accordingly.

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

