### PR TITLE
Replicating samples across devices (SP / TP enablement)

### DIFF
--- a/streaming/base/dataloader.py
+++ b/streaming/base/dataloader.py
@@ -71,7 +71,7 @@ class StreamingDataLoader(DataLoader):
             Optional[Dict[str, Any]]: The state, if a streaming dataset.
         """
         if isinstance(self.dataset, StreamingDataset):
-            world = World()
+            world = World.detect()
             num_samples = self.num_samples_yielded * world.num_ranks
             return self.dataset.state_dict(num_samples, False)
         return None

--- a/streaming/base/world.py
+++ b/streaming/base/world.py
@@ -129,15 +129,11 @@ class World:
         if self.num_ranks % ratio:
             raise ValueError(f'World size must be divisible by your tensor parallelism ratio.')
 
-        rank = self.rank // ratio
-        num_ranks = self.num_ranks // ratio
-        worker = rank * self.workers_per_rank + self.worker_of_rank
-        if self.ranks_per_node <= num_ranks:
-            num_nodes = num_ranks // self.ranks_per_node
-            ranks_per_node = self.ranks_per_node
-        else:
-            num_nodes = 1
-            ranks_per_node = num_ranks
+        rank = self.rank // ratio  # Evenly divide ranks.
+        num_ranks = self.num_ranks // ratio  # Floor divide our rank.
+        worker = rank * self.workers_per_rank + self.worker_of_rank  # Derive worker.
+        num_nodes = (num_ranks + self.ranks_per_node - 1) // self.ranks_per_node  # Ceil divide.
+        ranks_per_node = num_ranks // num_nodes  # Evenly divide ranks per node.
         return World(
             num_nodes=num_nodes,
             ranks_per_node=ranks_per_node,

--- a/streaming/base/world.py
+++ b/streaming/base/world.py
@@ -3,7 +3,7 @@
 
 """Information about nodes, ranks, and workers."""
 
-from typing import Tuple
+from typing import Any, Dict, Tuple
 
 from torch.utils.data import get_worker_info
 from typing_extensions import Self
@@ -47,7 +47,7 @@ class World:
         workers_per_rank: int,
         worker: int,
     ) -> None:
-        self.node = workers_per_rank // (ranks_per_node * workers_per_rank)
+        self.node = worker // (ranks_per_node * workers_per_rank)
         self.num_nodes = num_nodes
         self.is_multinode = 1 < num_nodes
 
@@ -64,6 +64,14 @@ class World:
         self.workers_per_rank = workers_per_rank
         self.is_leader = not worker
         self.is_local_leader = not self.worker_of_node
+
+    def to_json(self) -> Dict[str, Any]:
+        """Get a JSON version of this config.
+
+        Returns:
+            Dict[str, Any]: JSON config.
+        """
+        return dict(self.__dict__)
 
     @classmethod
     def _get_worker_info(cls) -> Tuple[int, int]:

--- a/streaming/base/world.py
+++ b/streaming/base/world.py
@@ -113,14 +113,20 @@ class World:
         if 0 <= ratio:
             raise ValueError(f'Tensor parallelism ratio must be postiive.')
 
-        if self.ranks_per_node % ratio:
-            raise ValueError(f'Ranks per node must be divisible by your tensor parallelism ratio.')
+        if self.num_ranks % ratio:
+            raise ValueError(f'World size must be divisible by your tensor parallelism ratio.')
 
-        rank_of_node = self.rank_of_node // ratio
-        ranks_per_node = self.ranks_per_node // ratio
-        worker = rank_of_node * self.workers_per_rank + self.worker_of_rank
+        rank = self.rank // ratio
+        num_ranks = self.num_ranks // ratio
+        worker = rank * self.workers_per_rank + self.worker_of_rank
+        if self.ranks_per_node <= num_ranks:
+            num_nodes = num_ranks // self.ranks_per_node
+            ranks_per_node = self.ranks_per_node
+        else:
+            num_nodes = 1
+            ranks_per_node = num_ranks
         return World(
-            num_nodes=self.num_nodes,
+            num_nodes=num_nodes,
             ranks_per_node=ranks_per_node,
             workers_per_rank=self.workers_per_rank,
             worker=worker,

--- a/streaming/base/world.py
+++ b/streaming/base/world.py
@@ -123,7 +123,7 @@ class World:
         Returns:
             Self: A new tensor-parallel version of this World state object.
         """
-        if 0 <= ratio:
+        if ratio <= 0:
             raise ValueError(f'Tensor parallelism ratio must be postiive.')
 
         if self.num_ranks % ratio:

--- a/streaming/base/world.py
+++ b/streaming/base/world.py
@@ -114,23 +114,24 @@ class World:
             worker=self.worker,
         )
 
-    def tensor_parallel(self, ratio: int) -> Self:
-        """Get a copy of this world state with the given tensor paralellism.
+    def replicate(self, replication: int) -> Self:
+        """Get a copy of this world state with the given replication factor.
 
         Args:
-            ratio (int): Ratio of tensor parallelism.
+            replication (int): Replication factor -- how many consecutive devices that should see
+                the same samples..
 
         Returns:
-            Self: A new tensor-parallel version of this World state object.
+            Self: A new sample replication version of this World state object.
         """
-        if ratio <= 0:
-            raise ValueError(f'Tensor parallelism ratio must be postiive.')
+        if replication <= 0:
+            raise ValueError(f'Replication factor must be positive.')
 
-        if self.num_ranks % ratio:
-            raise ValueError(f'World size must be divisible by your tensor parallelism ratio.')
+        if self.num_ranks % replication:
+            raise ValueError(f'World size must be divisible by your replication factor.')
 
-        rank = self.rank // ratio  # Evenly divide ranks.
-        num_ranks = self.num_ranks // ratio  # Floor divide our rank.
+        rank = self.rank // replication  # Evenly divide ranks.
+        num_ranks = self.num_ranks // replication  # Floor divide our rank.
         worker = rank * self.workers_per_rank + self.worker_of_rank  # Derive worker.
         num_nodes = (num_ranks + self.ranks_per_node - 1) // self.ranks_per_node  # Ceil divide.
         ranks_per_node = num_ranks // num_nodes  # Evenly divide ranks per node.

--- a/streaming/base/world.py
+++ b/streaming/base/world.py
@@ -101,6 +101,19 @@ class World:
         worker = rank * workers_per_rank + worker_of_rank
         return cls(num_nodes, ranks_per_node, workers_per_rank, worker)
 
+    def copy(self) -> Self:
+        """Get a copy of this world state.
+
+        Returns:
+            Self: A new copy with the same state.
+        """
+        return World(
+            num_nodes=self.num_nodes,
+            ranks_per_node=self.ranks_per_node,
+            workers_per_rank=self.workers_per_rank,
+            worker=self.worker,
+        )
+
     def tensor_parallel(self, ratio: int) -> Self:
         """Get a copy of this world state with the given tensor paralellism.
 

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -8,6 +8,9 @@ import numpy as np
 import pytest
 
 from streaming.base.partition import get_partitions
+from streaming.base.batching import generate_work
+from streaming.base.partition import get_partitions
+from streaming.base.world import World
 
 
 @pytest.mark.parametrize('partition_algo', ['orig', 'relaxed'])
@@ -222,3 +225,79 @@ def test_partition_nodrop_norepeat(physical_nodes: int, canonical_nodes: int, ra
 
     assert len(samples_seen) == num_samples
     assert samples_seen_set == set(range(num_samples))
+
+@pytest.mark.parametrize('physical_nodes', [1, 4])
+@pytest.mark.parametrize('canonical_nodes', [12, 4])
+@pytest.mark.parametrize('ranks_per_node', [8])
+@pytest.mark.parametrize('workers_per_rank', [1, 8])
+@pytest.mark.parametrize('batch_size', [2])
+@pytest.mark.parametrize('num_samples', [1024])
+@pytest.mark.parametrize('sample_in_epoch', [0, 256])
+@pytest.mark.parametrize('replication', [2, 4])
+def test_replication_samples(physical_nodes: int, canonical_nodes: int, ranks_per_node: int,
+                             workers_per_rank: int, batch_size: int, num_samples: int,
+                             sample_in_epoch: int, replication: int):
+    
+    # Create a World object reflecting the hardware -- the actual nodes and rank
+    actual_world = World(physical_nodes, ranks_per_node, workers_per_rank, 0)
+
+    # Create the World object with the given replication factor
+    replication_world = actual_world.replicate(replication)
+    
+    # Get the sample partition using attributes from the replication World object
+    sample_ids = get_partitions('relaxed', num_samples, canonical_nodes,
+                                replication_world.num_nodes, replication_world.ranks_per_node,
+                                replication_world.workers_per_rank, batch_size,
+                                sample_in_epoch, replication_world.num_nodes)
+
+    # Loop over all of the actual nodes/workers/ranks and check that the samples are replicated
+    # according to the `replication` factor.
+    # Use World objects to correctly index into the sample_ids partition.
+    # This is what happens during actual training.
+    for n in range(physical_nodes):
+        for w in range(workers_per_rank):
+            for r in range(0, ranks_per_node, replication):
+                # Get the actual and replication World objects for this node/rank/worker.
+                # This ensures we have the right rank and worker indices in the World objects.
+                baseline_worker_id = (n * ranks_per_node + r) * workers_per_rank + w
+                baseline_actual_world = World(physical_nodes, ranks_per_node,
+                                              workers_per_rank, baseline_worker_id)
+                baseline_replication_world = baseline_actual_world.replicate(replication)
+                # Check that the sample ids are all the same for this replication group
+                baseline_sample_ids = sample_ids[baseline_replication_world.node,
+                                                 baseline_replication_world.rank_of_node,
+                                                 baseline_replication_world.worker_of_rank]
+                # Loop over the replication group and make sure the sample ids are all the same.
+                for i in range(1, replication):
+                    repeated_worker_id = (n * ranks_per_node + r + i) * workers_per_rank + w
+                    repeated_actual_world = World(physical_nodes, ranks_per_node,
+                                                   workers_per_rank, repeated_worker_id)
+                    repeated_replication_world = repeated_actual_world.replicate(replication)
+                    repeated_sample_ids = sample_ids[repeated_replication_world.node,
+                                                     repeated_replication_world.rank_of_node,
+                                                     repeated_replication_world.worker_of_rank]
+                    assert np.array_equal(baseline_sample_ids, repeated_sample_ids)
+                
+@pytest.mark.parametrize('num_nodes', [4])
+@pytest.mark.parametrize('ranks_per_node', [8])
+@pytest.mark.parametrize('workers_per_rank', [2])
+@pytest.mark.parametrize('replication', [-10, 0])
+def test_replication_negative(num_nodes: int, ranks_per_node: int,
+                              workers_per_rank: int, replication: int):
+    
+    orig_world = World(num_nodes, ranks_per_node, workers_per_rank, 0)
+
+    with pytest.raises(ValueError, match=f'Replication factor must be positive.*'):
+        orig_world.replicate(replication)
+
+@pytest.mark.parametrize('num_nodes', [4, 8])
+@pytest.mark.parametrize('ranks_per_node', [8])
+@pytest.mark.parametrize('workers_per_rank', [2])
+@pytest.mark.parametrize('replication', [7, 11])
+def test_replication_divides_world_size(num_nodes: int, ranks_per_node: int, 
+                                        workers_per_rank: int, replication: int):
+    
+    orig_world = World(num_nodes, ranks_per_node, workers_per_rank, 0)
+
+    with pytest.raises(ValueError, match=f'World size must be divisible by*'):
+        orig_world.replicate(replication)

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -8,8 +8,6 @@ import numpy as np
 import pytest
 
 from streaming.base.partition import get_partitions
-from streaming.base.batching import generate_work
-from streaming.base.partition import get_partitions
 from streaming.base.world import World
 
 
@@ -226,6 +224,7 @@ def test_partition_nodrop_norepeat(physical_nodes: int, canonical_nodes: int, ra
     assert len(samples_seen) == num_samples
     assert samples_seen_set == set(range(num_samples))
 
+
 @pytest.mark.parametrize('physical_nodes', [1, 4])
 @pytest.mark.parametrize('canonical_nodes', [12, 4])
 @pytest.mark.parametrize('ranks_per_node', [8])
@@ -237,18 +236,18 @@ def test_partition_nodrop_norepeat(physical_nodes: int, canonical_nodes: int, ra
 def test_replication_samples(physical_nodes: int, canonical_nodes: int, ranks_per_node: int,
                              workers_per_rank: int, batch_size: int, num_samples: int,
                              sample_in_epoch: int, replication: int):
-    
+
     # Create a World object reflecting the hardware -- the actual nodes and rank
     actual_world = World(physical_nodes, ranks_per_node, workers_per_rank, 0)
 
     # Create the World object with the given replication factor
     replication_world = actual_world.replicate(replication)
-    
+
     # Get the sample partition using attributes from the replication World object
     sample_ids = get_partitions('relaxed', num_samples, canonical_nodes,
                                 replication_world.num_nodes, replication_world.ranks_per_node,
-                                replication_world.workers_per_rank, batch_size,
-                                sample_in_epoch, replication_world.num_nodes)
+                                replication_world.workers_per_rank, batch_size, sample_in_epoch,
+                                replication_world.num_nodes)
 
     # Loop over all of the actual nodes/workers/ranks and check that the samples are replicated
     # according to the `replication` factor.
@@ -260,8 +259,8 @@ def test_replication_samples(physical_nodes: int, canonical_nodes: int, ranks_pe
                 # Get the actual and replication World objects for this node/rank/worker.
                 # This ensures we have the right rank and worker indices in the World objects.
                 baseline_worker_id = (n * ranks_per_node + r) * workers_per_rank + w
-                baseline_actual_world = World(physical_nodes, ranks_per_node,
-                                              workers_per_rank, baseline_worker_id)
+                baseline_actual_world = World(physical_nodes, ranks_per_node, workers_per_rank,
+                                              baseline_worker_id)
                 baseline_replication_world = baseline_actual_world.replicate(replication)
                 # Check that the sample ids are all the same for this replication group
                 baseline_sample_ids = sample_ids[baseline_replication_world.node,
@@ -270,33 +269,35 @@ def test_replication_samples(physical_nodes: int, canonical_nodes: int, ranks_pe
                 # Loop over the replication group and make sure the sample ids are all the same.
                 for i in range(1, replication):
                     repeated_worker_id = (n * ranks_per_node + r + i) * workers_per_rank + w
-                    repeated_actual_world = World(physical_nodes, ranks_per_node,
-                                                   workers_per_rank, repeated_worker_id)
+                    repeated_actual_world = World(physical_nodes, ranks_per_node, workers_per_rank,
+                                                  repeated_worker_id)
                     repeated_replication_world = repeated_actual_world.replicate(replication)
                     repeated_sample_ids = sample_ids[repeated_replication_world.node,
                                                      repeated_replication_world.rank_of_node,
                                                      repeated_replication_world.worker_of_rank]
                     assert np.array_equal(baseline_sample_ids, repeated_sample_ids)
-                
+
+
 @pytest.mark.parametrize('num_nodes', [4])
 @pytest.mark.parametrize('ranks_per_node', [8])
 @pytest.mark.parametrize('workers_per_rank', [2])
 @pytest.mark.parametrize('replication', [-10, 0])
-def test_replication_negative(num_nodes: int, ranks_per_node: int,
-                              workers_per_rank: int, replication: int):
-    
+def test_replication_negative(num_nodes: int, ranks_per_node: int, workers_per_rank: int,
+                              replication: int):
+
     orig_world = World(num_nodes, ranks_per_node, workers_per_rank, 0)
 
     with pytest.raises(ValueError, match=f'Replication factor must be positive.*'):
         orig_world.replicate(replication)
 
+
 @pytest.mark.parametrize('num_nodes', [4, 8])
 @pytest.mark.parametrize('ranks_per_node', [8])
 @pytest.mark.parametrize('workers_per_rank', [2])
 @pytest.mark.parametrize('replication', [7, 11])
-def test_replication_divides_world_size(num_nodes: int, ranks_per_node: int, 
-                                        workers_per_rank: int, replication: int):
-    
+def test_replication_divides_world_size(num_nodes: int, ranks_per_node: int, workers_per_rank: int,
+                                        replication: int):
+
     orig_world = World(num_nodes, ranks_per_node, workers_per_rank, 0)
 
     with pytest.raises(ValueError, match=f'World size must be divisible by*'):

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -15,7 +15,7 @@ from tests.common.utils import convert_to_mds
 def test_get_shm_prefix(local_remote_dir: Tuple[str, str]):
     local, remote = local_remote_dir
 
-    _, _ = get_shm_prefix(streams_local=[local], streams_remote=[remote], world=World())
+    _, _ = get_shm_prefix(streams_local=[local], streams_remote=[remote], world=World.detect())
 
 
 @pytest.mark.usefixtures('local_remote_dir')
@@ -24,7 +24,7 @@ def test_get_shm_prefix_same_local_dir(local_remote_dir: Tuple[str, str]):
     with pytest.raises(ValueError, match='Reused local directory.*Provide a different one.'):
         _, _ = get_shm_prefix(streams_local=[local, local],
                               streams_remote=[remote, remote],
-                              world=World())
+                              world=World.detect())
 
 
 @pytest.mark.usefixtures('local_remote_dir')
@@ -32,17 +32,17 @@ def test_get_shm_prefix_same_split_dir(local_remote_dir: Tuple[str, str]):
     local, remote = local_remote_dir
     _, _ = get_shm_prefix(streams_local=[local, remote],
                           streams_remote=[local, remote],
-                          world=World())
+                          world=World.detect())
     with pytest.raises(ValueError, match='Reused local directory.*vs.*Provide a different one.'):
         _, _ = get_shm_prefix(streams_local=[local, remote],
                               streams_remote=[local, remote],
-                              world=World())
+                              world=World.detect())
 
 
 def test_same_local_remote_none(local_remote_dir: Tuple[str, str]):
     local, _ = local_remote_dir
-    _, _ = get_shm_prefix(streams_local=[local], streams_remote=[None], world=World())
-    _, _ = get_shm_prefix(streams_local=[local], streams_remote=[None], world=World())
+    _, _ = get_shm_prefix(streams_local=[local], streams_remote=[None], world=World.detect())
+    _, _ = get_shm_prefix(streams_local=[local], streams_remote=[None], world=World.detect())
 
 
 @pytest.mark.parametrize('from_beginning', [True, False])


### PR DESCRIPTION
### 1. `World`

- Streaming's model of the world/the run/the job is (num nodes, ranks per node) rank processes + (num nodes, ranks per node, workers per rank) worker processes.
- For example, 8 ranks, 8 workers/rank -> 8 + 8 * 8 = 72 StreamingDataset replicas per node.
- Currently they coordinate via filelocks and shared memory.
- A `World` is just our wrapper around `torch.dist` and `torch.utils.data.get_worker_info`.
- The `World` just tells you which one you are, out of how many (nodes, ranks/node, workers/rank).
- There's always only one `World`, semantically speaking.
- However, when in a rank, `get_worker_info()` will say we are worker 0 of 1. One has to keep that in mind.

### 2. `StreamingDataset` argument `replication: Optional[int]`

- `replication` iterates the same samples for groups of adjacent GPUs (ranks).
- It does this by scaling down (in number) and repeating ranks.
- But the underlying data doesn't change, so we are correspondingly scaling up the ranks (in length).
- It prefers to merge ranks within the same node first, then if it needs to merge further, across node boundaries.