### PR TITLE
Column logical (not physical) type and allow_schema_mismatch

### DIFF
--- a/simulation/core/sim_dataset.py
+++ b/simulation/core/sim_dataset.py
@@ -363,7 +363,7 @@ class SimulationDataset(StreamingDataset):
                 shutil.rmtree(local_foldernames[stream_idx])
 
         # Build the shard index (for partitioning and mapping samples to shards).
-        self.samples_per_shard = np.array([shard.samples for shard in self.shards], np.int64)
+        self.samples_per_shard = np.array([shard.num_samples for shard in self.shards], np.int64)
         self.sample_offset_per_shard = self.samples_per_shard.cumsum() - self.samples_per_shard
         self.spanner = SimulationSpanner(self.samples_per_shard)
 

--- a/streaming/dataset.py
+++ b/streaming/dataset.py
@@ -516,7 +516,7 @@ class StreamingDataset(Array, IterableDataset):
             self.cache_limit = None
 
         # Build the shard index (for partitioning and mapping samples to shards).
-        self.samples_per_shard = np.array([shard.samples for shard in self.shards], np.int64)
+        self.samples_per_shard = np.array([shard.num_samples for shard in self.shards], np.int64)
         self.sample_offset_per_shard = self.samples_per_shard.cumsum() - self.samples_per_shard
         self.spanner = Spanner(self.samples_per_shard)
 

--- a/streaming/format/base/shard/base.py
+++ b/streaming/format/base/shard/base.py
@@ -37,7 +37,7 @@ class Shard(Array):
     ) -> None:
         self.conf = conf
         self.stream = stream
-        self.num_samples = self.samples = num_samples
+        self.num_samples = num_samples
         self.files = files
 
     @classmethod

--- a/streaming/format/base/shard/dual_row.py
+++ b/streaming/format/base/shard/dual_row.py
@@ -3,10 +3,11 @@
 
 """Streaming shard abstract base classes."""
 
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from streaming.format.base.file import ShardFile
 from streaming.format.base.shard.row import RowShard
+from streaming.format.base.type import Type as LogicalType
 from streaming.stream.dir_conf import StreamDirConf
 
 __all__ = ['DualRowShard']
@@ -31,6 +32,7 @@ class DualRowShard(RowShard):
         conf: Optional[Any] = None,
         stream: StreamDirConf,
         num_samples: int,
+        logical_columns: Dict[str, LogicalType],
         data_file: ShardFile,
         meta_file: ShardFile,
     ) -> None:
@@ -38,6 +40,7 @@ class DualRowShard(RowShard):
             conf=conf,
             stream=stream,
             num_samples=num_samples,
+            logical_columns=logical_columns,
             files=[data_file, meta_file],
         )
         self.data_file = data_file

--- a/streaming/format/base/shard/mono_row.py
+++ b/streaming/format/base/shard/mono_row.py
@@ -3,10 +3,11 @@
 
 """Streaming shard abstract base classes."""
 
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from streaming.format.base.file import ShardFile
 from streaming.format.base.shard.row import RowShard
+from streaming.format.base.type import Type as LogicalType
 from streaming.stream.dir_conf import StreamDirConf
 
 __all__ = ['MonoRowShard']
@@ -30,12 +31,14 @@ class MonoRowShard(RowShard):
         conf: Optional[Any] = None,
         stream: StreamDirConf,
         num_samples: int,
+        logical_columns: Dict[str, LogicalType],
         file: ShardFile,
     ) -> None:
         super().__init__(
             conf=conf,
             stream=stream,
             num_samples=num_samples,
+            logical_columns=logical_columns,
             files=[file],
         )
         self.file = file

--- a/streaming/format/base/type.py
+++ b/streaming/format/base/type.py
@@ -1,0 +1,167 @@
+# Copyright 2022-2024 MosaicML Streaming authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The Streaming logical type hierarchy.
+
+This is a common language of types which the type systems of all Streaming shard formats are mapped
+to. A field is stored as its shard format-specific physical type, and loaded and returned as its
+logical type.
+"""
+
+from typing import Optional, Tuple
+
+import numpy as np
+from numpy.typing import DTypeLike
+
+__all__ = [
+    'Type', 'Bytes', 'Str', 'Number', 'Decimal', 'Float', 'Float64', 'Float32', 'Float16', 'Int',
+    'Int64', 'Int32', 'Int16', 'Int8', 'UInt64', 'UInt32', 'UInt16', 'UInt8', 'Bool', 'NDArray',
+    'Image', 'JSON', 'Pickle'
+]
+
+
+class Type:
+    """Logical type."""
+
+    def get_signature(self) -> str:
+        """Get a string representation of this logical type.
+
+        Returns:
+            str: String representation.
+        """
+        return self.__class__.__name__
+
+
+class Bytes(Type):
+    """Bytes logical type."""
+    pass
+
+
+class Str(Type):
+    """UTF-8 string logical type."""
+    pass
+
+
+class Number(Type):
+    """Number logical type."""
+    pass
+
+
+class Decimal(Number):
+    """Decimal logical type."""
+    pass
+
+
+class Float(Number):
+    """Native floating point logical type.
+
+    This logical type refers to your programming language's default floating point type. Presumably
+    the value will have been serialized at that precision or higher.
+
+    For example, in Python/CPython, the language has its own ``float`` type, which is internally
+    backed by a ``double`` in the implementation.
+    """
+    pass
+
+
+class Float64(Float):
+    """Float64 logical type."""
+    pass
+
+
+class Float32(Float64):
+    """Float32 logical type."""
+    pass
+
+
+class Float16(Float32):
+    """Float16 logical type."""
+    pass
+
+
+class Int(Number):
+    """Arbitrary-precision integer logical type."""
+    pass
+
+
+class Int64(Int):
+    """``int64`` logical type."""
+    pass
+
+
+class Int32(Int64):
+    """``int32`` logical type."""
+    pass
+
+
+class Int16(Int32):
+    """``int16`` logical type."""
+    pass
+
+
+class Int8(Int16):
+    """``int8`` logical type."""
+    pass
+
+
+class UInt64(Int):
+    """``uint64`` logical type."""
+    pass
+
+
+class UInt32(UInt64):
+    """``uint32`` logical type."""
+    pass
+
+
+class UInt16(UInt32):
+    """``uint16`` logical type."""
+    pass
+
+
+class UInt8(UInt16):
+    """``uint8`` logical type."""
+    pass
+
+
+class Bool(UInt8):
+    """``bool`` logical type."""
+    pass
+
+
+class NDArray(Type):
+    """Numpy ndarray logical type.
+
+    Args:
+        shape (Tuple[int], optional): Optional shape requirement.
+        dtype (DTypeLike, optional): Optional dtype requirement.
+    """
+
+    def __init__(
+        self,
+        shape: Optional[Tuple[int]] = None,
+        dtype: Optional[DTypeLike] = None,
+    ) -> None:
+        self.shape = shape
+        self.dtype = np.dtype(dtype) if dtype else None
+
+    def get_signature(self) -> str:
+        logical_type = self.__class__.__name__
+        shape = ','.join(map(str, self.shape)) if self.shape else ''
+        dtype = self.dtype.name if self.dtype else ''
+        return ':'.join([logical_type, shape, dtype])
+
+
+class Image(Type):
+    """PIL Image logical type."""
+    pass
+
+
+class JSON(Type):
+    """JSON logical type."""
+    pass
+
+
+class Pickle(Type):
+    """Pickle logical type."""
+    pass

--- a/streaming/format/jsonl/encodings.py
+++ b/streaming/format/jsonl/encodings.py
@@ -6,7 +6,12 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-__all__ = ['is_jsonl_encoded', 'is_jsonl_encoding']
+from streaming.format.base.type import Float as LogicalFloat
+from streaming.format.base.type import Int as LogicalInt
+from streaming.format.base.type import Str as LogicalStr
+from streaming.format.base.type import Type as LogicalType
+
+__all__ = ['is_jsonl_encoded', 'is_jsonl_encoding', 'jsonl_encoding_to_logical_type']
 
 
 class Encoding(ABC):
@@ -36,6 +41,8 @@ class Encoding(ABC):
 class Str(Encoding):
     """Store str."""
 
+    logical_type = LogicalStr
+
     @classmethod
     def is_encoded(cls, obj: Any) -> bool:
         return cls._validate(obj, str)
@@ -43,6 +50,8 @@ class Str(Encoding):
 
 class Int(Encoding):
     """Store int."""
+
+    logical_type = LogicalInt
 
     @classmethod
     def is_encoded(cls, obj: Any) -> bool:
@@ -52,12 +61,18 @@ class Int(Encoding):
 class Float(Encoding):
     """Store float."""
 
+    logical_type = LogicalFloat
+
     @classmethod
     def is_encoded(cls, obj: Any) -> bool:
         return cls._validate(obj, float)
 
 
-_encodings = {'str': Str, 'int': Int, 'float': Float}
+_encodings = {
+    'str': Str,
+    'int': Int,
+    'float': Float,
+}
 
 
 def is_jsonl_encoded(encoding: str, value: Any) -> bool:
@@ -84,3 +99,16 @@ def is_jsonl_encoding(encoding: str) -> bool:
         bool: Whether encoding is supported.
     """
     return encoding in _encodings
+
+
+def jsonl_encoding_to_logical_type(encoding: str) -> LogicalType:
+    """Get the logical type of the given encoding.
+
+    Args:
+        encoding (str): Encoding.
+
+    Returns:
+        LogicalType: Its logical type.
+    """
+    cls = _encodings[encoding]
+    return cls.logical_type()

--- a/streaming/format/mds/shard.py
+++ b/streaming/format/mds/shard.py
@@ -14,7 +14,8 @@ from typing_extensions import Self
 from streaming.format.base.file import ShardFile
 from streaming.format.base.phase import ShardFilePhase
 from streaming.format.base.shard.mono_row import MonoRowShard
-from streaming.format.mds.encodings import is_mds_encoding_safe, mds_decode
+from streaming.format.mds.encodings import (is_mds_encoding_safe, mds_decode,
+                                            mds_encoding_to_logical_type)
 from streaming.stream.dir_conf import StreamDirConf
 
 __all__ = ['MDSShard']
@@ -51,10 +52,14 @@ class MDSShard(MonoRowShard):
         file: ShardFile,
         columns: List[MDSColumn],
     ) -> None:
+        col_names = [col.name for col in columns]
+        col_logical_types = [mds_encoding_to_logical_type(col.encoding) for col in columns]
+        logical_columns = dict(zip(col_names, col_logical_types))
         super().__init__(
             conf=conf,
             stream=stream,
             num_samples=num_samples,
+            logical_columns=logical_columns,
             file=file,
         )
         self.columns = columns

--- a/streaming/format/xsv/encodings.py
+++ b/streaming/format/xsv/encodings.py
@@ -6,7 +6,12 @@
 from abc import ABC, abstractmethod
 from typing import Any
 
-__all__ = ['is_xsv_encoding', 'xsv_decode', 'xsv_encode']
+from streaming.format.base.type import Float as LogicalFloat
+from streaming.format.base.type import Int as LogicalInt
+from streaming.format.base.type import Str as LogicalStr
+from streaming.format.base.type import Type as LogicalType
+
+__all__ = ['is_xsv_encoding', 'xsv_encoding_to_logical_type', 'xsv_decode', 'xsv_encode']
 
 
 class Encoding(ABC):
@@ -48,6 +53,8 @@ class Encoding(ABC):
 class Str(Encoding):
     """Store str."""
 
+    logical_type = LogicalStr
+
     @classmethod
     def encode(cls, obj: Any) -> str:
         cls._validate(obj, str)
@@ -60,6 +67,8 @@ class Str(Encoding):
 
 class Int(Encoding):
     """Store int."""
+
+    logical_type = LogicalInt
 
     @classmethod
     def encode(cls, obj: Any) -> str:
@@ -74,6 +83,8 @@ class Int(Encoding):
 class Float(Encoding):
     """Store float."""
 
+    logical_type = LogicalFloat
+
     @classmethod
     def encode(cls, obj: Any) -> str:
         cls._validate(obj, float)
@@ -84,7 +95,11 @@ class Float(Encoding):
         return float(obj)
 
 
-_encodings = {'str': Str, 'int': Int, 'float': Float}
+_encodings = {
+    'str': Str,
+    'int': Int,
+    'float': Float,
+}
 
 
 def is_xsv_encoding(encoding: str) -> bool:
@@ -97,6 +112,19 @@ def is_xsv_encoding(encoding: str) -> bool:
         bool: Whether encoding is supported.
     """
     return encoding in _encodings
+
+
+def xsv_encoding_to_logical_type(encoding: str) -> LogicalType:
+    """Get the logical type of the given encoding.
+
+    Args:
+        encoding (str): Encoding.
+
+    Returns:
+        LogicalType: Its logical type.
+    """
+    cls = _encodings[encoding]
+    return cls.logical_type()
 
 
 def xsv_encode(encoding: str, value: Any) -> str:

--- a/streaming/format/xsv/shard.py
+++ b/streaming/format/xsv/shard.py
@@ -11,7 +11,7 @@ from typing_extensions import Self
 from streaming.format.base.file import ShardFile
 from streaming.format.base.phase import ShardFilePhase
 from streaming.format.base.shard.dual_row import DualRowShard
-from streaming.format.xsv.encodings import xsv_decode
+from streaming.format.xsv.encodings import xsv_decode, xsv_encoding_to_logical_type
 from streaming.stream.dir_conf import StreamDirConf
 
 __all__ = ['XSVShard']
@@ -47,15 +47,19 @@ class XSVShard(DualRowShard):
         newline: str,
         separator: Optional[str],
     ) -> None:
+        column_logical_types = list(map(xsv_encoding_to_logical_type, column_encodings))
+        logical_columns = dict(zip(column_names, column_logical_types))
         super().__init__(
             conf=conf,
             stream=stream,
             num_samples=num_samples,
+            logical_columns=logical_columns,
             data_file=data_file,
             meta_file=meta_file,
         )
         self.column_names = column_names
         self.column_encodings = column_encodings
+        self.column_logical_types = column_logical_types
         self.newline = newline
         self.separator = separator
 


### PR DESCRIPTION
This PR was split out of a larger Parquet streaming PR, to follow.

1. Implement `allow_schema_mismatch` -- checks all shards to verify that their schema (column name and type signatures) match. This functionality is an important safety check for Parquet streaming relating to accidentally including Parquet files and other user error.
2. We are able to do this across shard types (a string field in a JSONL shard should be returned the same as that same string field in an MDS shard, say) because we now have the concept of logical (as opposed to physical) column types. Logical column types are Streaming's vocabulary of types which are shared by all shard formats, which each shard's encodings map to. Shard formats (really, talking about MDS here) may have multiple ways to encode a value, that all have the same logical type.