### PR TITLE
Add allow_unsafe_types args to StreamingCOCO

### DIFF
--- a/streaming/vision/coco.py
+++ b/streaming/vision/coco.py
@@ -68,6 +68,9 @@ class StreamingCOCO(StreamingDataset):
         shuffle_algo (str): Which shuffling algorithm to use. Defaults to ``py1s``.
         shuffle_seed (int): Seed for Deterministic data shuffling. Defaults to ``9176``.
         shuffle_block_size (int): Unit of shuffle. Defaults to ``1 << 18``.
+        allow_unsafe_types (bool): If a shard contains Pickle, which allows arbitrary code
+            execution during deserialization, whether to keep going if ``True`` or raise an error
+            if ``False``. Defaults to ``False``.
         transform (callable, optional): A function/transform that takes in an image and bboxes and
             returns a transformed version. Defaults to ``None``.
     """
@@ -91,6 +94,7 @@ class StreamingCOCO(StreamingDataset):
                  shuffle_algo: str = 'py1s',
                  shuffle_seed: int = 9176,
                  shuffle_block_size: int = 1 << 18,
+                 allow_unsafe_types: bool = False,
                  transform: Optional[Callable] = None) -> None:
         super().__init__(remote=remote,
                          local=local,
@@ -108,7 +112,8 @@ class StreamingCOCO(StreamingDataset):
                          shuffle=shuffle,
                          shuffle_algo=shuffle_algo,
                          shuffle_seed=shuffle_seed,
-                         shuffle_block_size=shuffle_block_size)
+                         shuffle_block_size=shuffle_block_size,
+                         allow_unsafe_types=allow_unsafe_types)
         self.transform = transform
 
     def get_item(self, idx: int) -> Any:


### PR DESCRIPTION
## Description of changes:
- The COCO dataset conversion script uses pickle data format for [bounding boxes](https://github.com/mosaicml/streaming/blob/main/streaming/vision/convert/coco.py#L205-L206). Hence, we need an arg `allow_unsafe_types` to the downstream class (StreamingCOCO) to allow iteration.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:
https://github.com/mosaicml/streaming/issues/567

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
