### PR TITLE
Make streaming use the correct number of unique samples with SP/TP

### DIFF
--- a/streaming/base/dataloader.py
+++ b/streaming/base/dataloader.py
@@ -73,6 +73,13 @@ class StreamingDataLoader(DataLoader):
         if isinstance(self.dataset, StreamingDataset):
             world = World.detect()
             num_samples = self.num_samples_yielded * world.num_ranks
+            if self.dataset.replication is not None:
+                # Check if we are using `replication`. If we are, then we need to adjust the
+                # `num_samples_yielded` to reflect the fact that sample ids are shared across
+                # `replication` consecutive devices. For example, if `replication` is 2, then the
+                # number of samples seen is half the number of samples yielded, since every pair
+                # of devices shares sample ids. So the index into the sample partition is halved.
+                num_samples = num_samples // self.dataset.replication
             return self.dataset.state_dict(num_samples, False)
         return None
 

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -1006,8 +1006,8 @@ class StreamingDataset(Array, IterableDataset):
             # `repetition` consecutive devices. For example, if `repetition` is 2, then the
             # sample id partition will be half as large, since every pair of devices shares
             # sample ids. So the `sample_in_epoch` offset for the partition is also halved.
-            if self.replication is not None:
-                sample_in_epoch = sample_in_epoch // self.replication
+            # if self.replication is not None:
+            #     sample_in_epoch = sample_in_epoch // self.replication
             epoch_sample_ids = generate_work(self.batching_method, self, p_world, epoch,
                                              sample_in_epoch)
             shape_shm, data_shm = self._share_work(epoch_sample_ids)

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -1002,10 +1002,10 @@ class StreamingDataset(Array, IterableDataset):
         # Do expensive work that may use a lot of cores/memory just once, in the local leader.
         if u_world.is_local_leader:
             if self.replication is not None and not u_world.worker_of_rank:
-                logger.warning(f'The `replication` has been set and training is resuming ',
-                               f'from sample {sample_in_epoch}. Make sure you are accounting ',
-                               f"for sample replication when using StreamingDataset's ",
-                               f'`state_dict` method for deterministic resumption. Otherwise, ',
+                logger.warning(f'The `replication` arg has been set and training is resuming ' +
+                               f'from sample {sample_in_epoch}. Make sure you are accounting ' +
+                               f"for sample replication when using StreamingDataset's " +
+                               f'`state_dict` method for deterministic resumption. Otherwise, ' +
                                f'you will resume training from the wrong sample.')
             epoch_sample_ids = generate_work(self.batching_method, self, p_world, epoch,
                                              sample_in_epoch)


### PR DESCRIPTION
## Description of changes:
The TP/SP PR assumed that streaming would track/receive an increased number of samples when using SP/TP. For example, with `replication` = 2, Composer would previously track the # of elapsed samples without taking into account replication, which meant that even if 100 unique samples had been seen in training, since `replication` was 2, Composer would think that 200 samples had been seen, and pass that on to Streaming for resumption.

This issue was previously addressed by dividing the sample offset on resumption. With Composer now correctly calculating the number of unique samples elapsed during training, this fix is not needed on the Streaming side.

This change means we also need to track # unique samples using `StreamingDataLoader`.

Tested this with Shashank's help -- loss curves are overlapping on resumption.
<img width="971" alt="Screenshot 2024-03-04 at 6 13 05 PM" src="https://github.com/mosaicml/streaming/assets/28932043/3870b2c3-bcdc-4d41-a1f5-3c7418ade907">


<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
