### PR TITLE
Modify StreamingDataset to support passing process_group as construct…

### DIFF
--- a/streaming/base/dataloader.py
+++ b/streaming/base/dataloader.py
@@ -71,7 +71,7 @@ class StreamingDataLoader(DataLoader):
             Optional[Dict[str, Any]]: The state, if a streaming dataset.
         """
         if isinstance(self.dataset, StreamingDataset):
-            world = World.detect()
+            world = World.detect(self.dataset.process_group)
             num_samples = self.num_samples_yielded * world.num_ranks
             if self.dataset.replication is not None:
                 # Check if we are using `replication`. If we are, then we need to adjust the

--- a/streaming/base/shared/prefix.py
+++ b/streaming/base/shared/prefix.py
@@ -9,10 +9,11 @@ prevent shared resources like shared memory from colliding.
 
 from collections import Counter
 from time import sleep
-from typing import Iterator, List, Tuple, Union
+from typing import Iterator, List, Optional, Tuple, Union
 
 import numpy as np
 from torch import distributed as dist
+from torch.distributed.distributed_c10d import ProcessGroup
 
 from streaming.base.constant import LOCALS, TICK
 from streaming.base.shared import SharedMemory
@@ -165,7 +166,8 @@ def _check_and_find_retrying(streams_local: List[str], streams_remote: List[Unio
 def get_shm_prefix(streams_local: List[str],
                    streams_remote: List[Union[str, None]],
                    world: World,
-                   retry: int = 100) -> Tuple[int, SharedMemory]:
+                   retry: int = 100,
+                   process_group: Optional[ProcessGroup] = None) -> Tuple[int, SharedMemory]:
     """Register or lookup our shared memory prefix.
 
     Args:
@@ -193,7 +195,7 @@ def get_shm_prefix(streams_local: List[str],
         shm.buf[:len(data)] = data
 
     if dist.is_available() and dist.is_initialized():
-        dist.barrier()
+        dist.barrier(process_group)
 
     # Non-local leaders go next, searching for match.
     if not world.is_local_leader:

--- a/streaming/base/world.py
+++ b/streaming/base/world.py
@@ -3,8 +3,9 @@
 
 """Information about nodes, ranks, and workers."""
 
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 
+from torch.distributed.distributed_c10d import ProcessGroup
 from torch.utils.data import get_worker_info
 from typing_extensions import Self
 
@@ -88,15 +89,18 @@ class World:
         return ret
 
     @classmethod
-    def detect(cls) -> Self:
+    def detect(cls, process_group: Optional[ProcessGroup] = None) -> Self:
         """Detect the world state.
+
+        Args:
+            process_group (ProcessGroup, optional): the process group used to determine world state
 
         Returns:
             Self: A new World state object according to dist and get_worker_info().
         """
-        rank = dist.get_rank()
-        ranks_per_node = dist.get_local_world_size()
-        num_nodes = dist.get_world_size() // ranks_per_node
+        rank = dist.get_rank(process_group)
+        ranks_per_node = dist.get_local_world_size(process_group)
+        num_nodes = dist.get_world_size(process_group) // ranks_per_node
         worker_of_rank, workers_per_rank = cls._get_worker_info()
         worker = rank * workers_per_rank + worker_of_rank
         return cls(num_nodes, ranks_per_node, workers_per_rank, worker)


### PR DESCRIPTION
…or arg

## Description of changes:

Modify StreamingDataset to support passing process_group as a constructor argument. Currently, StreamingDataset assumes it should use the default process group; however, for certain use cases (e.g., Pipeline Distributed Parallel training), users may want to specify a different process group. This change accommodates this flexibility. 

## Issue #, if available:

N/A

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [X] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [X] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [X] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.
