### PR TITLE
COCO Dataset fix -- avoids `allow_unsafe_types=True`

### DIFF
--- a/streaming/vision/convert/coco.py
+++ b/streaming/vision/convert/coco.py
@@ -181,8 +181,8 @@ def each(dataset: _COCODetection, shuffle: bool) -> Iterable[Dict[str, bytes]]:
             'img_id': img_id,
             'htot': htot,
             'wtot': wtot,
-            'bbox_sizes': bbox_sizes,  # (_, 4) float32.
-            'bbox_labels': bbox_labels,  # int64.
+            'bbox_sizes': np.array(bbox_sizes, dtype=np.float32),  # (_,4) np.float32 array.
+            'bbox_labels': np.array(bbox_labels, dtype=np.int64),  # np.int64 array.
         }
 
 
@@ -202,8 +202,8 @@ def main(args: Namespace) -> None:
         'img_id': 'int',
         'htot': 'int',
         'wtot': 'int',
-        'bbox_sizes': 'pkl',
-        'bbox_labels': 'pkl'
+        'bbox_sizes': 'ndarray:float32',
+        'bbox_labels': 'ndarray:int64',
     }
 
     for (split, expected_num_samples, shuffle) in [


### PR DESCRIPTION
## Description of changes:

Modified the mds conversion types for the COCO dataset to ensure that it does not use `pkl` at all.

Verified by downloading raw COCO dataset, converting to MDS, and then iterating over a dataset that used the materialized MDS files.

Replacement for #614, addresses #567 

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
