### PR TITLE
Ensure shards cannot be larger than 4GB

### DIFF
--- a/streaming/base/format/base/writer.py
+++ b/streaming/base/format/base/writer.py
@@ -99,6 +99,10 @@ class Writer(ABC):
             if size_limit_value < 0:
                 raise ValueError(f'`size_limit` must be greater than zero, instead, ' +
                                  f'found as {size_limit_value}.')
+            if size_limit_value >= 2**32:
+                raise ValueError(f'`size_limit` must be less than 2**32, instead, ' +
+                                 f'found as {size_limit_value}. This is because sample ' +
+                                 f'byte offsets are stored with uint32.')
 
         # Validate keyword arguments
         invalid_kwargs = [

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -25,6 +25,13 @@ class TestMDSWriter:
         with pytest.raises(ValueError, match=f'.*Invalid Writer argument.*'):
             _ = MDSWriter(out=local, columns=columns, min_workers=1)
 
+    def test_max_size_limit(self, local_remote_dir: Tuple[str, str]):
+        local, _ = local_remote_dir
+        dataset = SequenceDataset(100)
+        columns = dict(zip(dataset.column_names, dataset.column_encodings))
+        with pytest.raises(ValueError, match=f'`size_limit` must be less than*'):
+            _ = MDSWriter(out=local, columns=columns, size_limit=2**32)
+
     @pytest.mark.parametrize('num_samples', [100])
     @pytest.mark.parametrize('size_limit', [32])
     def test_config(self, local_remote_dir: Tuple[str, str], num_samples: int,
@@ -152,6 +159,13 @@ class TestMDSWriter:
 
 class TestJSONWriter:
 
+    def test_max_size_limit(self, local_remote_dir: Tuple[str, str]):
+        local, _ = local_remote_dir
+        dataset = SequenceDataset(100)
+        columns = dict(zip(dataset.column_names, dataset.column_encodings))
+        with pytest.raises(ValueError, match=f'`size_limit` must be less than*'):
+            _ = JSONWriter(out=local, columns=columns, size_limit=2**32)
+
     @pytest.mark.parametrize('num_samples', [100])
     @pytest.mark.parametrize('size_limit', [32])
     def test_config(self, local_remote_dir: Tuple[str, str], num_samples: int,
@@ -235,6 +249,14 @@ class TestJSONWriter:
 
 
 class TestXSVWriter:
+
+    def test_max_size_limit(self, local_remote_dir: Tuple[str, str]):
+        local, _ = local_remote_dir
+        dataset = SequenceDataset(100)
+        columns = dict(zip(dataset.column_names, dataset.column_encodings))
+        separator = ','
+        with pytest.raises(ValueError, match=f'`size_limit` must be less than*'):
+            _ = XSVWriter(out=local, columns=columns, separator=separator, size_limit=2**32)
 
     @pytest.mark.parametrize('num_samples', [100])
     @pytest.mark.parametrize('size_limit', [32])


### PR DESCRIPTION
## Description of changes:
Based on issue #659, users have seen that shards exceeding 4GB are not possible since we are encoding sample byte offsets using uint32, which has a max value of `2**32 - 1`. To prevent users from hitting sample access errors much later, we instead will throw an error here.

If there are future use cases that MUST use shards larger than 4GB, we can revisit this and increase the byte offset encoding type to uint64 if applicable. This is currently not the case for any workload we support, including vision.

Added unit tests to all 3 writer types ensuring that the error is thrown correctly.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
