### PR TITLE
Helpful error on `py1e` for improperly written datasets

### DIFF
--- a/streaming/base/shuffle/py1e.py
+++ b/streaming/base/shuffle/py1e.py
@@ -72,6 +72,13 @@ def get_shuffle_py1e(shard_sizes: NDArray[np.int64],
         cn_spans = spans[cn_begin:cn_end]
         cn_span_sizes = np.array([end - begin for begin, end in cn_spans])
         num_cn_samples = cn_span_sizes.sum()
+        if num_cn_samples == 0.0:
+            raise ValueError(f'The number of samples assigned to a canonical node is 0. This ' +
+                             f'very likely indicates that the number of samples in this stream ' +
+                             f'is less than the number of canonical nodes, which is ' +
+                             f'{num_canonical_nodes}. Please check your index.json file and ' +
+                             f'ensure that your dataset has been written out correctly. ' +
+                             f'If this was intended, reduce num_canonical_nodes.')
         # The spans of a canonical node are shuffled, so they have sample ids that are
         # not contiguous. We need to get the correct sample ids for the current canonical node.
         cn_samples = np.empty(num_cn_samples)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -19,6 +19,31 @@ from tests.common.utils import convert_to_mds
 
 
 @pytest.mark.usefixtures('local_remote_dir')
+def test_tiny_dataset_exception(local_remote_dir: Tuple[str, str]):
+
+    remote_dir, local_dir = local_remote_dir
+    convert_to_mds(out_root=remote_dir,
+                   dataset_name='sequencedataset',
+                   num_samples=1,
+                   size_limit=1 << 8)
+
+    # Build StreamingDataset
+    dataset = StreamingDataset(
+        local=local_dir,
+        remote=remote_dir,
+        shuffle=True,
+        num_canonical_nodes=2,
+        batch_size=1,
+    )
+
+    with pytest.raises(ValueError, match=f'The number of samples assigned to a canonical node*'):
+        # When we iterate through the dataset, we should throw an error because
+        # the number of samples is greater than num_canonical_nodes.
+        for _ in dataset:
+            pass
+
+
+@pytest.mark.usefixtures('local_remote_dir')
 def test_no_batch_size_exception(local_remote_dir: Tuple[str, str]):
 
     remote_dir, local_dir = local_remote_dir


### PR DESCRIPTION
## Description of changes:
Previously, if your dataset had less samples than the num canonical nodes, there would be an uninformative error thrown in py1e. Now, this has been remedied. Added a unit test to check if the error is thrown as well.

No other shuffling algo has this issue :)

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
