### PR TITLE
Fix node calculation in `replication` for `World` object

### DIFF
--- a/docs/source/getting_started/main_concepts.md
+++ b/docs/source/getting_started/main_concepts.md
@@ -99,14 +99,12 @@ Below, we pass in a list of {class}`streaming.Stream` objects to a {class}`strea
 stream_1 = Stream(
     remote = 's3://stream_1/directory',
     local = '/local/cache/stream_1',
-    batch_size = 4,
     proportion = 0.25,
 )
 # Stream 2 is similar to above, but will be 3/4 of the training dataset.
 stream_2 = Stream(
     remote = 's3://stream_2/directory',
     local = '/local/cache/stream_2',
-    batch_size = 4,
     proportion = 0.75,
 )
 

--- a/streaming/base/world.py
+++ b/streaming/base/world.py
@@ -133,7 +133,12 @@ class World:
         rank = self.rank // replication  # Evenly divide ranks.
         num_ranks = self.num_ranks // replication  # Floor divide our rank.
         worker = rank * self.workers_per_rank + self.worker_of_rank  # Derive worker.
-        num_nodes = (num_ranks + self.ranks_per_node - 1) // self.ranks_per_node  # Ceil divide.
+        # Attempt to evenly divide ranks per node. If not possible, the World
+        # object will just use one node.
+        if num_ranks % self.ranks_per_node == 0:
+            num_nodes = num_ranks // self.ranks_per_node
+        else:
+            num_nodes = 1
         ranks_per_node = num_ranks // num_nodes  # Evenly divide ranks per node.
         return World(
             num_nodes=num_nodes,

--- a/tests/test_partition.py
+++ b/tests/test_partition.py
@@ -225,17 +225,21 @@ def test_partition_nodrop_norepeat(physical_nodes: int, canonical_nodes: int, ra
     assert samples_seen_set == set(range(num_samples))
 
 
-@pytest.mark.parametrize('physical_nodes', [1, 4])
+@pytest.mark.parametrize('physical_nodes', [1, 4, 7, 13])
 @pytest.mark.parametrize('canonical_nodes', [12, 4, 64])
 @pytest.mark.parametrize('ranks_per_node', [8])
 @pytest.mark.parametrize('workers_per_rank', [1, 8])
 @pytest.mark.parametrize('batch_size', [2, 8])
 @pytest.mark.parametrize('num_samples', [1024, 16384])
 @pytest.mark.parametrize('sample_in_epoch', [0, 256])
-@pytest.mark.parametrize('replication', [2, 4])
+@pytest.mark.parametrize('replication', [2, 4, 8])
 def test_replication_samples(physical_nodes: int, canonical_nodes: int, ranks_per_node: int,
                              workers_per_rank: int, batch_size: int, num_samples: int,
                              sample_in_epoch: int, replication: int):
+
+    # Make sure canonical nodes works with physical nodes
+    if physical_nodes % canonical_nodes != 0 and canonical_nodes % physical_nodes != 0:
+        canonical_nodes = physical_nodes
 
     # Create a World object reflecting the hardware -- the actual nodes and rank
     actual_world = World(physical_nodes, ranks_per_node, workers_per_rank, 0)


### PR DESCRIPTION
## Description of changes:

A customer was hitting an issue where the number of nodes was not being calculated correctly in the `replication` function of the `World` object. This is because we did not properly account and test for cases where the number of TP blocks was not cleanly divisible by the original number of ranks per node. For example, with 37 nodes, 8 GPUs per node, and `replication` of 8, the `World` object returned by the `replication` function would have 5 nodes and 7 ranks per node, which did not account for the last 2 TP blocks (which in this case, were the last 2 nodes).

To address this, we check if the number of TP blocks is divisible by the number of ranks per node, and if it's not, we set the number of nodes to 1. So, using the previous example, we now return a `World` object with 1 node and 37 ranks in the node, corresponding to the 37 TP blocks. Download optimality is still guaranteed with 1 node since canonical nodes will still be partitioned among these 37 ranks of the new `World` object, ensuring that no node will have to download more samples than intended.

I also expanded the test cases to include previously failing cases, since the test runs very fast anyways.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
