### PR TITLE
Warning condition changed for Sequence Parallelism

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -995,12 +995,12 @@ class StreamingDataset(Array, IterableDataset):
 
         # Do expensive work that may use a lot of cores/memory just once, in the local leader.
         if u_world.is_local_leader:
-            if self.replication is not None and not u_world.worker_of_rank:
-                logger.warning(f'The `replication` arg has been set and training is resuming ' +
-                               f'from sample {sample_in_epoch}. Make sure you are accounting ' +
-                               f"for sample replication when using StreamingDataset's " +
-                               f'`state_dict` method for deterministic resumption. Otherwise, ' +
-                               f'you will resume training from the wrong sample.')
+            if self.replication is not None and self.replication > 1 and not u_world.worker_of_rank:
+                logger.warning(f'The `replication` arg has been set to {self.replication} and ' +
+                               f'training is resuming from sample {sample_in_epoch}. ' +
+                               f'Make sure you are accounting for sample replication when using ' +
+                               f"StreamingDataset's `state_dict` method for deterministic resumption. " +
+                               f'Otherwise, you will resume training from the wrong sample.')
             # Ensure that batch_size is passed in, and is an integer. This is necessary for
             # deterministic resumption and optimal performance.
             if not isinstance(self.batch_size, int):


### PR DESCRIPTION
## Description of changes:

It is confusing to see the warning message when replication is set to 1. 
Changed to only show the warning when replication > 1 I.e., sequence parallelism is actually in action. 

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
