### PR TITLE
Make sure epoch_size is an int

### DIFF
--- a/docs/source/getting_started/main_concepts.md
+++ b/docs/source/getting_started/main_concepts.md
@@ -99,14 +99,12 @@ Below, we pass in a list of {class}`streaming.Stream` objects to a {class}`strea
 stream_1 = Stream(
     remote = 's3://stream_1/directory',
     local = '/local/cache/stream_1',
-    batch_size = 4,
     proportion = 0.25,
 )
 # Stream 2 is similar to above, but will be 3/4 of the training dataset.
 stream_2 = Stream(
     remote = 's3://stream_2/directory',
     local = '/local/cache/stream_2',
-    batch_size = 4,
     proportion = 0.75,
 )
 

--- a/streaming/base/stream.py
+++ b/streaming/base/stream.py
@@ -288,7 +288,7 @@ class Stream:
             stream.repeat = repeat
             stream.choose = choose
 
-        return choose_per_epoch
+        return int(choose_per_epoch)
 
     def _download_file(self, from_basename: str, to_basename: Optional[str] = None) -> str:
         """Safely download a file from remote to local cache.


### PR DESCRIPTION
## Description of changes:
This is a small fix to make sure that `self.epoch_size` is an int instead of `numpy.int64`. This will make sure that we get all of Python's int-related errors, such as a ZeroDivisionError thrown at [this line](https://github.com/mosaicml/streaming/blob/4f338e1cdffcda415ca3937289fd4c8b317039f9/streaming/base/dataset.py#L519) if `self._parallel_rank_world.num_ranks` is 0, for example.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
