### PR TITLE
fix: expand user path for Writer's output directory.

### DIFF
--- a/streaming/base/format/base/writer.py
+++ b/streaming/base/format/base/writer.py
@@ -124,7 +124,7 @@ class Writer(ABC):
         self.shards = []
 
         # Remove local directory if requested prior to creating writer
-        local = os.path.expanduser(out) if isinstance(out, str) else out[0]
+        local = os.path.expanduser(out) if isinstance(out, str) else os.path.expanduser(out[0])
         if os.path.exists(local) and kwargs.get('exist_ok', False):
             logger.warning(
                 f'Directory {local} exists and is not empty; exist_ok is set to True so will remove contents.'

--- a/streaming/base/format/base/writer.py
+++ b/streaming/base/format/base/writer.py
@@ -124,7 +124,7 @@ class Writer(ABC):
         self.shards = []
 
         # Remove local directory if requested prior to creating writer
-        local = out if isinstance(out, str) else out[0]
+        local = os.path.expanduser(out) if isinstance(out, str) else out[0]
         if os.path.exists(local) and kwargs.get('exist_ok', False):
             logger.warning(
                 f'Directory {local} exists and is not empty; exist_ok is set to True so will remove contents.'


### PR DESCRIPTION
## Description of changes:

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

When setting the `out` argument of `Writer` (e.g. MDSWriter) to something like `~/awesome-streamdataset`, it will create a directory in current workdir named with "~" which is quite strange.

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

BTW, it seems that `pre-commit run -a` and `pytest -vv -s .` does not work well on the latest main branch.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
