### PR TITLE
Fix linting issues with numpy 2

### DIFF
--- a/streaming/base/shared/prefix.py
+++ b/streaming/base/shared/prefix.py
@@ -118,7 +118,7 @@ def _check_and_find(streams_local: List[str], streams_remote: List[Union[str, No
         if any(streams_remote):
             # Get the indices of the local directories which matches with the current
             # shared memory.
-            matching_index = np.where(np.in1d(streams_local, their_locals))[0]
+            matching_index = np.where(np.isin(streams_local, their_locals))[0]
             if matching_index.size > 0:
                 for idx in matching_index:
                     # If there is a conflicting local directory for a non-None remote directory,

--- a/streaming/base/spanner.py
+++ b/streaming/base/spanner.py
@@ -56,6 +56,6 @@ class Spanner:
             shard_start = self.shard_bounds[shard]
             shard_stop = self.shard_bounds[shard + 1]
             if shard_start <= index < shard_stop:
-                return shard, int(index - shard_start)  # pyright: ignore
+                return shard, int(index - shard_start.item())
 
         raise RuntimeError('Internal error: shards were indexed incorrectly')

--- a/streaming/base/spanner.py
+++ b/streaming/base/spanner.py
@@ -56,6 +56,6 @@ class Spanner:
             shard_start = self.shard_bounds[shard]
             shard_stop = self.shard_bounds[shard + 1]
             if shard_start <= index < shard_stop:
-                return shard, int(index - shard_start)
+                return shard, int(index - shard_start)  # pyright: ignore
 
         raise RuntimeError('Internal error: shards were indexed incorrectly')


### PR DESCRIPTION
## Description of changes:

Seeing the error below on CI/CD linting:
```
home/runner/work/streaming/streaming/streaming/base/spanner.py:59:35 - error: Argument of type "NDArray[signedinteger[Any]]" cannot be assigned to parameter "__x" of type "ReadableBuffer | str | SupportsInt | SupportsIndex | SupportsTrunc" in function "__new__"
    Type "NDArray[signedinteger[Any]]" cannot be assigned to type "ReadableBuffer | str | SupportsInt | SupportsIndex | SupportsTrunc"
      "NDArray[signedinteger[Any]]" is incompatible with "str"
      "NDArray[signedinteger[Any]]" is incompatible with "ReadOnlyBuffer"
      "NDArray[signedinteger[Any]]" is incompatible with "bytearray"
      "NDArray[signedinteger[Any]]" is incompatible with "memoryview"
      "NDArray[signedinteger[Any]]" is incompatible with "array[Any]"
      "NDArray[signedinteger[Any]]" is incompatible with "mmap"
      "NDArray[signedinteger[Any]]" is incompatible with "_CData" (reportGeneralTypeIssues)
```
This seems to be an issue with the numpy upgrade and typing for casting to ints. We cast to `int` explicitly using `.item()` to address the typing issue.

The second error is:
```
/home/runner/work/streaming/streaming/streaming/base/shared/prefix.py:121:42 - error: "in1d" is not a known member of module (reportGeneralTypeIssues)
```
Which is happening because `np.in1d` is deprecated in numpy 2, in favor of `np.isin` ([see here](https://numpy.org/doc/stable/reference/generated/numpy.in1d.html)). We simply replace the call with `np.isin`.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
