### PR TITLE
enable adaptive retry for s3 download

### DIFF
--- a/streaming/base/storage/download.py
+++ b/streaming/base/storage/download.py
@@ -53,12 +53,15 @@ def download_from_s3(remote: str, local: str, timeout: float) -> None:
             extra_args (Dict[str, Any], optional): Extra arguments supported by boto3.
                 Defaults to ``None``.
         """
+        retries = {
+            'mode': 'adaptive',
+        }
         if unsigned:
             # Client will be using unsigned mode in which public
             # resources can be accessed without credentials
-            config = Config(read_timeout=timeout, signature_version=UNSIGNED)
+            config = Config(read_timeout=timeout, signature_version=UNSIGNED, retries=retries)
         else:
-            config = Config(read_timeout=timeout)
+            config = Config(read_timeout=timeout, retries=retries)
 
         if extra_args is None:
             extra_args = {}


### PR DESCRIPTION
enable adaptive retry for s3 download
adaptive retry document: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html

test run: test-uploader-fv1sNH