### PR TITLE
Fix Linting from Pillow version update

### DIFF
--- a/tests/test_encodings.py
+++ b/tests/test_encodings.py
@@ -201,7 +201,7 @@ class TestMDSEncodings:
 
         # Creating the (32 x 32) NumPy Array with random values
         size = {'RGB': (224, 224, 3), 'L': (28, 28)}[mode]
-        np_data = np.random.randint(255, size=size, dtype=np.uint8)
+        np_data = np.array(np.random.randint(255, size=size, dtype=np.uint8))
         # Default image mode of PIL Image is 'I'
         img = Image.fromarray(np_data).convert(mode)
 


### PR DESCRIPTION
## Description of changes:

Pillow version is bumped to 10.4.0 from 10.3.0, which results in the following Linting error

tests/test_encodings.py:206:31 - error: Argument of type "int" cannot be assigned to parameter "obj" of type "SupportsArrayInterface" in function "fromarray"

Reason is that fromarray expects np.array while np.random.randint returns Union[int, array]. Wrap with np.array fixes it.  
