### PR TITLE
Improve error message on non-0 rank when index file download failed

### DIFF
--- a/streaming/base/stream.py
+++ b/streaming/base/stream.py
@@ -454,8 +454,8 @@ class Stream:
                 wait_for_file_to_exist(
                     filename, TICK, self.download_timeout,
                     f'Index file {os.path.join(self.remote or "", self.split or "", basename)} ' +
-                    f'-> {filename} took too long to download or failed to download. Either increase the ' +
-                    f'`download_timeout` value or check the local rank 0 traceback.')
+                    f'-> {filename} took too long to download or failed to download. Either increase the '
+                    + f'`download_timeout` value or check the local rank 0 traceback.')
 
         # Load the index.
         try:

--- a/streaming/base/stream.py
+++ b/streaming/base/stream.py
@@ -454,8 +454,8 @@ class Stream:
                 wait_for_file_to_exist(
                     filename, TICK, self.download_timeout,
                     f'Index file {os.path.join(self.remote or "", self.split or "", basename)} ' +
-                    f'-> {filename} took too long to download. Either increase the ' +
-                    f'`download_timeout` value or check the other traceback.')
+                    f'-> {filename} took too long to download or failed to download. Either increase the ' +
+                    f'`download_timeout` value or check the local rank 0 traceback.')
 
         # Load the index.
         try:


### PR DESCRIPTION
Improve error message on non-0 rank to let users look at rank 0 traceback when index file download timeout or failed 