### PR TITLE
Make Pytest log in color in Github Action

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ reportUnusedCoroutine = "error"
 # Pytest
 [tool.pytest.ini_options]
 # By default, do not run remote tests
-addopts = "--cov=streaming --cov-fail-under=50 --codeblocks --strict-markers -m 'not daily and not remote' -ra --tb=native"
+addopts = "--cov=streaming --cov-fail-under=50 --codeblocks --strict-markers -m 'not daily and not remote' -ra --tb=native --color=yes"
 
 markers = [
     # For distributed testing


### PR DESCRIPTION
Currently, running pytest locally generates logs in color. But in Github Actions (GA), the logs are only in white. And it does not look so nice. Adding the flag
```
 --color=yes
```
causes pytest to log in color and makes things look nice again. This improves visibility and makes it easier on the eyes to see when tests fail/succeed.

I tested this flag on my fork of MegaBlocks but it should be the same here.

**Without:**
Here is a [GA](https://github.com/eitanturok/megablocks/actions/runs/10151013963/job/28069397071) without the `--color=yes` flag:

![without_color](https://github.com/user-attachments/assets/6c41573a-08a9-4e26-a121-d4ac9e12c28d)


**With:**
Here is a [GA](https://github.com/eitanturok/megablocks/actions/runs/10165283474/job/28112737604) with the `--color=yes` flag:

![with_color](https://github.com/user-attachments/assets/aa17d62c-31d9-4531-b749-54dc1e2b9c04)
