### PR TITLE
Fix dataloader hang at the end of an epoch

### DIFF
--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -1335,6 +1335,7 @@ class StreamingDataset(Array, IterableDataset):
             # The second scenario is rare, where ready_thread has higher priority and progresses way
             # faster than this thread, which means at the end of epoch all other threads need to wait.
             if it.prepare_index == it.total or it.ready_index == it.total:
+                it.prepare_index = it.total
                 break
 
             # Background thread or a main process crashed, terminate this thread.

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -1331,7 +1331,10 @@ class StreamingDataset(Array, IterableDataset):
                 break
 
             # If we're out of samples this epoch, exit this thread because we are done downloading.
-            if it.prepare_index == it.total:
+            # Or, if the ready_index has reached to the end, exit this thread to unblock other threads.
+            # The second scenario is rare, where ready_thread has higher priority and progresses way
+            # faster than this thread, which means at the end of epoch all other threads need to wait.
+            if it.prepare_index == it.total or it.ready_index == it.total:
                 break
 
             # Background thread or a main process crashed, terminate this thread.

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -1331,7 +1331,7 @@ class StreamingDataset(Array, IterableDataset):
                 break
 
             # If we're out of samples this epoch, exit this thread because we are done downloading.
-            # Or, if the ready_index has reached to the end, exit this thread to unblock other threads.
+            # Or, if the ready_index has reached the end, exit this thread to unblock other threads.
             # The second scenario is rare, where ready_thread has higher priority and progresses way
             # faster than this thread, which means at the end of epoch all other threads need to wait.
             if it.prepare_index == it.total or it.ready_index == it.total:


### PR DESCRIPTION
## Description of changes:

This bug fix addresses a common issue where GPU utilization drops significantly during training when the batch size is large, typically ranging from 1024 and above. The root cause was identified as resource contention in multithreading. With large batch sizes, both the main iterator thread and the ready thread consume the majority of resources, leaving the prepare_thread with insufficient resources to perform its tasks effectively. To be more precise, the main iterator thread waits on the ready thread. As a result, prepare_thread struggles to keep up. At the end of an epoch, the "prepare thread" takes a long time to catch up to get the total iterations. This causes a noticeable drop in GPU utilization that can last from a few seconds to several minutes, depending on the total number of iterations to catch up. This PR resolves the issue by ensuring that the prepare_thread exits promptly once the ready_thread completes its execution.

We conducted extensive regression testing and observed no adverse effects on training large LLM models. What's better, we saw a 40% reduction in overall training time, and the throughput drops across epochs were significantly mitigated.

Attached are some example plots illustrating the improvements.

streaming regression testing suite: 
* streaming-regression-tests-runner-0rMyg4
* streaming-regression-tests-runner-aVhR9e

[mlflow test suite for the resnet model](https://dbc-04ac0685-8857.staging.cloud.databricks.com/ml/experiments/3786652098314699?o=3360802220363900&searchFilter=&orderByKey=attributes.start_time&orderByAsc=false&startTime=LAST_24_HOURS&lifecycleFilter=Active&modelVersionFilter=All+Runs&datasetsFilter=W10%3D)

Additionally, several GitHub issues reported earlier seem to be related to this bug. We encourage users experiencing similar problems to try this fix and provide feedback. Relevant issues include:
[Issue 643](https://github.com/mosaicml/streaming/issues/643)
[Issue 686](https://github.com/mosaicml/streaming/issues/686)


<img width="905" alt="Screenshot 2024-08-12 at 2 36 21 PM" src="https://github.com/user-attachments/assets/82d7215b-6dba-40b0-b8f4-fb6b797acbc2">
<img width="902" alt="Screenshot 2024-08-12 at 2 36 29 PM" src="https://github.com/user-attachments/assets/2c32943d-48c9-4560-bae4-54882ac00fff">

## Issue #, if available:

It is hypothetical that this [issue](https://github.com/mosaicml/streaming/issues/686) and this [issue](https://github.com/mosaicml/streaming/issues/643) are also relevant, where several users observed a throughput drop at the end of an epoch.  

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
