### PR TITLE
Add default compression, and warning about local paths to dataframe_to_mds

### DIFF
--- a/streaming/base/converters/dataframe_to_mds.py
+++ b/streaming/base/converters/dataframe_to_mds.py
@@ -265,7 +265,7 @@ def dataframe_to_mds(dataframe: DataFrame,
         raise ValueError(f'`out` and `columns` need to be specified in `mds_kwargs`')
 
     if 'compression' not in mds_kwargs:
-        logger.info("Defaulting to zstd compression")
+        logger.info('Defaulting to zstd compression')
         mds_kwargs['compression'] = 'zstd'
 
     if udf_iterable is not None:
@@ -292,16 +292,15 @@ def dataframe_to_mds(dataframe: DataFrame,
     # Fix output format as mds_path: Tuple(local, remote)
     if cu.remote is None:
         # If dataframe_to_mds is being called, this is in a distributed Spark env.
-        # If there is no remote, it's because the given out path is local, which does not 
-        # in general make sense, unless this 'local' path is FUSE-mounted distributed 
+        # If there is no remote, it's because the given out path is local, which does not
+        # in general make sense, unless this 'local' path is FUSE-mounted distributed
         # storage such as /dbfs or /Volumes in Databricks for example.
         # It's not wrong in this case, but probably nevertheless desirable to specify a local temp
         # path explicitly, to interpret the FUSE-mounted path as remote
-        logger.warning(
-            f"Path {cu.local} is interpreted as a local path. If this is actually " +
-            "mounted distributed storage, it will work, but consider also specifying " +
-            "a local temp path. Pass a (local, remote) tuple as 'out', as in " +
-            f"('/local_disk0/my_tmp', {cu.local})")
+        logger.warning(f"Path {cu.local} is interpreted as a local path. If this is actually " +
+                       'mounted distributed storage, it will work, but consider also specifying ' +
+                       "a local temp path. Pass a (local, remote) tuple as 'out', as in " +
+                       f"('/local_disk0/my_tmp', {cu.local})")
         mds_path = (cu.local, '')
     else:
         mds_path = (cu.local, cu.remote)

--- a/streaming/base/converters/dataframe_to_mds.py
+++ b/streaming/base/converters/dataframe_to_mds.py
@@ -268,10 +268,6 @@ def dataframe_to_mds(dataframe: DataFrame,
         logger.info("Defaulting to zstd compression")
         mds_kwargs['compression'] = 'zstd'
 
-    if 'size_limit' not in mds_kwargs:
-        logger.info("Defaulting size_limit to 1 << 29")
-        mds_kwargs['size_limit'] = 1 << 29
-
     if udf_iterable is not None:
         if 'columns' not in mds_kwargs:
             raise ValueError(
@@ -301,10 +297,11 @@ def dataframe_to_mds(dataframe: DataFrame,
         # storage such as /dbfs or /Volumes in Databricks for example.
         # It's not wrong in this case, but probably nevertheless desirable to specify a local temp
         # path explicitly, to interpret the FUSE-mounted path as remote
-        logger.warning(f"Path {cu.local} is interpreted as a local path. If this is actually " +
-                       "mounted distributed storage, it will work, but consider also specifying " +
-                       "a local temp path. Pass a (local, remote) tuple in out, as in " +
-                       f"('/local_disk0/my_tmp', {cu.local})")
+        logger.warning(
+            f"Path {cu.local} is interpreted as a local path. If this is actually " +
+            "mounted distributed storage, it will work, but consider also specifying " +
+            "a local temp path. Pass a (local, remote) tuple as 'out', as in " +
+            f"('/local_disk0/my_tmp', {cu.local})")
         mds_path = (cu.local, '')
     else:
         mds_path = (cu.local, cu.remote)

--- a/streaming/base/converters/dataframe_to_mds.py
+++ b/streaming/base/converters/dataframe_to_mds.py
@@ -264,6 +264,14 @@ def dataframe_to_mds(dataframe: DataFrame,
     if 'out' not in mds_kwargs:
         raise ValueError(f'`out` and `columns` need to be specified in `mds_kwargs`')
 
+    if 'compression' not in mds_kwargs:
+        logger.info("Defaulting to zstd compression")
+        mds_kwargs['compression'] = 'zstd'
+
+    if 'size_limit' not in mds_kwargs:
+        logger.info("Defaulting size_limit to 1 << 29")
+        mds_kwargs['size_limit'] = 1 << 29
+
     if udf_iterable is not None:
         if 'columns' not in mds_kwargs:
             raise ValueError(
@@ -287,6 +295,16 @@ def dataframe_to_mds(dataframe: DataFrame,
 
     # Fix output format as mds_path: Tuple(local, remote)
     if cu.remote is None:
+        # If dataframe_to_mds is being called, this is in a distributed Spark env.
+        # If there is no remote, it's because the given out path is local, which does not 
+        # in general make sense, unless this 'local' path is FUSE-mounted distributed 
+        # storage such as /dbfs or /Volumes in Databricks for example.
+        # It's not wrong in this case, but probably nevertheless desirable to specify a local temp
+        # path explicitly, to interpret the FUSE-mounted path as remote
+        logger.warning(f"Path {cu.local} is interpreted as a local path. If this is actually " +
+                       "mounted distributed storage, it will work, but consider also specifying " +
+                       "a local temp path. Pass a (local, remote) tuple in out, as in " +
+                       f"('/local_disk0/my_tmp', {cu.local})"
         mds_path = (cu.local, '')
     else:
         mds_path = (cu.local, cu.remote)

--- a/streaming/base/converters/dataframe_to_mds.py
+++ b/streaming/base/converters/dataframe_to_mds.py
@@ -297,10 +297,10 @@ def dataframe_to_mds(dataframe: DataFrame,
         # storage such as /dbfs or /Volumes in Databricks for example.
         # It's not wrong in this case, but probably nevertheless desirable to specify a local temp
         # path explicitly, to interpret the FUSE-mounted path as remote
-        logger.warning(f"Path {cu.local} is interpreted as a local path. If this is actually " +
+        logger.warning(f'Path {cu.local} is interpreted as a local path. If this is actually ' +
                        'mounted distributed storage, it will work, but consider also specifying ' +
-                       "a local temp path. Pass a (local, remote) tuple as 'out', as in " +
-                       f"('/local_disk0/my_tmp', {cu.local})")
+                       'a local temp path. Pass a (local, remote) tuple as "out", as in ' +
+                       f'("/local_disk0/my_tmp", "{cu.local}")')
         mds_path = (cu.local, '')
     else:
         mds_path = (cu.local, cu.remote)

--- a/streaming/base/converters/dataframe_to_mds.py
+++ b/streaming/base/converters/dataframe_to_mds.py
@@ -304,7 +304,7 @@ def dataframe_to_mds(dataframe: DataFrame,
         logger.warning(f"Path {cu.local} is interpreted as a local path. If this is actually " +
                        "mounted distributed storage, it will work, but consider also specifying " +
                        "a local temp path. Pass a (local, remote) tuple in out, as in " +
-                       f"('/local_disk0/my_tmp', {cu.local})"
+                       f"('/local_disk0/my_tmp', {cu.local})")
         mds_path = (cu.local, '')
     else:
         mds_path = (cu.local, cu.remote)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -142,7 +142,8 @@ def integrity_check(out: Union[str, Tuple[str, str]],
         n_shard_files = 0
         cu = CloudUploader.get(mds_root, exist_ok=True, keep_local=True)
         for o in cu.list_objects():
-            if o.endswith('.mds'):
+            # ends with .mds, or perhaps .mds.zstd
+            if '.mds' in o:
                 n_shard_files += 1
         return n_shard_files
 


### PR DESCRIPTION
## Description of changes:

### Set more appropriate defaults for compression in dataframe_to_mds.

In a distributed Spark env, it's probably worth saving I/O with compression, as many data types in MDS files will compress well (tokens). This enables default zstd compression if not specified.

### Warn about local-only paths

In Databricks in particular, it's possible to provide a path to remote storage as a FUSE-mounted 'local' path likes /Volumes or /dbfs. It is interpreted as a local path, not remote. This works, but, in practice seems to be suboptimal as MDSWriter will causes lots of writes to the 'local' file. Instead it's probably better and more in line with default logic in CloudUploader to specify a temp dir as the local path, and the FUSE path as remote.

Because this is not _necessarily_ a problem, it generates a warning only, not an error.

## Issue #, if available:

None.

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [X] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [X] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [X] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [X] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.
