### PR TITLE
Ensure deterministic sample order between epochs when `shuffle=False`

### DIFF
--- a/streaming/base/batching/device_per_stream.py
+++ b/streaming/base/batching/device_per_stream.py
@@ -146,7 +146,7 @@ def generate_work_device_per_stream_batching(dataset: StreamingDataset, world: W
     max_device_batches_per_node += padding_max_device_batches
 
     # Shuffle seed may change with each epoch, which impacts the order of streams in global batches.
-    epoch_seed = dataset.shuffle_seed + epoch if dataset.shuffle else dataset.shuffle_seed
+    epoch_seed = dataset.shuffle_seed + epoch if dataset.epoch_seed_change else dataset.shuffle_seed
     epoch_rng = np.random.default_rng(epoch_seed)
 
     # Shuffle the device batch origin order for each node.

--- a/streaming/base/batching/device_per_stream.py
+++ b/streaming/base/batching/device_per_stream.py
@@ -145,7 +145,8 @@ def generate_work_device_per_stream_batching(dataset: StreamingDataset, world: W
     padding_max_device_batches = num_devices - (max_device_batches_per_node % num_devices)
     max_device_batches_per_node += padding_max_device_batches
 
-    # Shuffle seed may change with each epoch, which impacts the order of streams in global batches.
+    # When shuffling is enabled, each epoch has a different rng.
+    # Otherwise, we keep the rng the same to keep the sample ordering deterministic.
     epoch_seed = dataset.shuffle_seed + epoch if dataset.epoch_seed_change else dataset.shuffle_seed
     epoch_rng = np.random.default_rng(epoch_seed)
 

--- a/streaming/base/batching/device_per_stream.py
+++ b/streaming/base/batching/device_per_stream.py
@@ -145,8 +145,9 @@ def generate_work_device_per_stream_batching(dataset: StreamingDataset, world: W
     padding_max_device_batches = num_devices - (max_device_batches_per_node % num_devices)
     max_device_batches_per_node += padding_max_device_batches
 
-    # Shuffle seed changes with every epoch, so the order of streams in our batches also changes.
-    epoch_rng = np.random.default_rng(dataset.shuffle_seed + epoch)
+    # Shuffle seed may change with each epoch, which impacts the order of streams in global batches.
+    epoch_seed = dataset.shuffle_seed + epoch if dataset.shuffle else dataset.shuffle_seed
+    epoch_rng = np.random.default_rng(epoch_seed)
 
     # Shuffle the device batch origin order for each node.
     for node in range(world.num_nodes):

--- a/streaming/base/batching/per_stream.py
+++ b/streaming/base/batching/per_stream.py
@@ -106,7 +106,7 @@ def generate_work_per_stream_batching(dataset: StreamingDataset, world: World, e
     all_partition_batches = np.concatenate(batches_from_partitions)
 
     # Shuffle seed may change with each epoch, which impacts the order of streams in global batches.
-    epoch_seed = dataset.shuffle_seed + epoch if dataset.shuffle else dataset.shuffle_seed
+    epoch_seed = dataset.shuffle_seed + epoch if dataset.epoch_seed_change else dataset.shuffle_seed
     epoch_rng = np.random.default_rng(epoch_seed)
 
     # stream_origins is an array that tells us which stream each batch is using.

--- a/streaming/base/batching/per_stream.py
+++ b/streaming/base/batching/per_stream.py
@@ -105,8 +105,9 @@ def generate_work_per_stream_batching(dataset: StreamingDataset, world: World, e
     # Combine all global batches from all streams into one array.
     all_partition_batches = np.concatenate(batches_from_partitions)
 
-    # Shuffle seed changes with every epoch, so the order of streams in our batches also changes.
-    epoch_rng = np.random.default_rng(dataset.shuffle_seed + epoch)
+    # Shuffle seed may change with each epoch, which impacts the order of streams in global batches.
+    epoch_seed = dataset.shuffle_seed + epoch if dataset.shuffle else dataset.shuffle_seed
+    epoch_rng = np.random.default_rng(epoch_seed)
 
     # stream_origins is an array that tells us which stream each batch is using.
     stream_origins = np.concatenate(

--- a/streaming/base/batching/per_stream.py
+++ b/streaming/base/batching/per_stream.py
@@ -105,7 +105,8 @@ def generate_work_per_stream_batching(dataset: StreamingDataset, world: World, e
     # Combine all global batches from all streams into one array.
     all_partition_batches = np.concatenate(batches_from_partitions)
 
-    # Shuffle seed may change with each epoch, which impacts the order of streams in global batches.
+    # When shuffling is enabled, each epoch has a different rng.
+    # Otherwise, we keep the rng the same to keep the sample ordering deterministic.
     epoch_seed = dataset.shuffle_seed + epoch if dataset.epoch_seed_change else dataset.shuffle_seed
     epoch_rng = np.random.default_rng(epoch_seed)
 

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -427,6 +427,9 @@ class StreamingDataset(Array, IterableDataset):
             if epoch_size_value < 0:
                 raise ValueError(f'Epoch size cannot be negative. Received {epoch_size_value}.')
 
+        # Determine if we should be changing the seed every epoch
+        self.epoch_seed_change = self.shuffle and self.sampling_method == 'balanced'
+
         # Initialize torch dist ourselves, if necessary.
         destroy_dist = maybe_init_dist()
 
@@ -881,10 +884,9 @@ class StreamingDataset(Array, IterableDataset):
             # the number of items to choose from each stream, obtained during initialization
             stream_choose = self.streams[stream_id].choose
             # Only use a new seed for the epoch if using balanced sampling and if we are shuffling.
-            use_epoch = self.sampling_method == 'balanced' and self.shuffle == True
             choose_per_stream_shard = get_sampling(samples_per_stream_shard, stream_choose,
                                                    self.sampling_granularity, self.shuffle_seed,
-                                                   epoch, use_epoch)
+                                                   epoch, self.epoch_seed_change)
 
             # Iterate over each shard of this stream.
             for shard_id, shard_samples, shard_choose in zip(stream_shard_ids,

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -883,7 +883,8 @@ class StreamingDataset(Array, IterableDataset):
             samples_per_stream_shard = self.samples_per_shard[stream_shard_ids]
             # the number of items to choose from each stream, obtained during initialization
             stream_choose = self.streams[stream_id].choose
-            # Only use a new seed for the epoch if using balanced sampling and if we are shuffling.
+            # When shuffling is enabled, each epoch has a different rng.
+            # Otherwise, we keep the rng the same to keep the sample ordering deterministic.
             choose_per_stream_shard = get_sampling(samples_per_stream_shard, stream_choose,
                                                    self.sampling_granularity, self.shuffle_seed,
                                                    epoch, self.epoch_seed_change)

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -880,7 +880,8 @@ class StreamingDataset(Array, IterableDataset):
             samples_per_stream_shard = self.samples_per_shard[stream_shard_ids]
             # the number of items to choose from each stream, obtained during initialization
             stream_choose = self.streams[stream_id].choose
-            use_epoch = self.sampling_method == 'balanced'
+            # Only use a new seed for the epoch if using balanced sampling and if we are shuffling.
+            use_epoch = self.sampling_method == 'balanced' and self.shuffle == True
             choose_per_stream_shard = get_sampling(samples_per_stream_shard, stream_choose,
                                                    self.sampling_granularity, self.shuffle_seed,
                                                    epoch, use_epoch)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import numpy as np
+import pytest
 
 from streaming.base.sampling import get_sampling
 
 
-def test_choose_per_shard_adds_up():
+@pytest.mark.parametrize('use_epoch', [True, False])
+def test_choose_per_shard_adds_up(use_epoch: bool):
     for granularity in range(1, 100):
         for _ in range(10):
             samples_per_shard = 100 + np.random.choice(100, 10)
@@ -14,7 +16,6 @@ def test_choose_per_shard_adds_up():
             choose = np.random.choice(samples)
             seed = np.random.choice(31337)
             epoch = np.random.choice(42)
-            use_epoch = bool(np.random.choice(2))
             choose_per_shard = get_sampling(samples_per_shard, choose, granularity, seed, epoch,
                                             use_epoch)
             assert (0 <= choose_per_shard).all()
@@ -22,17 +23,17 @@ def test_choose_per_shard_adds_up():
             assert sum(choose_per_shard) == choose
 
 
-def test_is_deterministic():
+@pytest.mark.parametrize('use_epoch', [True, False])
+def test_is_deterministic(use_epoch: bool):
     for granularity in range(1, 100):
-        for _iter in range(3):
+        for _ in range(3):
             samples_per_shard = 100 + np.random.choice(100, 10)
             samples = sum(samples_per_shard)
             choose = np.random.choice(samples)
             seed = np.random.choice(31337)
             epoch = np.random.choice(42)
-            use_epoch = bool(np.random.choice(2))
             last = None
-            for _repeat in range(2):
+            for _ in range(2):
                 choose_per_shard = get_sampling(samples_per_shard, choose, granularity, seed,
                                                 epoch, use_epoch)
                 if last is not None:
@@ -40,7 +41,8 @@ def test_is_deterministic():
                 last = choose_per_shard
 
 
-def test_balance():
+@pytest.mark.parametrize('use_epoch', [True, False])
+def test_balance(use_epoch: bool):
     samples_per_shard = 1_000 + np.random.choice(1_000, 10)
     samples = sum(samples_per_shard)
     choose = np.random.choice(samples)
@@ -49,7 +51,6 @@ def test_balance():
         for _ in range(10):
             seed = np.random.choice(31337)
             epoch = np.random.choice(42)
-            use_epoch = bool(np.random.choice(2))
             choose_per_shard += get_sampling(samples_per_shard, choose, granularity, seed, epoch,
                                              use_epoch)
     choose_per_shard /= 99 * 10


### PR DESCRIPTION
## Description of changes:

Previously, the sample order would change between epochs even when `shuffle=False`, which is counterintuitive and is not the desired behavior. This PR fixes that.

Addresses #749 

Added unit testing and cleaned up a few others.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
