### PR TITLE
Check file size within LocalUploader

### DIFF
--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -1207,7 +1207,14 @@ class LocalUploader(CloudUploader):
                 local_filename = os.path.join(self.local, filename)
                 remote_filename = os.path.join(self.remote, filename)  # pyright: ignore
                 logger.debug(f'Copying to {remote_filename}')
+                local_file_size = os.stat(local_filename).st_size
                 shutil.copy(local_filename, remote_filename)
+                remote_file_size = os.stat(local_filename).st_size
+                # LocalUploader can be used by fuse-mount system.
+                # which may not be as reliable, thus do the checking.
+                if local_file_size != remote_file_size:
+                    raise RuntimeError(f'Uploading failed! {local_file_size}!= {remote_file_size}')
+
                 self.clear_local(local=local_filename)
 
         _upload_file()


### PR DESCRIPTION
## Description of changes:

LocalUploader can be used by fuse-mount file system which may be not as reliable. We have seen upload finishing but the shard files are missing, however no errors were thrown. Thus adding a check to assert local file size matches the remote file size.

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
