### PR TITLE
Fix linting for numpy 2.1.0

### DIFF
--- a/streaming/base/spanner.py
+++ b/streaming/base/spanner.py
@@ -51,6 +51,7 @@ class Spanner:
 
         span = index // self.span_size
         for shard in self.spans[span]:
+            shard = int(shard)
             shard_start = self.shard_bounds[shard]
             shard_stop = self.shard_bounds[shard + 1]
             if shard_start <= index < shard_stop:

--- a/streaming/base/spanner.py
+++ b/streaming/base/spanner.py
@@ -51,10 +51,9 @@ class Spanner:
 
         span = index // self.span_size
         for shard in self.spans[span]:
-            shard = int(shard)
             shard_start = self.shard_bounds[shard]
             shard_stop = self.shard_bounds[shard + 1]
             if shard_start <= index < shard_stop:
-                return shard, int(index - shard_start.item())
+                return shard, int(index - shard_start.item())  # pyright: ignore
 
         raise RuntimeError('Internal error: shards were indexed incorrectly')


### PR DESCRIPTION
## Description of changes:

Numpy 2.1.0 changed a few things for linting it seems...ignoring pyright on just this line since this would be the second time a numpy version bump caused linting to fail.

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
