### PR TITLE
Add MapType as JSON-compatible

### DIFF
--- a/streaming/base/converters/dataframe_to_mds.py
+++ b/streaming/base/converters/dataframe_to_mds.py
@@ -19,8 +19,9 @@ try:
     from pyspark.sql.dataframe import DataFrame
     from pyspark.sql.types import (ArrayType, BinaryType, BooleanType, ByteType, DateType,
                                    DayTimeIntervalType, DecimalType, DoubleType, FloatType,
-                                   IntegerType, LongType, NullType, ShortType, StringType,
-                                   StructField, StructType, TimestampNTZType, TimestampType)
+                                   IntegerType, LongType, MapType, NullType, ShortType,
+                                   StringType, StructField, StructType, TimestampNTZType,
+                                   TimestampType)
 except ImportError as e:
     e.msg = get_import_exception_message(e.name, extra_deps='spark')  # pyright: ignore
     raise e
@@ -70,6 +71,8 @@ def is_json_compatible(data_type: Any):
         return all(is_json_compatible(field.dataType) for field in data_type.fields)
     elif isinstance(data_type, ArrayType):
         return is_json_compatible(data_type.elementType)
+    elif isinstance(data_type, MapType):
+        return is_json_compatible(data_type.keyType) and is_json_compatible(data_type.valueType)
     elif isinstance(data_type, (StringType, IntegerType, FloatType, BooleanType, NullType)):
         return True
     else:

--- a/streaming/base/converters/dataframe_to_mds.py
+++ b/streaming/base/converters/dataframe_to_mds.py
@@ -19,9 +19,8 @@ try:
     from pyspark.sql.dataframe import DataFrame
     from pyspark.sql.types import (ArrayType, BinaryType, BooleanType, ByteType, DateType,
                                    DayTimeIntervalType, DecimalType, DoubleType, FloatType,
-                                   IntegerType, LongType, MapType, NullType, ShortType,
-                                   StringType, StructField, StructType, TimestampNTZType,
-                                   TimestampType)
+                                   IntegerType, LongType, MapType, NullType, ShortType, StringType,
+                                   StructField, StructType, TimestampNTZType, TimestampType)
 except ImportError as e:
     e.msg = get_import_exception_message(e.name, extra_deps='spark')  # pyright: ignore
     raise e

--- a/tests/base/converters/test_dataframe_to_mds.py
+++ b/tests/base/converters/test_dataframe_to_mds.py
@@ -421,7 +421,9 @@ class TestDataFrameToMDS:
         schema_with_string_map_keys = StructType(
             [StructField('map_field', MapType(StringType(), StringType()), nullable=True)])
 
-        valid_schemas = [message_schema, prompt_response_schema, combined_schema, schema_with_string_map_keys]
+        valid_schemas = [
+            message_schema, prompt_response_schema, combined_schema, schema_with_string_map_keys
+        ]
 
         schema_with_binary = StructType([StructField('data', BinaryType(), nullable=True)])
 

--- a/tests/base/converters/test_dataframe_to_mds.py
+++ b/tests/base/converters/test_dataframe_to_mds.py
@@ -428,7 +428,7 @@ class TestDataFrameToMDS:
         schema_with_binary = StructType([StructField('data', BinaryType(), nullable=True)])
 
         # Schema with MapType having non-string keys
-        schema_with_non_string_map_keys = StructType(
+        non_string_map_keys_schema = StructType(
             [StructField('map_field', MapType(BinaryType(), StringType()), nullable=True)])
 
         # Schema with DateType and TimestampType
@@ -438,7 +438,7 @@ class TestDataFrameToMDS:
         ])
 
         invalid_schemas = [
-            schema_with_binary, schema_with_non_string_map_keys, schema_with_date_and_timestamp
+            schema_with_binary, non_string_map_keys_schema, schema_with_date_and_timestamp
         ]
 
         for s in valid_schemas:

--- a/tests/base/converters/test_dataframe_to_mds.py
+++ b/tests/base/converters/test_dataframe_to_mds.py
@@ -418,13 +418,16 @@ class TestDataFrameToMDS:
                     ]), True), True)
         ])
 
-        valid_schemas = [message_schema, prompt_response_schema, combined_schema]
+        schema_with_string_map_keys = StructType(
+            [StructField('map_field', MapType(StringType(), StringType()), nullable=True)])
+
+        valid_schemas = [message_schema, prompt_response_schema, combined_schema, schema_with_string_map_keys]
 
         schema_with_binary = StructType([StructField('data', BinaryType(), nullable=True)])
 
         # Schema with MapType having non-string keys
         schema_with_non_string_map_keys = StructType(
-            [StructField('map_field', MapType(IntegerType(), StringType()), nullable=True)])
+            [StructField('map_field', MapType(BinaryType(), StringType()), nullable=True)])
 
         # Schema with DateType and TimestampType
         schema_with_date_and_timestamp = StructType([
@@ -437,10 +440,10 @@ class TestDataFrameToMDS:
         ]
 
         for s in valid_schemas:
-            assert is_json_compatible(s)
+            assert is_json_compatible(s), str(s)
 
         for s in invalid_schemas:
-            assert not is_json_compatible(s)
+            assert not is_json_compatible(s), str(s)
 
     def test_complex_schema(self,
                             complex_dataframe: Any,

--- a/tests/base/converters/test_dataframe_to_mds.py
+++ b/tests/base/converters/test_dataframe_to_mds.py
@@ -418,11 +418,11 @@ class TestDataFrameToMDS:
                     ]), True), True)
         ])
 
-        schema_with_string_map_keys = StructType(
+        string_map_keys_schema = StructType(
             [StructField('map_field', MapType(StringType(), StringType()), nullable=True)])
 
         valid_schemas = [
-            message_schema, prompt_response_schema, combined_schema, schema_with_string_map_keys
+            message_schema, prompt_response_schema, combined_schema, string_map_keys_schema
         ]
 
         schema_with_binary = StructType([StructField('data', BinaryType(), nullable=True)])


### PR DESCRIPTION
## Description of changes:

`dataframe_to_mds` does not directly support the Spark Map type as there is no direct analog in streaming (?)
However, the dataframe_to_mds will accept "unsupported" Spark types if they are JSON-compatible, and if the user specifies type 'json' for the column.

However the logic of `is_json_compatible` doesn't include `MapType`, when a map is conceptually fine as a dict, and Spark uses simple dicts to represent such maps in pandas DFs. As long as the map's key and value types are JSON compatible, it should be considered JSON compatible.

With this change, it's possible to have columns including a map type successfully convert to JSON in an MDS file if the given type for the column is specified as 'json'.

## Merge Checklist:

### General
- [X] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [X] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [X] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.
