### PR TITLE
Allow JSON encoder to handle ndarray

### DIFF
--- a/streaming/base/format/mds/encodings.py
+++ b/streaming/base/format/mds/encodings.py
@@ -510,6 +510,8 @@ class JSON(Encoding):
     """Store arbitrary data as JSON."""
 
     def encode(self, obj: Any) -> bytes:
+        if isinstance(obj, np.ndarray):
+            obj = obj.tolist()
         data = json.dumps(obj)
         self._is_valid(obj, data)
         return data.encode('utf-8')

--- a/tests/test_encodings.py
+++ b/tests/test_encodings.py
@@ -286,6 +286,22 @@ class TestMDSEncodings:
         # Validate data content
         assert dec_data == data
 
+    @pytest.mark.parametrize('data', [np.array([1]), np.array(['foo']), np.array([{'foo': 1}])])
+    def test_json_encode_decode_ndarray(self, data: Any):
+        json_enc = mdsEnc.JSON()
+        assert json_enc.size is None
+
+        # Test encode
+        enc_data = json_enc.encode(data)
+        assert isinstance(enc_data, bytes)
+
+        # Test decode
+        dec_data = json_enc.decode(enc_data)
+        assert isinstance(dec_data, list)
+
+        # Validate data content
+        assert dec_data == data.tolist()
+
     def test_json_invalid_data(self):
         wrong_json_with_single_quotes = "{'name': 'streaming'}"
         with pytest.raises(json.JSONDecodeError):


### PR DESCRIPTION
## Description of changes:

The JSON encoder encodes a variety of data types via `json.dumps`, including primitives, lists, dicts, etc.
However `json.dumps` doesn't work with `ndarray`s ; it won't serialize them.
Conceptually, there isn't a strong reason to refuse to encode input as JSON where `ndarray` is used instead of lists, when one could simply transform even multi-dimensional `ndarray`s to supported Python lists with `.tolist()`.

This change simply has the encoder call `.tolist()` on its arg if passed an `ndarray`, and the rest works as expected.

This is actually relevant because the serialization of array type data from Spark to pandas will use `ndarray`s (being based on Arrow), and the result can't be passed to `dataframe_to_mds` even if the output type is given as `'json'`. It's possible to workaround by passing a transformation of the pandas DF to this function. But, it seemed simple and natural to just support this directly.

## Merge Checklist:


### General
- [X] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [X] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [X] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [X] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [X] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.
