### PR TITLE
Fixed broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ Getting started guides, examples, API references, and other useful information c
 
 We have end-to-end tutorials for training a model on:
 
-- [CIFAR-10](https://streaming.docs.mosaicml.com/en/stable/examples/cifar10.html)
-- [FaceSynthetics](https://streaming.docs.mosaicml.com/en/stable/examples/facesynthetics.html)
-- [SyntheticNLP](https://streaming.docs.mosaicml.com/en/stable/examples/synthetic_nlp.html)
+- [CIFAR-10](https://docs.mosaicml.com/projects/streaming/en/stable/how_to_guides/cifar10.html)
+- [FaceSynthetics](https://github.com/mosaicml/streaming/blob/main/examples/facesynthetics.ipynb)
+- [SyntheticNLP](https://docs.mosaicml.com/projects/streaming/en/stable/how_to_guides/synthetic_nlp.html)
 
 We also have starter code for the following popular datasets, which can be found in the `streaming` [directory](https://github.com/mosaicml/streaming/tree/main/streaming):
 


### PR DESCRIPTION
## Description of changes:

Updated links to CIFAR10, FaceSynthetics and SyntheticNLP how-to guides to point to the new docs website

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [x] This is a documentation change or typo fix. If so, skip the rest of this checklist.