### PR TITLE
Introducing Streaming Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@
     <a href="https://github.com/mosaicml/streaming/blob/main/LICENSE">
         <img alt="License" src="https://img.shields.io/badge/License-Apache%202.0-green.svg?logo=slack">
     </a>
+    <a href="https://gurubase.io/g/streaming">
+        <img alt="License" src="https://img.shields.io/badge/Gurubase-Ask%20Streaming%20Guru-006BFF">
+    </a>
 </p>
 <br />
 


### PR DESCRIPTION
Hello 

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Streaming Guru](https://gurubase.io/g/streaming) to Gurubase. Streaming Guru uses the data from this repo and data from the [docs](https://docs.mosaicml.com/projects/streaming/en/stable/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Streaming Guru" badge, which highlights that Streaming now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Streaming Guru in Gurubase, just let me know that's totally fine.