### PR TITLE
Add better error message for shared prefix 

### DIFF
--- a/streaming/base/shared/prefix.py
+++ b/streaming/base/shared/prefix.py
@@ -203,7 +203,8 @@ def get_shm_prefix(streams_local: list[str],
                 shm = SharedMemory(name, False)
             except FileNotFoundError:
                 raise RuntimeError(f'Internal error: shared memory prefix was not registered by ' +
-                                   f'local leader')
+                                   f'local leader.' +
+                                   f'possibly specified different ``local`` from different ranks')
             their_locals, their_prefix_int = _unpack_locals(bytes(shm.buf))
             if streams_local == their_locals and prefix_int == their_prefix_int:
                 break

--- a/streaming/base/shared/prefix.py
+++ b/streaming/base/shared/prefix.py
@@ -203,8 +203,8 @@ def get_shm_prefix(streams_local: list[str],
                 shm = SharedMemory(name, False)
             except FileNotFoundError:
                 raise RuntimeError(f'Internal error: shared memory prefix was not registered by ' +
-                                   f'local leader.' +
-                                   f'possibly specified different ``local`` from different ranks')
+                                   f'local leader. It is possibly because you specified ' +
+                                   f'different ``local`` parameters from different ranks')
             their_locals, their_prefix_int = _unpack_locals(bytes(shm.buf))
             if streams_local == their_locals and prefix_int == their_prefix_int:
                 break

--- a/streaming/base/shared/prefix.py
+++ b/streaming/base/shared/prefix.py
@@ -203,8 +203,8 @@ def get_shm_prefix(streams_local: list[str],
                 shm = SharedMemory(name, False)
             except FileNotFoundError:
                 raise RuntimeError(f'Internal error: shared memory prefix was not registered by ' +
-                                   f'local leader. It is possibly because you specified ' +
-                                   f'different ``local`` parameters from different ranks')
+                                   f'local leader. This may be because you specified ' +
+                                   f'different ``local`` parameters from different ranks.')
             their_locals, their_prefix_int = _unpack_locals(bytes(shm.buf))
             if streams_local == their_locals and prefix_int == their_prefix_int:
                 break


### PR DESCRIPTION
## Description of changes:

When users accidentally set local instead of remote, and use different values to local, they may hit an error in creating shared prefix. Although this is not the designed user path, the error message is not helpful. Adding an extra line to indicate the possible cause.  

```
/usr/lib/python3/dist-packages/streaming/base/shared/prefix.py:203: in get_shm_prefix
    shm = SharedMemory(name, False)
/usr/lib/python3/dist-packages/streaming/base/shared/memory.py:49: in __init__
    shm = BuiltinSharedMemory(name, create, size)
/usr/lib/python3.11/multiprocessing/shared_memory.py:104: in __init__
    self._fd = _posixshmem.shm_open(
E   FileNotFoundError: [Errno 2] No such file or directory: '/000001_locals'

During handling of the above exception, another exception occurred:
tests/tp/test_tp.py:150: in test_tp_dataloader
    ds = streaming.StreamingDataset(local=f'{tmp_path}/train', batch_size=1)
/usr/lib/python3/dist-packages/streaming/base/dataset.py:529: in __init__
    self._shm_prefix_int, self._locals_shm = get_shm_prefix(streams_local, streams_remote,
/usr/lib/python3/dist-packages/streaming/base/shared/prefix.py:205: in get_shm_prefix
    raise RuntimeError(f'Internal error: shared memory prefix was not registered by ' +
E   RuntimeError: Internal error: shared memory prefix was not registered by local leader
```


## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
