### PR TITLE
Fix device_per_stream bugs

### DIFF
--- a/streaming/base/batching/device_per_stream.py
+++ b/streaming/base/batching/device_per_stream.py
@@ -76,7 +76,7 @@ def generate_work_device_per_stream_batching(dataset: StreamingDataset, world: W
             # same as the ratio of the stream's samples to overall samples.
             # This ensures that the overall training shuffle block size is still approximately
             # equal to what is set by the user, and allows for reasoning about cache_limit as well.
-            if samples_in_stream < dataset.num_canonical_nodes:  # third patch
+            if samples_in_stream < dataset.num_canonical_nodes:
                 logger.warning(
                     f'Because of the `device_per_stream` batching method and stream with index {stream_id} '
                     +

--- a/streaming/base/batching/device_per_stream.py
+++ b/streaming/base/batching/device_per_stream.py
@@ -87,7 +87,7 @@ def generate_work_device_per_stream_batching(dataset: StreamingDataset, world: W
             if not isinstance(dataset.shuffle_block_size, int):
                 raise TypeError(f'Dataset `shuffle_block_size` must be an integer. ' +
                                 f'Got {type(dataset.shuffle_block_size)} instead.')
-            shuffle_block_portion = int(dataset.shuffle_block_size * stream.proportion)
+            shuffle_block_portion = max(1, int(dataset.shuffle_block_size * stream.proportion))
             stream_shuffle = get_shuffle(dataset.shuffle_algo, shuffle_units,
                                          dataset.num_canonical_nodes, dataset.shuffle_seed, epoch,
                                          shuffle_block_portion)
@@ -122,8 +122,7 @@ def generate_work_device_per_stream_batching(dataset: StreamingDataset, world: W
                 (stream_samples_inorder, np.full(padding_samples, -1)))
             # Reshape samples to be device batches in order of traversal.
             stream_samples_inorder = stream_samples_inorder.reshape(-1, batch_size)
-            num_full_batches = max(1,
-                                   np.count_nonzero(np.min(stream_samples_inorder, axis=1) >= 0))
+            num_full_batches = np.count_nonzero(np.min(stream_samples_inorder, axis=1) >= 0)
             per_node_batches_per_stream.append(num_full_batches)
             if num_full_batches != stream_samples_inorder.shape[0]:
                 logger.warning(

--- a/streaming/base/batching/device_per_stream.py
+++ b/streaming/base/batching/device_per_stream.py
@@ -78,11 +78,12 @@ def generate_work_device_per_stream_batching(dataset: StreamingDataset, world: W
             # equal to what is set by the user, and allows for reasoning about cache_limit as well.
             if samples_in_stream < dataset.num_canonical_nodes:  # third patch
                 logger.warning(
-                    f"Because of the `device_per_stream` batching method and stream with index {stream_id} "
-                    + f"has less samples ({samples_in_stream}) than canonical nodes ({dataset.num_canonical_nodes}), stream will be dropped."
+                    f'Because of the `device_per_stream` batching method and stream with index {stream_id} '
+                    +
+                    f'has less samples ({samples_in_stream}) than canonical nodes ({dataset.num_canonical_nodes}), stream will be dropped.'
                 )
                 continue
-            
+
             if not isinstance(dataset.shuffle_block_size, int):
                 raise TypeError(f'Dataset `shuffle_block_size` must be an integer. ' +
                                 f'Got {type(dataset.shuffle_block_size)} instead.')
@@ -121,7 +122,8 @@ def generate_work_device_per_stream_batching(dataset: StreamingDataset, world: W
                 (stream_samples_inorder, np.full(padding_samples, -1)))
             # Reshape samples to be device batches in order of traversal.
             stream_samples_inorder = stream_samples_inorder.reshape(-1, batch_size)
-            num_full_batches = max(1, np.count_nonzero(np.min(stream_samples_inorder, axis=1) >= 0))
+            num_full_batches = max(1,
+                                   np.count_nonzero(np.min(stream_samples_inorder, axis=1) >= 0))
             per_node_batches_per_stream.append(num_full_batches)
             if num_full_batches != stream_samples_inorder.shape[0]:
                 logger.warning(


### PR DESCRIPTION
## Description of changes:

Fixed a few bugs when the batching method is set to `device_per_stream` and the number of samples in a stream is small:

1. If a stream has `num_full_batches = 0`, we raise a warning and not an error. This happens typically if the numebr of samples in the stream is smaller than the device batch size.
2. In case we shuffle, we can have `samples_in_stream < num_canonical_nodes`. In this case we drop the samples in the stream instead of returning an error.
3. We can have `shuffle_block_portion = 0` if a stream proportion is too small. (Not covered in the tests)

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
