### PR TITLE
refactored the download module to have reusable clients

### DIFF
--- a/streaming/base/constant.py
+++ b/streaming/base/constant.py
@@ -32,5 +32,5 @@ CACHE_FILELOCK = 'cache_filelock'
 # Time to wait, in seconds.
 TICK = 0.007
 
-# Default timeout tie
+# Default download timeout
 DEFAULT_TIMEOUT = 60.0

--- a/streaming/base/constant.py
+++ b/streaming/base/constant.py
@@ -31,3 +31,6 @@ CACHE_FILELOCK = 'cache_filelock'
 
 # Time to wait, in seconds.
 TICK = 0.007
+
+# Default timeout tie
+DEFAULT_TIMEOUT = 60.0

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -26,7 +26,7 @@ from torch.utils.data import IterableDataset
 from streaming.base.array import Array
 from streaming.base.batching import generate_work
 from streaming.base.constant import (BARRIER, BARRIER_FILELOCK, CACHE_FILELOCK, CACHE_USAGE,
-                                     EPOCH_DATA, EPOCH_SHAPE, NEXT_EPOCH, RESUME,
+                                     DEFAULT_TIMEOUT, EPOCH_DATA, EPOCH_SHAPE, NEXT_EPOCH, RESUME,
                                      SHARD_ACCESS_TIMES, SHARD_STATES, TICK)
 from streaming.base.distributed import maybe_init_dist
 from streaming.base.format import get_index_basename
@@ -314,7 +314,7 @@ class StreamingDataset(Array, IterableDataset):
                  local: Optional[str] = None,
                  split: Optional[str] = None,
                  download_retry: int = 2,
-                 download_timeout: float = 60,
+                 download_timeout: float = DEFAULT_TIMEOUT,
                  validate_hash: Optional[str] = None,
                  keep_zip: bool = False,
                  epoch_size: Optional[Union[int, str]] = None,

--- a/streaming/base/storage/__init__.py
+++ b/streaming/base/storage/__init__.py
@@ -3,16 +3,16 @@
 
 """Base module for downloading/uploading files from/to cloud storage."""
 # isort: off
-from streaming.base.storage.download import (
-    download_file, download_from_alipan, download_from_azure, download_from_azure_datalake,
-    download_from_databricks_unity_catalog, download_from_dbfs, download_from_gcs,
-    download_from_hf, download_from_local, download_from_oci, download_from_s3, download_from_sftp)
+from streaming.base.storage.download import (CloudDownloader, S3Downloader, SFTPDownloader,
+                                             GCSDownloader, OCIDownloader, AzureDownloader,
+                                             AzureDataLakeDownloader, HFDownloader,
+                                             DatabricksUnityCatalogDownloader, DBFSDownloader,
+                                             AlipanDownloader, LocalDownloader)
 from streaming.base.storage.upload import (AzureDataLakeUploader, AzureUploader, CloudUploader,
                                            GCSUploader, HFUploader, LocalUploader, OCIUploader,
                                            S3Uploader)
 
 __all__ = [
-    'download_file',
     'CloudUploader',
     'S3Uploader',
     'GCSUploader',
@@ -21,15 +21,16 @@ __all__ = [
     'AzureUploader',
     'AzureDataLakeUploader',
     'HFUploader',
-    'download_from_s3',
-    'download_from_sftp',
-    'download_from_gcs',
-    'download_from_oci',
-    'download_from_azure',
-    'download_from_azure_datalake',
-    'download_from_databricks_unity_catalog',
-    'download_from_dbfs',
-    'download_from_alipan',
-    'download_from_local',
-    'download_from_hf',
+    'CloudDownloader',
+    'S3Downloader',
+    'SFTPDownloader',
+    'GCSDownloader',
+    'OCIDownloader',
+    'AzureDownloader',
+    'AzureDataLakeDownloader',
+    'HFDownloader',
+    'DatabricksUnityCatalogDownloader',
+    'DBFSDownloader',
+    'AlipanDownloader',
+    'LocalDownloader',
 ]

--- a/streaming/base/storage/download.py
+++ b/streaming/base/storage/download.py
@@ -77,6 +77,7 @@ class CloudDownloader(abc.ABC):
             remote (str | None): Remote path.
             local (str): Local path.
             timeout (float): How long to wait for file to download before raising an exception.
+                Defaults to ``60`` seconds.
 
         Raises:
             ValueError: If the remote path is not provided while local does not exist or remote
@@ -96,6 +97,7 @@ class CloudDownloader(abc.ABC):
             remote (str | None): Remote path.
             local (str): Local path.
             timeout (float): How long to wait for file to download before raising an exception.
+                Defaults to ``60`` seconds.
 
         Raises:
             ValueError: If the remote path does not contain the expected prefix or remote is

--- a/streaming/base/storage/download.py
+++ b/streaming/base/storage/download.py
@@ -41,11 +41,11 @@ class CloudDownloader(abc.ABC):
     """Download files from a remote storage to a local filesystem."""
 
     @classmethod
-    def get(cls, remote_dir: Optional[str]) -> 'CloudDownloader':
+    def get(cls, remote_dir: Optional[str] = None) -> 'CloudDownloader':
         """Get the downloader for the remote path.
 
         Args:
-            remote (str): Remote path.
+            remote (str | None): Remote path.
 
         Returns:
             CloudDownloader: Downloader for the remote path.
@@ -70,12 +70,13 @@ class CloudDownloader(abc.ABC):
         """Directly download a file from remote storage to local filesystem.
 
         Args:
-            remote (str): Remote path.
+            remote (str | None): Remote path.
             local (str): Local path.
             timeout (float): How long to wait for file to download before raising an exception.
 
         Raises:
-            ValueError: If the remote path is not provided or remote path is not supported.
+            ValueError: If the remote path is not provided while local does not exist or remote
+                path is not supported.
         """
         downloader = cls.get(remote)
         downloader.download(remote, local, timeout)
@@ -85,13 +86,13 @@ class CloudDownloader(abc.ABC):
         """Download a file from remote storage to local filesystem.
 
         Args:
-            remote (str): Remote path.
+            remote (str | None): Remote path.
             local (str): Local path.
             timeout (float): How long to wait for file to download before raising an exception.
 
         Raises:
             ValueError: If the remote path does not contain the expected prefix or remote is
-                not provided.
+                not provided while local does not exist.
         """
         if os.path.exists(local):
             return

--- a/streaming/base/storage/download.py
+++ b/streaming/base/storage/download.py
@@ -54,8 +54,7 @@ class CloudDownloader(abc.ABC):
             ValueError: If the remote path is not supported.
         """
         if remote_dir is None:
-            # Return the default downloader, assuming that it exists
-            return DOWNLOADER_MAPPINGS['']()
+            return _DEFAULT_DOWNLOADER()
 
         prefix = urllib.parse.urlparse(remote_dir).scheme
         if prefix == 'dbfs' and remote_dir.startswith('dbfs:/Volumes'):
@@ -843,10 +842,8 @@ def _register_cloud_downloader_subclasses() -> dict[str, type[CloudDownloader]]:
     for sub_class in sub_classes:
         downloader_mappings[sub_class.prefix()] = sub_class
 
-    if '' not in downloader_mappings:
-        raise ValueError('A default downloader with the prefix of an empty string is required.')
-
     return downloader_mappings
 
 
 DOWNLOADER_MAPPINGS = _register_cloud_downloader_subclasses()
+_DEFAULT_DOWNLOADER = LocalDownloader

--- a/streaming/base/storage/download.py
+++ b/streaming/base/storage/download.py
@@ -60,7 +60,7 @@ class CloudDownloader(abc.ABC):
         if remote_dir is None:
             return _LOCAL_DOWNLOADER()
 
-        logger.info('Acquiring downloader client for remote directory %s', remote_dir)
+        logger.debug('Acquiring downloader client for remote directory %s', remote_dir)
 
         prefix = urllib.parse.urlparse(remote_dir).scheme
         if prefix == 'dbfs' and remote_dir.startswith('dbfs:/Volumes'):

--- a/streaming/base/storage/download.py
+++ b/streaming/base/storage/download.py
@@ -4,6 +4,7 @@
 """Shard downloading from various storage providers."""
 
 import abc
+import logging
 import os
 import pathlib
 import shutil
@@ -13,6 +14,8 @@ from typing import Any, Optional
 
 from streaming.base.constant import DEFAULT_TIMEOUT
 from streaming.base.util import get_import_exception_message
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     'CloudDownloader',
@@ -56,6 +59,8 @@ class CloudDownloader(abc.ABC):
         """
         if remote_dir is None:
             return _LOCAL_DOWNLOADER()
+        
+        logger.info("Acquiring downloader client for remote directory %s", remote_dir)
 
         prefix = urllib.parse.urlparse(remote_dir).scheme
         if prefix == 'dbfs' and remote_dir.startswith('dbfs:/Volumes'):

--- a/streaming/base/storage/download.py
+++ b/streaming/base/storage/download.py
@@ -59,8 +59,8 @@ class CloudDownloader(abc.ABC):
         """
         if remote_dir is None:
             return _LOCAL_DOWNLOADER()
-        
-        logger.info("Acquiring downloader client for remote directory %s", remote_dir)
+
+        logger.info('Acquiring downloader client for remote directory %s', remote_dir)
 
         prefix = urllib.parse.urlparse(remote_dir).scheme
         if prefix == 'dbfs' and remote_dir.startswith('dbfs:/Volumes'):

--- a/streaming/base/storage/download.py
+++ b/streaming/base/storage/download.py
@@ -3,27 +3,29 @@
 
 """Shard downloading from various storage providers."""
 
+import abc
 import os
 import pathlib
 import shutil
+import sys
 import urllib.parse
-from time import sleep, time
 from typing import Any, Optional
 
 from streaming.base.util import get_import_exception_message
 
 __all__ = [
-    'download_from_s3',
-    'download_from_sftp',
-    'download_from_gcs',
-    'download_from_oci',
-    'download_from_azure',
-    'download_from_azure_datalake',
-    'download_from_hf',
-    'download_from_databricks_unity_catalog',
-    'download_from_dbfs',
-    'download_from_alipan',
-    'download_from_local',
+    'CloudDownloader',
+    'S3Downloader',
+    'SFTPDownloader',
+    'GCSDownloader',
+    'OCIDownloader',
+    'AzureDownloader',
+    'AzureDataLakeDownloader',
+    'HFDownloader',
+    'DatabricksUnityCatalogDownloader',
+    'DBFSDownloader',
+    'AlipanDownloader',
+    'LocalDownloader',
 ]
 
 BOTOCORE_CLIENT_ERROR_CODES = {'403', '404', 'NoSuchKey'}
@@ -35,25 +37,194 @@ Credentials. See also https://docs.mosaicml.com/projects/mcli/en/latest/resource
 """
 
 
-def download_from_s3(remote: str, local: str, timeout: float) -> None:
-    """Download a file from remote AWS S3 (or any S3 compatible object store) to local.
+class CloudDownloader(abc.ABC):
+    """Download files from a remote storage to a local filesystem."""
 
-    Args:
-        remote (str): Remote path (S3).
-        local (str): Local path (local filesystem).
-        timeout (float): How long to wait for shard to download before raising an exception.
-    """
-
-    def _download_file(unsigned: bool = False,
-                       extra_args: Optional[dict[str, Any]] = None) -> None:
-        """Download the file from AWS S3 bucket. The bucket can be either public or private.
+    @classmethod
+    def get(cls, remote_dir: Optional[str]) -> 'CloudDownloader':
+        """Get the downloader for the remote path.
 
         Args:
-            unsigned (bool, optional):  Set to True if it is a public bucket.
-                Defaults to ``False``.
-            extra_args (Dict[str, Any], optional): Extra arguments supported by boto3.
-                Defaults to ``None``.
+            remote (str): Remote path.
+
+        Returns:
+            CloudDownloader: Downloader for the remote path.
+
+        Raises:
+            ValueError: If the remote path is not provided or remote path is not supported.
         """
+        if not remote_dir:
+            raise ValueError('Remote path must be provided.')
+
+        prefix = urllib.parse.urlparse(remote_dir).scheme
+        if prefix == 'dbfs' and remote_dir.startswith('dbfs:/Volumes'):
+            prefix = 'dbfs-uc'
+
+        if prefix not in DOWNLOADER_MAPPINGS:
+            raise ValueError(f'Unsupported remote path: {remote_dir}')
+
+        return DOWNLOADER_MAPPINGS[prefix]()
+
+    @classmethod
+    def direct_download(cls, remote: Optional[str], local: str, timeout: float = 60.0) -> None:
+        """Directly download a file from remote storage to local filesystem.
+
+        Args:
+            remote (str): Remote path.
+            local (str): Local path.
+            timeout (float): How long to wait for file to download before raising an exception.
+
+        Raises:
+            ValueError: If the remote path is not provided or remote path is not supported.
+        """
+        downloader = cls.get(remote)
+        downloader.download(remote, local, timeout)
+        downloader.clean_up()
+
+    def download(self, remote: Optional[str], local: str, timeout: float = 60.0) -> None:
+        """Download a file from remote storage to local filesystem.
+
+        Args:
+            remote (str): Remote path.
+            local (str): Local path.
+            timeout (float): How long to wait for file to download before raising an exception.
+
+        Raises:
+            ValueError: If the remote path does not contain the expected prefix or remote is
+                not provided.
+        """
+        if not remote:
+            raise ValueError(
+                'In the absence of local dataset, path to remote dataset must be provided')
+
+        if sys.platform == 'win32':
+            remote = pathlib.PureWindowsPath(remote).as_posix()
+            local = pathlib.PureWindowsPath(local).as_posix()
+
+        self._validate_remote_path(remote)
+        self._download_impl(remote, local, timeout)
+
+    @staticmethod
+    @abc.abstractmethod
+    def prefix() -> str:
+        """Return the prefix of the downloader.
+
+        Returns:
+            str: Prefix of the downloader.
+        """
+
+    @abc.abstractmethod
+    def clean_up(self) -> None:
+        """Clean up the downloader when it is done being used."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def _download_impl(self, remote: str, local: str, timeout: float) -> None:
+        """Implementation of the download function.
+
+        Args:
+            remote (str): Remote path.
+            local (str): Local path.
+            timeout (float): How long to wait for file to download before raising an exception.
+        """
+        raise NotImplementedError
+
+    def _validate_remote_path(self, remote: str) -> None:
+        """Validate the remote path.
+
+        Args:
+            remote (str): Remote path.
+
+        Raises:
+            ValueError: If the remote path does not contain the expected prefix.
+        """
+        # Single slash because some protocols only use a single slash, not double
+        url_scheme = urllib.parse.urlparse(remote).scheme
+
+        if url_scheme != self.prefix():
+            raise ValueError(
+                f'Expected remote path to start with url scheme of `{url_scheme}`, got {remote}.')
+
+
+class S3Downloader(CloudDownloader):
+    """Download files from AWS S3 to local filesystem."""
+
+    def __init__(self):
+        super().__init__()
+
+        self._s3_client: Optional[Any] = None  # Hard to tell exactly what the typing of this is
+        self._requester_pays_buckets = [
+            name.strip()
+            for name in os.environ.get('MOSAICML_STREAMING_AWS_REQUESTER_PAYS', '').split(',')
+        ]
+
+    @staticmethod
+    def prefix() -> str:
+        """Return the prefix of the downloader.
+
+        Returns:
+            str: returns s3.
+        """
+        return 's3'
+
+    def clean_up(self) -> None:
+        """Clean up the downloader when it is done being used."""
+        self._s3_client = None
+
+    def _download_impl(self, remote: str, local: str, timeout: float) -> None:
+        """Implementation of the download function."""
+        from boto3.s3.transfer import TransferConfig
+        from botocore.exceptions import ClientError, NoCredentialsError
+
+        if self._s3_client is None:
+            try:
+                self._create_s3_client(timeout=timeout)
+            except NoCredentialsError:
+                # Public S3 buckets without credentials
+                self._create_s3_client(unsigned=True, timeout=timeout)
+            except Exception as e:
+                raise e
+        assert self._s3_client is not None
+
+        obj = urllib.parse.urlparse(remote)
+        extra_args = {}
+        # When enabled, the requester instead of the bucket owner pays the cost of the request
+        # and the data download from the bucket.
+        if obj.netloc in self._requester_pays_buckets:
+            extra_args['RequestPayer'] = 'requester'
+
+        try:
+            self._s3_client.download_file(obj.netloc,
+                                          obj.path.lstrip('/'),
+                                          local,
+                                          ExtraArgs=extra_args,
+                                          Config=TransferConfig(use_threads=False))
+        except ClientError as e:
+            if e.response['Error']['Code'] in BOTOCORE_CLIENT_ERROR_CODES:
+                e.args = (
+                    f'Object {remote} not found! Either check the bucket path or the bucket ' +
+                    'permission. If the bucket is a requester pays bucket, then provide the ' +
+                    'bucket name to the environment variable ' +
+                    '`MOSAICML_STREAMING_AWS_REQUESTER_PAYS`.',)
+                raise e
+            elif e.response['Error']['Code'] == '400':
+                # Recreate s3 client as public
+                # TODO(ethantang-db) not sure if this is the right way, can there be a bucket with
+                # a mixed amount of content that is both private and public? If so, then we might
+                # need two clients, one for public and one for private
+                self._create_s3_client(unsigned=True, timeout=timeout)
+                self._download_impl(remote, local, timeout)
+            else:
+                raise e
+        except Exception as e:
+            raise e
+
+    def _create_s3_client(self, unsigned: bool = False, timeout: float = 60.0) -> Any:
+        """Create an S3 client."""
+        from boto3.session import Session
+        from botocore import UNSIGNED
+        from botocore.config import Config
+
         retries = {
             'mode': 'adaptive',
         }
@@ -64,512 +235,574 @@ def download_from_s3(remote: str, local: str, timeout: float) -> None:
         else:
             config = Config(read_timeout=timeout, retries=retries)
 
-        if extra_args is None:
-            extra_args = {}
-
-        # Create a new session per thread
-        session = boto3.session.Session()
-        # Create a resource client using a thread's session object
-        s3 = session.client('s3', config=config, endpoint_url=os.environ.get('S3_ENDPOINT_URL'))
-        # Threads calling S3 operations return RuntimeError (cannot schedule new futures after
-        # interpreter shutdown). Temporary solution is to have `use_threads` as `False`.
-        # Issue: https://github.com/boto/boto3/issues/3113
-        s3.download_file(obj.netloc,
-                         obj.path.lstrip('/'),
-                         local,
-                         ExtraArgs=extra_args,
-                         Config=TransferConfig(use_threads=False))
-
-    import boto3
-    from boto3.s3.transfer import TransferConfig
-    from botocore import UNSIGNED
-    from botocore.config import Config
-    from botocore.exceptions import ClientError, NoCredentialsError
-
-    obj = urllib.parse.urlparse(remote)
-    if obj.scheme != 's3':
-        raise ValueError(
-            f'Expected obj.scheme to be `s3`, instead, got {obj.scheme} for remote={remote}')
-
-    extra_args = {}
-    # When enabled, the requester instead of the bucket owner pays the cost of the request
-    # and the data download from the bucket.
-    if os.environ.get('MOSAICML_STREAMING_AWS_REQUESTER_PAYS') is not None:
-        requester_pays_buckets = os.environ.get(  # yapf: ignore
-            'MOSAICML_STREAMING_AWS_REQUESTER_PAYS').split(',')  # pyright: ignore
-        requester_pays_buckets = [name.strip() for name in requester_pays_buckets]
-        if obj.netloc in requester_pays_buckets:
-            extra_args['RequestPayer'] = 'requester'
-
-    try:
-        _download_file(extra_args=extra_args)
-    except NoCredentialsError:
-        # Public S3 buckets without credentials
-        _download_file(unsigned=True, extra_args=extra_args)
-    except ClientError as e:
-        if e.response['Error']['Code'] in BOTOCORE_CLIENT_ERROR_CODES:
-            e.args = (f'Object {remote} not found! Either check the bucket path or the bucket ' +
-                      f'permission. If the bucket is a requester pays bucket, then provide the ' +
-                      f'bucket name to the environment variable ' +
-                      f'`MOSAICML_STREAMING_AWS_REQUESTER_PAYS`.',)
-            raise e
-        elif e.response['Error']['Code'] == '400':
-            # Public S3 buckets without credentials
-            _download_file(unsigned=True, extra_args=extra_args)
-    except Exception:
-        raise
+        # Creating the session
+        self._s3_client = Session().client('s3',
+                                           config=config,
+                                           endpoint_url=os.environ.get('S3_ENDPOINT_URL'))
 
 
-def download_from_sftp(remote: str, local: str) -> None:
-    """Download a file from remote SFTP server to local filepath.
+class SFTPDownloader(CloudDownloader):
+    """Download files from SFTP to local filesystem."""
 
-    Authentication must be provided via username/password in the ``remote`` URI, or a valid SSH
-    config, or a default key discoverable in ``~/.ssh/``.
+    def __init__(self):
+        """Initialize the downloader."""
+        super().__init__()
 
-    Args:
-        remote (str): Remote path (SFTP).
-        local (str): Local path (local filesystem).
-    """
-    from paramiko import SSHClient
+        from urllib.parse import SplitResult
 
-    # Parse URL
-    url = urllib.parse.urlsplit(remote)
-    if url.scheme.lower() != 'sftp':
-        raise ValueError('If specifying a URI, only the sftp scheme is supported.')
-    if not url.hostname:
-        raise ValueError('If specifying a URI, the URI must include the hostname.')
-    if url.query or url.fragment:
-        raise ValueError('Query and fragment parameters are not supported as part of a URI.')
-    hostname = url.hostname
-    port = url.port
-    username = url.username
-    password = url.password
-    remote_path = url.path
+        from paramiko import SSHClient
 
-    # Get SSH key file if specified
-    key_filename = os.environ.get('COMPOSER_SFTP_KEY_FILE', None)
-    known_hosts_filename = os.environ.get('COMPOSER_SFTP_KNOWN_HOSTS_FILE', None)
+        self._ssh_client: Optional[SSHClient] = None
+        self._url: Optional[SplitResult] = None
 
-    # Default port
-    port = port if port else 22
+    @staticmethod
+    def prefix() -> str:
+        """Return the prefix of the downloader.
 
-    # Local tmp
-    local_tmp = local + '.tmp'
-    if os.path.exists(local_tmp):
-        os.remove(local_tmp)
+        Returns:
+            str: returns sftp.
+        """
+        return 'sftp'
 
-    with SSHClient() as ssh_client:
-        # Connect SSH Client
-        ssh_client.load_system_host_keys(known_hosts_filename)
-        ssh_client.connect(
-            hostname=hostname,
-            port=port,
-            username=username,
-            password=password,
+    def clean_up(self) -> None:
+        """Clean up the downloader when it is done being used."""
+        if self._ssh_client is not None:
+            self._ssh_client.close()
+            self._ssh_client = None
+
+    def _download_impl(self, remote: str, local: str, timeout: float) -> None:
+        """Implementation of the download function."""
+        url = urllib.parse.urlsplit(remote)
+        local_tmp = local + '.tmp'
+
+        if os.path.exists(local_tmp):
+            os.remove(local_tmp)
+
+        if self._ssh_client is None:
+            self._create_ssh_client(url)
+        assert self._ssh_client is not None
+
+        sftp_client = self._ssh_client.open_sftp()
+        sftp_client.get(remotepath=url.path, localpath=local_tmp)
+        os.rename(local_tmp, local)
+
+    def _validate_remote_path(self, remote: str) -> None:
+        """Validates the remote path for sftp client."""
+        super()._validate_remote_path(remote)
+
+        url = urllib.parse.urlsplit(remote)
+        if url.hostname is None:
+            raise ValueError('If specifying a URI, the URI must include the hostname.')
+        if url.query or url.fragment:
+            raise ValueError('Query and fragment parameters are not supported as part of a URI.')
+
+        if self._url is None:
+            self._url = url
+            return
+
+        assert self._url.hostname == url.hostname
+        assert self._url.port == url.port or (self._url.port is None and url.port == 22)
+        assert self._url.username == url.username
+        assert self._url.password == url.password
+
+    def _create_ssh_client(self, url: urllib.parse.SplitResult) -> None:
+        """Create an SSH client."""
+        assert url.hostname is not None, 'Hostname must be provided for SFTP download.'
+
+        from paramiko import SSHClient
+
+        # Get SSH key file if specified
+        key_filename = os.environ.get('COMPOSER_SFTP_KEY_FILE', None)
+        known_hosts_filename = os.environ.get('COMPOSER_SFTP_KNOWN_HOSTS_FILE', None)
+
+        self._ssh_client = SSHClient()
+        self._ssh_client.load_system_host_keys(known_hosts_filename)
+        self._ssh_client.connect(
+            hostname=url.hostname,  # ignore: reportGeneralTypeIssues
+            port=url.port if url.port is not None else 22,
+            username=url.username,
+            password=url.password,
             key_filename=key_filename,
         )
 
-        # SFTP Client
-        sftp_client = ssh_client.open_sftp()
-        sftp_client.get(remotepath=remote_path, localpath=local_tmp)
-    os.rename(local_tmp, local)
+
+class GCSDownloader(CloudDownloader):
+
+    def __init__(self):
+        super().__init__()
+
+        from google.cloud.storage import Client
+
+        self._gcs_client: Optional[Any | Client] = None
+
+    @staticmethod
+    def prefix() -> str:
+        """Return the prefix of the downloader.
+
+        Returns:
+            str: returns gs.
+        """
+        return 'gs'
+
+    def clean_up(self) -> None:
+        """Clean up the downloader when it is done being used."""
+        self._gcs_client = None
+
+    def _download_impl(self, remote: str, local: str, timeout: float) -> None:
+        from google.cloud.storage import Client
+
+        if self._gcs_client is None:
+            self._create_gcs_client()
+        assert self._gcs_client is not None
+
+        url = urllib.parse.urlparse(remote)
+
+        if isinstance(self._gcs_client, Client):
+            from google.cloud.storage import Blob, Bucket
+            blob = Blob(url.path.lstrip('/'), Bucket(self._gcs_client, url.netloc))
+            blob.download_to_filename(local)
+        else:
+            from boto3.s3.transfer import TransferConfig
+            from botocore.exceptions import ClientError
+
+            try:
+                self._gcs_client.download_file(url.netloc,
+                                               url.path.lstrip('/'),
+                                               local,
+                                               Config=TransferConfig(use_threads=False))
+            except ClientError as e:
+                if e.response['Error']['Code'] in BOTOCORE_CLIENT_ERROR_CODES:
+                    raise FileNotFoundError(f'Object {remote} not found') from e
+            except Exception as e:
+                raise e
+
+    def _create_gcs_client(self) -> None:
+        if 'GCS_KEY' in os.environ and 'GCS_SECRET' in os.environ:
+            from boto3.session import Session
+
+            self._gcs_client = Session().client('s3',
+                                                region_name='auto',
+                                                endpoint_url='https://storage.googleapis.com',
+                                                aws_access_key_id=os.environ['GCS_KEY'],
+                                                aws_secret_access_key=os.environ['GCS_SECRET'])
+        else:
+            from google.auth import default as default_auth
+            from google.auth.exceptions import DefaultCredentialsError
+            from google.cloud.storage import Client
+
+            try:
+                credentials, _ = default_auth()
+                self._gcs_client = Client(credentials=credentials)
+            except (DefaultCredentialsError, EnvironmentError):
+                raise ValueError(GCS_ERROR_NO_AUTHENTICATION)
 
 
-def download_from_gcs(remote: str, local: str) -> None:
-    """Download a file from remote GCS to local.
+class OCIDownloader(CloudDownloader):
 
-    Args:
-        remote (str): Remote path (GCS).
-        local (str): Local path (local filesystem).
-    """
-    from google.auth.exceptions import DefaultCredentialsError
-    obj = urllib.parse.urlparse(remote)
-    if obj.scheme != 'gs':
-        raise ValueError(
-            f'Expected obj.scheme to be `gs`, instead, got {obj.scheme} for remote={remote}')
+    def __init__(self):
+        super().__init__()
 
-    if 'GCS_KEY' in os.environ and 'GCS_SECRET' in os.environ:
-        _gcs_with_hmac(remote, local, obj)
-    else:
-        try:
-            _gcs_with_service_account(local, obj)
-        except (DefaultCredentialsError, EnvironmentError):
-            raise ValueError(GCS_ERROR_NO_AUTHENTICATION)
+        import oci
+        self._oci_client: Optional[oci.object_storage.ObjectStorageClient] = None
 
+    @staticmethod
+    def prefix() -> str:
+        """Return the prefix of the downloader.
 
-def _gcs_with_hmac(remote: str, local: str, obj: urllib.parse.ParseResult) -> None:
-    """Download a file from remote GCS to local using user level credentials.
+        Returns:
+            str: returns oci.
+        """
+        return 'oci'
 
-    Args:
-        remote (str): Remote path (GCS).
-        local (str): Local path (local filesystem).
-        obj (ParseResult): ParseResult object of remote.
-    """
-    import boto3
-    from boto3.s3.transfer import TransferConfig
-    from botocore.exceptions import ClientError
+    def clean_up(self) -> None:
+        """Clean up the downloader when it is done being used."""
+        self._oci_client = None
 
-    # Create a new session per thread
-    session = boto3.session.Session()
-    # Create a resource client using a thread's session object
-    gcs_client = session.client('s3',
-                                region_name='auto',
-                                endpoint_url='https://storage.googleapis.com',
-                                aws_access_key_id=os.environ['GCS_KEY'],
-                                aws_secret_access_key=os.environ['GCS_SECRET'])
-    try:
-        # Threads calling S3 operations return RuntimeError (cannot schedule new futures after
-        # interpreter shutdown). Temporary solution is to have `use_threads` as `False`.
-        # Issue: https://github.com/boto/boto3/issues/3113
-        gcs_client.download_file(obj.netloc,
-                                 obj.path.lstrip('/'),
-                                 local,
-                                 Config=TransferConfig(use_threads=False))
-    except ClientError as e:
-        if e.response['Error']['Code'] in BOTOCORE_CLIENT_ERROR_CODES:
-            raise FileNotFoundError(f'Object {remote} not found.') from e
-    except Exception:
-        raise
+    def _download_impl(self, remote: str, local: str, timeout: float) -> None:
+        if self._oci_client is None:
+            self._create_oci_client()
+        assert self._oci_client is not None
+
+        url = urllib.parse.urlparse(remote)
+        bucket_name = url.netloc.split('@' + self._oci_client.get_namespace().data)[0]
+        object_path = url.path.strip('/')
+        object_details = self._oci_client.get_object(self._oci_client.get_namespace().data,
+                                                     bucket_name, object_path)
+        local_tmp = local + '.tmp'
+        with open(local_tmp, 'wb') as f:
+            for chunk in object_details.data.raw.stream(2048**2, decode_content=False):
+                f.write(chunk)
+        os.rename(local_tmp, local)
+
+    def _create_oci_client(self) -> None:
+        import oci
+
+        config = oci.config.from_file()
+        self._oci_client = oci.object_storage.ObjectStorageClient(
+            config=config, retry_strategy=oci.retry.DEFAULT_RETRY_STRATEGY)
 
 
-def _gcs_with_service_account(local: str, obj: urllib.parse.ParseResult) -> None:
-    """Download a file from remote GCS to local using service account credentials.
+class HFDownloader(CloudDownloader):
 
-    Args:
-        local (str): Local path (local filesystem).
-        obj (ParseResult): ParseResult object of remote path (GCS).
-    """
-    from google.auth import default as default_auth
-    from google.cloud.storage import Blob, Bucket, Client
+    def __init__(self):
+        super().__init__()
 
-    credentials, _ = default_auth()
-    gcs_client = Client(credentials=credentials)
-    blob = Blob(obj.path.lstrip('/'), Bucket(gcs_client, obj.netloc))
-    blob.download_to_filename(local)
+    @staticmethod
+    def prefix() -> str:
+        """Return the prefix of the downloader.
 
+        Returns:
+            str: returns hf.
+        """
+        return 'hf'
 
-def download_from_oci(remote: str, local: str) -> None:
-    """Download a file from remote OCI to local.
+    def clean_up(self) -> None:
+        """Clean up the downloader when it is done being used."""
+        pass
 
-    Args:
-        remote (str): Remote path (OCI).
-        local (str): Local path (local filesystem).
-    """
-    import oci
-    config = oci.config.from_file()
-    client = oci.object_storage.ObjectStorageClient(
-        config=config, retry_strategy=oci.retry.DEFAULT_RETRY_STRATEGY)
-    namespace = client.get_namespace().data
-    obj = urllib.parse.urlparse(remote)
-    if obj.scheme != 'oci':
-        raise ValueError(
-            f'Expected obj.scheme to be `oci`, instead, got {obj.scheme} for remote={remote}')
+    def _download_impl(self, remote: str, local: str, timeout: float) -> None:
+        from huggingface_hub import hf_hub_download
 
-    bucket_name = obj.netloc.split('@' + namespace)[0]
-    # Remove leading and trailing forward slash from string
-    object_path = obj.path.strip('/')
-    object_details = client.get_object(namespace, bucket_name, object_path)
-    local_tmp = local + '.tmp'
-    with open(local_tmp, 'wb') as f:
-        for chunk in object_details.data.raw.stream(2048**2, decode_content=False):
-            f.write(chunk)
-    os.rename(local_tmp, local)
+        _, _, _, repo_org, repo_name, path = remote.split('/', 5)
+        local_dirname = os.path.dirname(local)
+        hf_hub_download(repo_id=f'{repo_org}/{repo_name}',
+                        filename=path,
+                        repo_type='dataset',
+                        local_dir=local_dirname)
+
+        downloaded_name = os.path.join(local_dirname, path)
+        os.rename(downloaded_name, local)
 
 
-def download_from_hf(remote: str, local: str) -> None:
-    """Download a file from remote Hugging Face to local.
+class AzureDownloader(CloudDownloader):
 
-    Args:
-        remote (str): Remote path (Hugging Face).
-        local (str): Local path (local filesystem).
-    """
-    from huggingface_hub import hf_hub_download
+    def __init__(self):
+        super().__init__()
 
-    obj = urllib.parse.urlparse(remote)
-    if obj.scheme != 'hf':
-        raise ValueError(f'Expected remote path to start with `hf://`, got {remote}.')
+        from azure.storage.blob import BlobServiceClient
 
-    _, _, _, repo_org, repo_name, path = remote.split('/', 5)
-    local_dirname = os.path.dirname(local)
-    hf_hub_download(repo_id=f'{repo_org}/{repo_name}',
-                    filename=path,
-                    repo_type='dataset',
-                    local_dir=local_dirname)
+        self._azure_client: Optional[BlobServiceClient] = None
 
-    downloaded_name = os.path.join(local_dirname, path)
-    os.rename(downloaded_name, local)
+    @staticmethod
+    def prefix() -> str:
+        """Return the prefix of the downloader.
 
+        Returns:
+            str: returns azure.
+        """
+        return 'azure'
 
-def download_from_azure(remote: str, local: str) -> None:
-    """Download a file from remote Microsoft Azure to local.
+    def clean_up(self) -> None:
+        """Clean up the downloader when it is done being used."""
+        self._azure_client = None
 
-    Args:
-        remote (str): Remote path (azure).
-        local (str): Local path (local filesystem).
-    """
-    from azure.core.exceptions import ResourceNotFoundError
-    from azure.storage.blob import BlobServiceClient
+    def _download_impl(self, remote: str, local: str, timeout: float) -> None:
+        if self._azure_client is None:
+            self._create_azure_client()
+        assert self._azure_client is not None
 
-    obj = urllib.parse.urlparse(remote)
-    if obj.scheme != 'azure':
-        raise ValueError(
-            f'Expected obj.scheme to be `azure`, instead, got {obj.scheme} for remote={remote}')
-
-    # Create a new session per thread
-    service = BlobServiceClient(
-        account_url=f"https://{os.environ['AZURE_ACCOUNT_NAME']}.blob.core.windows.net",
-        credential=os.environ['AZURE_ACCOUNT_ACCESS_KEY'])
-    try:
+        obj = urllib.parse.urlparse(remote)
         file_path = obj.path.lstrip('/').split('/')
         container_name = file_path[0]
         blob_name = os.path.join(*file_path[1:])
-        blob_client = service.get_blob_client(container=container_name, blob=blob_name)
+        blob_client = self._azure_client.get_blob_client(container=container_name, blob=blob_name)
         local_tmp = local + '.tmp'
         with open(local_tmp, 'wb') as my_blob:
             blob_data = blob_client.download_blob()
             blob_data.readinto(my_blob)
         os.rename(local_tmp, local)
-    except ResourceNotFoundError as e:
-        raise FileNotFoundError(f'Object {remote} not found.') from e
-    except Exception:
-        raise
+
+    def _create_azure_client(self) -> None:
+        from azure.storage.blob import BlobServiceClient
+
+        self._azure_client = BlobServiceClient(
+            account_url=f"https://{os.environ['AZURE_ACCOUNT_NAME']}.blob.core.windows.net",
+            credential=os.environ['AZURE_ACCOUNT_ACCESS_KEY'])
 
 
-def download_from_azure_datalake(remote: str, local: str) -> None:
-    """Download a file from remote Microsoft Azure Data Lake to local.
+class AzureDataLakeDownloader(CloudDownloader):
 
-    Args:
-        remote (str): Remote path (azure).
-        local (str): Local path (local filesystem).
-    """
-    from azure.core.exceptions import ResourceNotFoundError
-    from azure.storage.filedatalake import DataLakeServiceClient
+    def __init__(self):
+        super().__init__()
 
-    obj = urllib.parse.urlparse(remote)
-    if obj.scheme != 'azure-dl':
-        raise ValueError(
-            f'Expected obj.scheme to be `azure-dl`, got {obj.scheme} for remote={remote}')
+        from azure.storage.filedatalake import DataLakeServiceClient
 
-    # Create a new session per thread
-    service = DataLakeServiceClient(
-        account_url=f"https://{os.environ['AZURE_ACCOUNT_NAME']}.dfs.core.windows.net",
-        credential=os.environ['AZURE_ACCOUNT_ACCESS_KEY'],
-    )
-    try:
-        file_client = service.get_file_client(file_system=obj.netloc,
-                                              file_path=obj.path.lstrip('/'))
-        local_tmp = local + '.tmp'
-        with open(local_tmp, 'wb') as my_file:
-            file_data = file_client.download_file()
-            file_data.readinto(my_file)
-        os.rename(local_tmp, local)
-    except ResourceNotFoundError as e:
-        raise FileNotFoundError(f'Object {remote} not found.') from e
-    except Exception:
-        raise
+        self._azure_dl_client: Optional[DataLakeServiceClient] = None
 
+    @staticmethod
+    def prefix() -> str:
+        """Return the prefix of the downloader.
 
-def download_from_databricks_unity_catalog(remote: str, local: str) -> None:
-    """Download a file from remote Databricks Unity Catalog to local.
+        Returns:
+            str: returns adl.
+        """
+        return 'azure-dl'
 
-    .. note::
-        The Databricks UC Volume path must be of the form
-        `dbfs:/Volumes/<catalog-name>/<schema-name>/<volume-name>/path`.
+    def clean_up(self) -> None:
+        """Clean up the downloader when it is done being used."""
+        self._azure_dl_client = None
 
-    Args:
-        remote (str): Remote path (Databricks Unity Catalog).
-        local (str): Local path (local filesystem).
-    """
-    try:
-        from databricks.sdk import WorkspaceClient
-        from databricks.sdk.core import DatabricksError
-    except ImportError as e:
-        e.msg = get_import_exception_message(e.name, 'databricks')  # pyright: ignore
-        raise e
+    def _download_impl(self, remote: str, local: str, timeout: float) -> None:
+        from azure.core.exceptions import ResourceNotFoundError
 
-    path = pathlib.Path(remote)
-    provider_prefix = os.path.join(path.parts[0], path.parts[1])
-    if provider_prefix != 'dbfs:/Volumes':
-        raise ValueError(
-            f'Expected path prefix to be `dbfs:/Volumes` if it is a Databricks Unity Catalog, ' +
-            f'instead, got {provider_prefix} for remote={remote}.')
+        if self._azure_dl_client is None:
+            self._create_azure_dl_client()
+        assert self._azure_dl_client is not None
 
-    client = WorkspaceClient()
-    file_path = urllib.parse.urlparse(remote)
-    local_tmp = local + '.tmp'
-    try:
-        with client.files.download(file_path.path).contents as response:
+        obj = urllib.parse.urlparse(remote)
+        try:
+            file_client = self._azure_dl_client.get_file_client(file_system=obj.netloc,
+                                                                file_path=obj.path.lstrip('/'))
+            local_tmp = local + '.tmp'
             with open(local_tmp, 'wb') as f:
-                # Download data in chunks to avoid memory issues.
-                for chunk in iter(lambda: response.read(64 * 1024 * 1024), b''):
-                    f.write(chunk)
-    except DatabricksError as e:
-        if e.error_code == 'REQUEST_LIMIT_EXCEEDED':
-            e.args = (f'Dataset download request has been rejected due to too many concurrent ' +
-                      f'operations. Increase the `download_retry` value to retry downloading ' +
-                      f'a file.',)
-        if e.error_code == 'NOT_FOUND':
+                file_data = file_client.download_file()
+                file_data.readinto(f)
+            os.rename(local_tmp, local)
+        except ResourceNotFoundError as e:
             raise FileNotFoundError(f'Object {remote} not found.') from e
-        raise e
-    os.rename(local_tmp, local)
+        except Exception as e:
+            raise e
+
+    def _create_azure_dl_client(self) -> None:
+        from azure.storage.filedatalake import DataLakeServiceClient
+
+        self._azure_dl_client = DataLakeServiceClient(
+            account_url=f"https://{os.environ['AZURE_ACCOUNT_NAME']}.dfs.core.windows.net",
+            credential=os.environ['AZURE_ACCOUNT_ACCESS_KEY'],
+        )
 
 
-def download_from_dbfs(remote: str, local: str) -> None:
-    """Download a file from remote Databricks File System to local.
+class DatabricksUnityCatalogDownloader(CloudDownloader):
 
-    Args:
-        remote (str): Remote path (dbfs).
-        local (str): Local path (local filesystem).
-    """
-    try:
-        from databricks.sdk import WorkspaceClient
+    def __init__(self):
+        super().__init__()
+
+        try:
+            from databricks.sdk import WorkspaceClient
+        except ImportError as e:
+            e.msg = get_import_exception_message(e.name, 'databricks')  # pyright: ignore
+            raise e
+
+        self._db_uc_client: Optional[WorkspaceClient] = None
+
+    @staticmethod
+    def prefix() -> str:
+        """Return the prefix of the downloader.
+
+        Returns:
+            str: returns dbfs-uc.
+        """
+        return 'dbfs-uc'
+
+    def clean_up(self) -> None:
+        """Clean up the downloader when it is done being used."""
+        self._db_uc_client = None
+
+    def _validate_remote_path(self, remote: str):
+        path = pathlib.Path(remote)
+        provider_prefix = os.path.join(path.parts[0], path.parts[1])
+        if provider_prefix != 'dbfs:/Volumes':
+            raise ValueError(
+                'Expected path prefix to be `dbfs:/Volumes` if it is a Databricks Unity ' +
+                f'Catalog, instead, got {provider_prefix} for remote={remote}.')
+
+    def _download_impl(self, remote: str, local: str, timeout: float) -> None:
         from databricks.sdk.core import DatabricksError
-    except ImportError as e:
-        e.msg = get_import_exception_message(e.name, 'databricks')  # pyright: ignore
-        raise e
 
-    obj = urllib.parse.urlparse(remote)
-    if obj.scheme != 'dbfs':
-        raise ValueError(f'Expected path prefix to be `dbfs` if it is a Databricks File System, ' +
-                         f'instead, got {obj.scheme} for remote={remote}.')
+        if self._db_uc_client is None:
+            self._create_db_uc_client()
+        assert self._db_uc_client is not None
 
-    client = WorkspaceClient()
-    file_path = urllib.parse.urlparse(remote)
-    local_tmp = local + '.tmp'
-    try:
-        with client.dbfs.download(file_path.path) as response:
-            with open(local_tmp, 'wb') as f:
-                # Multiple shard files are getting downloaded in parallel, so we need to
-                # read the data in chunks to avoid memory issues.
-                # Read 1MB of data at a time since that's the max limit it can read at a time.
-                for chunk in iter(lambda: response.read(1024 * 1024), b''):
-                    f.write(chunk)
-    except DatabricksError as e:
-        if e.error_code == 'PERMISSION_DENIED':
-            e.args = (f'Ensure the file path or credentials are set correctly. For ' +
-                      f'Databricks Unity Catalog, file path must starts with `dbfs:/Volumes` ' +
-                      f'and for Databricks File System, file path must starts with `dbfs`. ' +
-                      e.args[0],)
-        raise e
-    os.rename(local_tmp, local)
+        file_path = urllib.parse.urlparse(remote)
+        local_tmp = local + '.tmp'
+        response = self._db_uc_client.files.download(file_path.path).contents
 
+        assert response is not None
 
-def download_from_alipan(remote: str, local: str) -> None:
-    """Download a file from remote Alipan to local.
+        try:
+            with response:
+                with open(local_tmp, 'wb') as f:
+                    # Download data in chunks to avoid memory issues.
+                    for chunk in iter(lambda: response.read(64 * 1024 * 1024), b''):
+                        f.write(chunk)
+        except DatabricksError as e:
+            if e.error_code == 'REQUEST_LIMIT_EXCEEDED':
+                e.args = (
+                    'Dataset download request has been rejected due to too many concurrent ' +
+                    'operations. Increase the `download_retry` value to retry downloading ' +
+                    'a file.',)
+            if e.error_code == 'NOT_FOUND':
+                raise FileNotFoundError(f'Object {remote} not found.') from e
+            raise e
+        except Exception as e:
+            raise e
+        os.rename(local_tmp, local)
 
-    Args:
-        remote (str): Remote path (Alipan).
-        local (str): Local path (local filesystem).
-    """
-    from alipcs_py.alipcs import AliPCSApiMix
-    from alipcs_py.commands.download import download_file
-
-    web_refresh_token = os.environ['ALIPAN_WEB_REFRESH_TOKEN']
-    web_token_type = 'Bearer'
-    alipan_encrypt_password = os.environ.get('ALIPAN_ENCRYPT_PASSWORD', '').encode()
-
-    api = AliPCSApiMix(web_refresh_token, web_token_type=web_token_type)
-
-    obj = urllib.parse.urlparse(remote)
-    if obj.scheme != 'alipan':
-        raise ValueError(
-            f'Expected obj.scheme to be `alipan`, instead, got {obj.scheme} for remote={remote}')
-    if obj.netloc != '':
-        raise ValueError(
-            f'Expected remote to be alipan:///path/to/some, instead, got remote={remote}')
-
-    remote_path = obj.path
-    filename = pathlib.PosixPath(remote_path).name
-    localdir = pathlib.Path(local).parent
-
-    remote_pcs_file = api.get_file(remotepath=remote_path)
-    if remote_pcs_file is None:
-        raise FileNotFoundError(f'Object {remote} not found.')
-
-    download_file(
-        api,
-        remote_pcs_file,
-        localdir=localdir,
-        downloader='me',
-        concurrency=1,
-        show_progress=False,
-        encrypt_password=alipan_encrypt_password,
-    )
-    os.rename(localdir / filename, local)
+    def _create_db_uc_client(self) -> None:
+        from databricks.sdk import WorkspaceClient
+        self._db_uc_client = WorkspaceClient()
 
 
-def download_from_local(remote: str, local: str) -> None:
-    """Download a file from remote to local.
+class DBFSDownloader(CloudDownloader):
 
-    Args:
-        remote (str): Remote path (local filesystem).
-        local (str): Local path (local filesystem).
-    """
-    local_tmp = local + '.tmp'
-    if os.path.exists(local_tmp):
-        os.remove(local_tmp)
-    shutil.copy(remote, local_tmp)
-    os.rename(local_tmp, local)
+    def __init__(self):
+        super().__init__()
+
+        try:
+            from databricks.sdk import WorkspaceClient
+        except ImportError as e:
+            e.msg = get_import_exception_message(e.name, 'databricks')  # pyright: ignore
+            raise e
+
+        self._dbfs_client: Optional[WorkspaceClient] = None
+
+    @staticmethod
+    def prefix() -> str:
+        """Return the prefix of the downloader.
+
+        Returns:
+            str: returns dbfs.
+        """
+        return 'dbfs'
+
+    def clean_up(self) -> None:
+        """Clean up the downloader when it is done being used."""
+        self._dbfs_client = None
+
+    def _download_impl(self, remote: str, local: str, timeout: float) -> None:
+        from databricks.sdk.core import DatabricksError
+
+        if self._dbfs_client is None:
+            self._create_dbfs_client()
+        assert self._dbfs_client is not None
+
+        file_path = urllib.parse.urlparse(remote)
+        local_tmp = local + '.tmp'
+        response = self._dbfs_client.files.download(file_path.path).contents
+
+        assert response is not None
+
+        try:
+            with response:
+                with open(local_tmp, 'wb') as f:
+                    for chunk in iter(lambda: response.read(1024 * 1024), b''):
+                        f.write(chunk)
+        except DatabricksError as e:
+            if e.error_code == 'PERMISSION_DENIED':
+                e.args = (
+                    f'Ensure the file path or credentials are set correctly. For ' +
+                    f'Databricks Unity Catalog, file path must starts with `dbfs:/Volumes` ' +
+                    f'and for Databricks File System, file path must starts with `dbfs`. ' +
+                    e.args[0],)
+            raise e
+        except Exception as e:
+            raise e
+        os.rename(local_tmp, local)
+
+    def _create_dbfs_client(self) -> None:
+        from databricks.sdk import WorkspaceClient
+        self._dbfs_client = WorkspaceClient()
 
 
-def download_file(remote: Optional[str], local: str, timeout: float):
-    """Use the correct download handler to download the file.
+class AlipanDownloader(CloudDownloader):
 
-    Args:
-        remote (str, optional): Remote path (local filesystem).
-        local (str): Local path (local filesystem).
-        timeout (float): How long to wait for file to download before raising an exception.
-    """
-    if os.path.exists(local):
-        return
+    def __init__(self):
+        super().__init__()
 
-    # fix paths for windows
-    local = local.replace('\\', '/')
-    if remote:
-        remote = remote.replace('\\', '/')
+    @staticmethod
+    def prefix() -> str:
+        """Return the prefix of the downloader.
 
-    local_dir = os.path.dirname(local)
-    os.makedirs(local_dir, exist_ok=True)
+        Returns:
+            str: returns alipan.
+        """
+        return 'alipan'
 
-    if not remote:
-        raise ValueError(
-            'In the absence of local dataset, path to remote dataset must be provided')
-    elif remote.startswith('s3://'):
-        download_from_s3(remote, local, timeout)
-    elif remote.startswith('sftp://'):
-        download_from_sftp(remote, local)
-    elif remote.startswith('gs://'):
-        download_from_gcs(remote, local)
-    elif remote.startswith('oci://'):
-        download_from_oci(remote, local)
-    elif remote.startswith('hf://'):
-        download_from_hf(remote, local)
-    elif remote.startswith('azure://'):
-        download_from_azure(remote, local)
-    elif remote.startswith('azure-dl://'):
-        download_from_azure_datalake(remote, local)
-    elif remote.startswith('dbfs:/Volumes'):
-        download_from_databricks_unity_catalog(remote, local)
-    elif remote.startswith('dbfs:/'):
-        download_from_dbfs(remote, local)
-    elif remote.startswith('alipan://'):
-        download_from_alipan(remote, local)
-    else:
-        download_from_local(remote, local)
+    def clean_up(self) -> None:
+        """Clean up the downloader when it is done being used."""
+        pass
+
+    def _download_impl(self, remote: str, local: str, timeout: float) -> None:
+        from alipcs_py.alipcs import AliPCSApiMix
+        from alipcs_py.commands.download import download_file
+
+        web_refresh_token = os.environ['ALIPAN_WEB_REFRESH_TOKEN']
+        web_token_type = 'Bearer'
+        alipan_encrypt_password = os.environ.get('ALIPAN_ENCRYPT_PASSWORD', '').encode()
+
+        api = AliPCSApiMix(web_refresh_token, web_token_type=web_token_type)
+
+        obj = urllib.parse.urlparse(remote)
+        if obj.scheme != 'alipan':
+            raise ValueError(
+                f'Expected obj.scheme to be `alipan`, instead, got {obj.scheme} for remote={remote}'
+            )
+        if obj.netloc != '':
+            raise ValueError(
+                f'Expected remote to be alipan:///path/to/some, instead, got remote={remote}')
+
+        remote_path = obj.path
+        filename = pathlib.PosixPath(remote_path).name
+        localdir = pathlib.Path(local).parent
+
+        remote_pcs_file = api.get_file(remotepath=remote_path)
+        if remote_pcs_file is None:
+            raise FileNotFoundError(f'Object {remote} not found.')
+
+        download_file(
+            api,
+            remote_pcs_file,
+            localdir=localdir,
+            downloader='me',
+            concurrency=1,
+            show_progress=False,
+            encrypt_password=alipan_encrypt_password,
+        )
+        os.rename(localdir / filename, local)
 
 
-def wait_for_download(local: str, timeout: float = 60) -> None:
-    """Wait for a download by another thread/process to complete.
+class LocalDownloader(CloudDownloader):
 
-    Args:
-        local (str): Local path (local filesystem).
-        timeout (float): How long to wait for file to download before raising an exception.
-            Defaults to ``60``.
-    """
-    t0 = time()
-    while not os.path.exists(local):
-        elapsed = time() - t0
-        if timeout < elapsed:
-            raise TimeoutError(
-                f'Waited longer than {timeout}s for other worker to download {local}.')
-        sleep(0.25)
+    def __init__(self):
+        super().__init__()
+
+    @staticmethod
+    def prefix() -> str:
+        """Return the prefix of the downloader.
+
+        Returns:
+            str: returns file.
+        """
+        return ''
+
+    def clean_up(self) -> None:
+        """Clean up the downloader when it is done being used."""
+        pass
+
+    def _download_impl(self, remote: str, local: str, timeout: float) -> None:
+        """Download a file from remote to local.
+
+        Args:
+            remote (str): Remote path (local or unix filesystem).
+            local (str): Local path (local filesystem).
+        """
+        local_tmp = local + '.tmp'
+        if os.path.exists(local_tmp):
+            os.remove(local_tmp)
+        shutil.copy(remote, local_tmp)
+        os.rename(local_tmp, local)
+
+
+def _register_cloud_downloader_subclasses() -> dict[str, type[CloudDownloader]]:
+    """Register all CloudDownloader subclasses."""
+    sub_classes = CloudDownloader.__subclasses__()
+
+    downloader_mappings = {}
+
+    for sub_class in sub_classes:
+        downloader_mappings[sub_class.prefix()] = sub_class
+
+    return downloader_mappings
+
+
+DOWNLOADER_MAPPINGS = _register_cloud_downloader_subclasses()

--- a/streaming/base/stream.py
+++ b/streaming/base/stream.py
@@ -310,7 +310,7 @@ class Stream:
         local = os.path.join(self.local, self.split, to_basename or from_basename)
 
         # Attempt to download, possibly repeating on failure.
-        retry(num_attempts=self.download_retry)(
+        retry(clean_up_fn=self._downloader.clean_up, num_attempts=self.download_retry)(
             lambda: self._downloader.download(remote, local, self.download_timeout))()
 
         return local

--- a/streaming/base/util.py
+++ b/streaming/base/util.py
@@ -491,6 +491,7 @@ def retry(  # type: ignore
 
             def clean_up():
                 # Do clean up stuff here
+                print("cleaning up")
 
             @retry(RuntimeError, clean_up_fn=clean_up, num_attempts=3, initial_backoff=0.1)
             def flaky_function():

--- a/streaming/base/util.py
+++ b/streaming/base/util.py
@@ -16,7 +16,7 @@ from collections import OrderedDict
 from multiprocessing.shared_memory import SharedMemory as BuiltinSharedMemory
 from pathlib import Path
 from time import sleep, time
-from typing import Any, Callable, Sequence, TypeVar, Union, cast, overload
+from typing import Any, Callable, Optional, Sequence, TypeVar, Union, cast, overload
 
 import torch.distributed as dist
 
@@ -454,6 +454,7 @@ def _merge_index_from_root(out: Union[str, tuple[str, str]],
 @overload
 def retry(
     exc_class: Union[type[Exception], Sequence[type[Exception]]] = ...,
+    clean_up_fn: Optional[Callable[[], None]] = ...,
     num_attempts: int = ...,
     initial_backoff: float = ...,
     max_jitter: float = ...,
@@ -471,6 +472,7 @@ def retry(exc_class: TCallable) -> TCallable:
 # "(func: Never) -> Never"
 def retry(  # type: ignore
     exc_class: Union[TCallable, type[Exception], Sequence[type[Exception]]] = Exception,
+    clean_up_fn: Optional[Callable[[], None]] = None,
     num_attempts: int = 3,
     initial_backoff: float = 1.0,
     max_jitter: float = 0.5,
@@ -487,7 +489,10 @@ def retry(  # type: ignore
 
             num_tries = 0
 
-            @retry(RuntimeError, num_attempts=3, initial_backoff=0.1)
+            def clean_up():
+                print("cleaning up")
+
+            @retry(RuntimeError, clean_up_fn=clean_up, num_attempts=3, initial_backoff=0.1)
             def flaky_function():
                 global num_tries
                 if num_tries < 2:
@@ -499,11 +504,15 @@ def retry(  # type: ignore
 
     .. testoutput::
 
+        cleaning up
+        cleaning up
         Third time's a charm.
 
     Args:
         exc_class (Type[Exception] | Sequence[Type[Exception]]], optional): The exception class or
             classes to retry. Defaults to Exception.
+        clean_up_fn (Callable[[], None], optional): A function to call after each failed attempt
+            before retrying. Defaults to None.
         num_attempts (int, optional): The total number of attempts to make. Defaults to 3.
         initial_backoff (float, optional): The initial backoff, in seconds. Defaults to 1.0.
         max_jitter (float, optional): The maximum amount of random jitter to add. Defaults to 0.5.
@@ -523,6 +532,9 @@ def retry(  # type: ignore
                 try:
                     return func(*args, **kwargs)
                 except exc_class as e:
+                    if clean_up_fn is not None:
+                        clean_up_fn()
+
                     if i + 1 == num_attempts:
                         logger.debug(f'Attempt {i + 1}/{num_attempts} failed with: {e}')
                         raise e

--- a/streaming/base/util.py
+++ b/streaming/base/util.py
@@ -276,7 +276,7 @@ def _merge_index_from_list(index_file_urls: Sequence[Union[str, tuple[str, str]]
         keep_local (bool): Keep local copy of the merged index file. Defaults to ``True``
         download_timeout (int): The allowed time for downloading each json file. Defaults to 60.
     """
-    from streaming.base.storage.download import download_file
+    from streaming.base.storage.download import CloudDownloader
     from streaming.base.storage.upload import CloudUploader
 
     if not index_file_urls or not out:
@@ -319,7 +319,7 @@ def _merge_index_from_list(index_file_urls: Sequence[Union[str, tuple[str, str]]
             dest = os.path.join(temp_root, path.lstrip('/'))
 
             try:
-                download_file(src, dest, download_timeout)
+                CloudDownloader.direct_download(src, dest, download_timeout)
             except Exception as ex:
                 raise RuntimeError(f'Failed to download index.json: {src} to {dest}') from ex
 

--- a/streaming/base/util.py
+++ b/streaming/base/util.py
@@ -490,7 +490,7 @@ def retry(  # type: ignore
             num_tries = 0
 
             def clean_up():
-                print("cleaning up")
+                # Do clean up stuff here
 
             @retry(RuntimeError, clean_up_fn=clean_up, num_attempts=3, initial_backoff=0.1)
             def flaky_function():

--- a/streaming/multimodal/webvid.py
+++ b/streaming/multimodal/webvid.py
@@ -9,7 +9,7 @@ from typing import Any, Optional
 
 from streaming.base import StreamingDataset
 from streaming.base.dataset import TICK, _Iterator
-from streaming.base.storage import download_file
+from streaming.base.storage import CloudDownloader
 
 
 class StreamingInsideWebVid(StreamingDataset):
@@ -191,6 +191,8 @@ class StreamingOutsideGIWebVid(StreamingDataset):
         self.extra_local = extra_local
         self.extra_remote = extra_remote
 
+        self._extra_downloader = CloudDownloader.get(extra_remote)
+
     def get_item(self, idx: int) -> Any:
         """Get the sample at the index.
 
@@ -207,7 +209,7 @@ class StreamingOutsideGIWebVid(StreamingDataset):
             local = os.path.join(self.extra_local, rel_path)
             remote = os.path.join(self.extra_remote, rel_path)
             if not os.path.exists(local):
-                download_file(remote, local, self.download_timeout)
+                self._extra_downloader.download(remote, local, self.download_timeout)
             with open(local, 'rb') as fp:
                 content = fp.read()
             obj['content'] = content
@@ -322,6 +324,8 @@ class StreamingOutsideDTWebVid(StreamingDataset):
         self.extra_local = extra_local
         self.extra_remote = extra_remote
 
+        self._extra_downloader = CloudDownloader.get(extra_remote)
+
     def get_item(self, idx: int) -> Any:
         """Get the sample at the index.
 
@@ -338,7 +342,7 @@ class StreamingOutsideDTWebVid(StreamingDataset):
             local = os.path.join(self.extra_local, rel_path)
             remote = os.path.join(self.extra_remote, rel_path)
             if not os.path.exists(local):
-                download_file(remote, local, self.download_timeout)
+                self._extra_downloader.download(remote, local, self.download_timeout)
             with open(local, 'rb') as fp:
                 content = fp.read()
             obj['content'] = content
@@ -396,7 +400,7 @@ class StreamingOutsideDTWebVid(StreamingDataset):
                 local = os.path.join(self.extra_local, rel_path)
                 remote = os.path.join(self.extra_remote, rel_path)
                 if not os.path.exists(local):
-                    download_file(remote, local, self.download_timeout)
+                    self._extra_downloader.download(remote, local, self.download_timeout)
 
             # Step forward one sample.
             it.prepare_index += 1

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -113,8 +113,9 @@ class TestGCSClient:
 
     @pytest.mark.usefixtures('gcs_hmac_client', 'gcs_test', 'remote_local_file')
     def test_download_from_gcs(self, remote_local_file: Any):
-        with tempfile.NamedTemporaryFile(delete=True, suffix='.txt') as tmp:
-            file_name = tmp.name.split(os.sep)[-1]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_name = 'file.txt'
+            tmp = os.path.join(tmp_dir, file_name)
             mock_remote_filepath, _ = remote_local_file(cloud_prefix='gs://', filename=file_name)
             client = boto3.client('s3',
                                   region_name='us-east-1',
@@ -123,8 +124,8 @@ class TestGCSClient:
                                   aws_secret_access_key=os.environ['GCS_SECRET'])
             client.put_object(Bucket=MY_BUCKET, Key=os.path.join(MY_PREFIX, file_name), Body='')
             downloader = GCSDownloader()
-            downloader.download(mock_remote_filepath, tmp.name)
-            assert os.path.isfile(tmp.name)
+            downloader.download(mock_remote_filepath, tmp)
+            assert os.path.isfile(tmp)
 
     @patch('google.auth.default')
     @patch('google.cloud.storage.Client', spec=Client)
@@ -138,14 +139,15 @@ class TestGCSClient:
         def isinstance_impl(obj: Any, cls: Any):
             return obj.__class__ == cls.__class__
 
-        with tempfile.NamedTemporaryFile(delete=True, suffix='.txt') as tmp:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp = os.path.join(tmp_dir, 'file.txt')
             mock_isinstance.side_effect = isinstance_impl
             credentials_mock = Mock()
             mock_default.return_value = credentials_mock, None
             downloader = GCSDownloader()
-            downloader.download(out, tmp.name)
+            downloader.download(out, tmp)
             mock_client.assert_called_once_with(credentials=credentials_mock)
-            assert os.path.isfile(tmp.name)
+            assert os.path.isfile(tmp)
 
     @pytest.mark.usefixtures('gcs_hmac_client', 'gcs_test', 'remote_local_file')
     def test_filenotfound_exception(self, remote_local_file: Any):
@@ -172,24 +174,24 @@ class TestGCSClient:
 class TestDatabricksUnityCatalog:
 
     def test_invalid_prefix_from_db_uc(self, remote_local_file: Any):
-        with tempfile.NamedTemporaryFile(delete=True, suffix='.txt') as tmp:
-            file_name = tmp.name.split(os.sep)[-1]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_name = os.path.join(tmp_dir, 'file.txt')
             mock_remote_filepath, _ = remote_local_file(cloud_prefix='dbfs:/Volumess',
                                                         filename=file_name)
             with pytest.raises(Exception, match='Expected path prefix to be `dbfs:/Volumes`.*'):
                 downloader = DatabricksUnityCatalogDownloader()
-                downloader.download(mock_remote_filepath, tmp.name)
+                downloader.download(mock_remote_filepath, file_name)
 
 
 class TestDatabricksFileSystem:
 
     def test_invalid_prefix_from_dbfs(self, remote_local_file: Any):
-        with tempfile.NamedTemporaryFile(delete=True, suffix='.txt') as tmp:
-            file_name = tmp.name.split(os.sep)[-1]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_name = os.path.join(tmp_dir, 'file.txt')
             mock_remote_filepath, _ = remote_local_file(cloud_prefix='dbfsx:/', filename=file_name)
             with pytest.raises(Exception, match='Expected remote path to start with.*'):
                 downloader = DBFSDownloader()
-                downloader.download(mock_remote_filepath, tmp.name)
+                downloader.download(mock_remote_filepath, file_name)
 
 
 def test_download_from_local():
@@ -229,11 +231,11 @@ class TestDownload:
         downloader = CloudDownloader.get(mock_remote_filepath)
         assert isinstance(downloader, downloader_type)
 
-    def test_download_invalid_missing_remote(self):
-        with pytest.raises(ValueError):
-            CloudDownloader.get('')
+    def test_download_no_remote_dir(self):
+        downloader = CloudDownloader.get()
+        assert isinstance(downloader, CloudDownloader)
 
-    def test_downloader_without_remote(self):
+    def test_downloader_without_remote_and_local(self):
         with pytest.raises(ValueError):
             downloader = CloudDownloader.get('/path/to/local/file')
-            downloader.get('')
+            downloader.download('', '/path/to/local/file')

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -173,10 +173,11 @@ class TestGCSClient:
 
 class TestDatabricksUnityCatalog:
 
-    def test_invalid_prefix_from_db_uc(self, remote_local_file: Any):
+    @pytest.mark.parametrize('cloud_prefix', ['dbfs:/Volumess', 'dbfs:/Content'])
+    def test_invalid_prefix_from_db_uc(self, remote_local_file: Any, cloud_prefix: str):
         with tempfile.TemporaryDirectory() as tmp_dir:
             file_name = os.path.join(tmp_dir, 'file.txt')
-            mock_remote_filepath, _ = remote_local_file(cloud_prefix='dbfs:/Volumess',
+            mock_remote_filepath, _ = remote_local_file(cloud_prefix=cloud_prefix,
                                                         filename=file_name)
             with pytest.raises(Exception, match='Expected path prefix to be `dbfs:/Volumes`.*'):
                 downloader = DatabricksUnityCatalogDownloader()

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -9,13 +9,13 @@ from unittest.mock import Mock, patch
 import boto3
 import pytest
 from botocore.exceptions import ClientError
+from google.cloud.storage import Client
 
-from streaming.base.storage.download import (download_file, download_from_azure,
-                                             download_from_azure_datalake,
-                                             download_from_databricks_unity_catalog,
-                                             download_from_dbfs, download_from_gcs,
-                                             download_from_hf, download_from_local,
-                                             download_from_s3)
+from streaming.base.storage.download import (AlipanDownloader, AzureDataLakeDownloader,
+                                             AzureDownloader, CloudDownloader,
+                                             DatabricksUnityCatalogDownloader, DBFSDownloader,
+                                             GCSDownloader, HFDownloader, LocalDownloader,
+                                             OCIDownloader, S3Downloader, SFTPDownloader)
 from tests.conftest import GCS_URL, MY_BUCKET, R2_URL
 
 MY_PREFIX = 'train'
@@ -44,8 +44,19 @@ class TestAzureClient:
         with pytest.raises(ValueError):
             mock_remote_filepath, mock_local_filepath = remote_local_file(
                 cloud_prefix='aaazure://')
-            download_from_azure(mock_remote_filepath, mock_local_filepath)
-            download_from_azure_datalake(mock_remote_filepath, mock_local_filepath)
+            downloader = AzureDownloader()
+            downloader.download(mock_remote_filepath, mock_local_filepath)
+
+
+class TestAzureDataLakeClient:
+
+    @pytest.mark.usefixtures('remote_local_file')
+    def test_invalid_cloud_prefix(self, remote_local_file: Any):
+        with pytest.raises(ValueError):
+            mock_remote_filepath, mock_local_filepath = remote_local_file(
+                cloud_prefix='aadatalake://')
+            downloader = AzureDataLakeDownloader()
+            downloader.download(mock_remote_filepath, mock_local_filepath)
 
 
 class TestHFClient:
@@ -54,7 +65,8 @@ class TestHFClient:
     def test_invalid_cloud_prefix(self, remote_local_file: Any):
         with pytest.raises(ValueError):
             mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='hf://')
-            download_from_hf(mock_remote_filepath, mock_local_filepath)
+            downloader = HFDownloader()
+            downloader.download(mock_remote_filepath, mock_local_filepath)
 
 
 class TestS3Client:
@@ -66,7 +78,8 @@ class TestS3Client:
             mock_remote_filepath, _ = remote_local_file(cloud_prefix='s3://', filename=file_name)
             client = boto3.client('s3', region_name='us-east-1')
             client.put_object(Bucket=MY_BUCKET, Key=os.path.join(MY_PREFIX, file_name), Body='')
-            download_from_s3(mock_remote_filepath, tmp.name, 60)
+            downloader = S3Downloader()
+            downloader.download(mock_remote_filepath, tmp.name, 60.0)
             assert os.path.isfile(tmp.name)
 
     @pytest.mark.usefixtures('s3_client', 's3_test', 'r2_credentials', 'remote_local_file')
@@ -76,7 +89,8 @@ class TestS3Client:
             mock_remote_filepath, _ = remote_local_file(cloud_prefix='s3://', filename=file_name)
             client = boto3.client('s3', region_name='us-east-1')
             client.put_object(Bucket=MY_BUCKET, Key=os.path.join(MY_PREFIX, file_name), Body='')
-            download_from_s3(mock_remote_filepath, tmp.name, 60)
+            downloader = S3Downloader()
+            downloader.download(mock_remote_filepath, tmp.name, 60.0)
             assert os.path.isfile(tmp.name)
             assert os.environ['S3_ENDPOINT_URL'] == R2_URL
 
@@ -84,13 +98,15 @@ class TestS3Client:
     def test_clienterror_exception(self, remote_local_file: Any):
         with pytest.raises(ClientError):
             mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='s3://')
-            download_from_s3(mock_remote_filepath, mock_local_filepath, 60)
+            downloader = S3Downloader()
+            downloader.download(mock_remote_filepath, mock_local_filepath, 60)
 
     @pytest.mark.usefixtures('s3_client', 's3_test', 'remote_local_file')
     def test_invalid_cloud_prefix(self, remote_local_file: Any):
         with pytest.raises(ValueError):
             mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='s9://')
-            download_from_s3(mock_remote_filepath, mock_local_filepath, 60)
+            downloader = S3Downloader()
+            downloader.download(mock_remote_filepath, mock_local_filepath, 60)
 
 
 class TestGCSClient:
@@ -106,18 +122,28 @@ class TestGCSClient:
                                   aws_access_key_id=os.environ['GCS_KEY'],
                                   aws_secret_access_key=os.environ['GCS_SECRET'])
             client.put_object(Bucket=MY_BUCKET, Key=os.path.join(MY_PREFIX, file_name), Body='')
-            download_from_gcs(mock_remote_filepath, tmp.name)
+            downloader = GCSDownloader()
+            downloader.download(mock_remote_filepath, tmp.name)
             assert os.path.isfile(tmp.name)
 
     @patch('google.auth.default')
-    @patch('google.cloud.storage.Client')
+    @patch('google.cloud.storage.Client', spec=Client)
+    @patch('streaming.base.storage.download.isinstance')
     @pytest.mark.usefixtures('gcs_service_account_credentials')
     @pytest.mark.parametrize('out', ['gs://bucket/dir'])
-    def test_download_service_account(self, mock_client: Mock, mock_default: Mock, out: str):
+    def test_download_service_account(self, mock_isinstance: Mock, mock_client: Mock,
+                                      mock_default: Mock, out: str):
+
+        # Because of how mock works on the types... have to patch isinstance
+        def isinstance_impl(obj: Any, cls: Any):
+            return obj.__class__ == cls.__class__
+
         with tempfile.NamedTemporaryFile(delete=True, suffix='.txt') as tmp:
+            mock_isinstance.side_effect = isinstance_impl
             credentials_mock = Mock()
             mock_default.return_value = credentials_mock, None
-            download_from_gcs(out, tmp.name)
+            downloader = GCSDownloader()
+            downloader.download(out, tmp.name)
             mock_client.assert_called_once_with(credentials=credentials_mock)
             assert os.path.isfile(tmp.name)
 
@@ -125,19 +151,22 @@ class TestGCSClient:
     def test_filenotfound_exception(self, remote_local_file: Any):
         with pytest.raises(FileNotFoundError):
             mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='gs://')
-            download_from_gcs(mock_remote_filepath, mock_local_filepath)
+            downloader = GCSDownloader()
+            downloader.download(mock_remote_filepath, mock_local_filepath)
 
     @pytest.mark.usefixtures('gcs_hmac_client', 'gcs_test', 'remote_local_file')
     def test_invalid_cloud_prefix(self, remote_local_file: Any):
         with pytest.raises(ValueError):
             mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='s3://')
-            download_from_gcs(mock_remote_filepath, mock_local_filepath)
+            downloader = GCSDownloader()
+            downloader.download(mock_remote_filepath, mock_local_filepath)
 
     def test_no_credentials_error(self, remote_local_file: Any):
         """Ensure we raise a value error correctly if we have no credentials available."""
         with pytest.raises(ValueError):
             mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='gs://')
-            download_from_gcs(mock_remote_filepath, mock_local_filepath)
+            downloader = GCSDownloader()
+            downloader.download(mock_remote_filepath, mock_local_filepath)
 
 
 class TestDatabricksUnityCatalog:
@@ -147,8 +176,9 @@ class TestDatabricksUnityCatalog:
             file_name = tmp.name.split(os.sep)[-1]
             mock_remote_filepath, _ = remote_local_file(cloud_prefix='dbfs:/Volumess',
                                                         filename=file_name)
-            with pytest.raises(Exception, match='Expected path prefix to be.*'):
-                download_from_databricks_unity_catalog(mock_remote_filepath, tmp.name)
+            with pytest.raises(Exception, match='Expected path prefix to be `dbfs:/Volumes`.*'):
+                downloader = DatabricksUnityCatalogDownloader()
+                downloader.download(mock_remote_filepath, tmp.name)
 
 
 class TestDatabricksFileSystem:
@@ -157,8 +187,9 @@ class TestDatabricksFileSystem:
         with tempfile.NamedTemporaryFile(delete=True, suffix='.txt') as tmp:
             file_name = tmp.name.split(os.sep)[-1]
             mock_remote_filepath, _ = remote_local_file(cloud_prefix='dbfsx:/', filename=file_name)
-            with pytest.raises(Exception, match='Expected path prefix to be.*'):
-                download_from_dbfs(mock_remote_filepath, tmp.name)
+            with pytest.raises(Exception, match='Expected remote path to start with.*'):
+                downloader = DBFSDownloader()
+                downloader.download(mock_remote_filepath, tmp.name)
 
 
 def test_download_from_local():
@@ -171,96 +202,38 @@ def test_download_from_local():
     with open(mock_remote_file, 'w') as _:
         pass
 
-    download_from_local(mock_remote_file, mock_local_file)
+    downloader = LocalDownloader()
+    downloader.download(mock_remote_file, mock_local_file)
     assert os.path.isfile(mock_local_file)
 
 
 class TestDownload:
 
-    @patch('streaming.base.storage.download.download_from_s3')
+    @pytest.mark.parametrize('cloud_prefix,downloader_type', [
+        ('s3://', S3Downloader),
+        ('gs://', GCSDownloader),
+        ('hf://', HFDownloader),
+        ('oci://', OCIDownloader),
+        ('azure://', AzureDownloader),
+        ('azure-dl://', AzureDataLakeDownloader),
+        ('sftp://', SFTPDownloader),
+        ('dbfs:/Volumes', DatabricksUnityCatalogDownloader),
+        ('dbfs:/', DBFSDownloader),
+        ('alipan://', AlipanDownloader),
+        ('', LocalDownloader),
+    ])
     @pytest.mark.usefixtures('remote_local_file')
-    def test_download_from_s3_gets_called(self, mocked_requests: Mock, remote_local_file: Any):
-        mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='s3://')
-        download_file(mock_remote_filepath, mock_local_filepath, 60)
-        mocked_requests.assert_called_once()
-        mocked_requests.assert_called_once_with(mock_remote_filepath, mock_local_filepath, 60)
+    def test_getting_downloader(self, remote_local_file: Any, cloud_prefix: str,
+                                downloader_type: type[CloudDownloader]):
+        mock_remote_filepath, _ = remote_local_file(cloud_prefix=cloud_prefix)
+        downloader = CloudDownloader.get(mock_remote_filepath)
+        assert isinstance(downloader, downloader_type)
 
-    @patch('streaming.base.storage.download.download_from_gcs')
-    @pytest.mark.usefixtures('remote_local_file')
-    def test_download_from_gcs_gets_called(self, mocked_requests: Mock, remote_local_file: Any):
-        mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='gs://')
-        download_file(mock_remote_filepath, mock_local_filepath, 60)
-        mocked_requests.assert_called_once()
-        mocked_requests.assert_called_once_with(mock_remote_filepath, mock_local_filepath)
-
-    @patch('streaming.base.storage.download.download_from_hf')
-    @pytest.mark.usefixtures('remote_local_file')
-    def test_download_from_hf_gets_called(self, mocked_requests: Mock, remote_local_file: Any):
-        mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='hf://')
-        download_file(mock_remote_filepath, mock_local_filepath, 60)
-        mocked_requests.assert_called_once()
-        mocked_requests.assert_called_once_with(mock_remote_filepath, mock_local_filepath)
-
-    @patch('streaming.base.storage.download.download_from_azure')
-    @pytest.mark.usefixtures('remote_local_file')
-    def test_download_from_azure_gets_called(self, mocked_requests: Mock, remote_local_file: Any):
-        mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='azure://')
-        download_file(mock_remote_filepath, mock_local_filepath, 60)
-        mocked_requests.assert_called_once()
-        mocked_requests.assert_called_once_with(mock_remote_filepath, mock_local_filepath)
-
-    @patch('streaming.base.storage.download.download_from_azure_datalake')
-    @pytest.mark.usefixtures('remote_local_file')
-    def test_download_from_azure_datalake_gets_called(self, mocked_requests: Mock,
-                                                      remote_local_file: Any):
-        mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='azure-dl://')
-        download_file(mock_remote_filepath, mock_local_filepath, 60)
-        mocked_requests.assert_called_once()
-        mocked_requests.assert_called_once_with(mock_remote_filepath, mock_local_filepath)
-
-    @patch('streaming.base.storage.download.download_from_sftp')
-    @pytest.mark.usefixtures('remote_local_file')
-    def test_download_from_sftp_gets_called(self, mocked_requests: Mock, remote_local_file: Any):
-        mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='sftp://')
-        download_file(mock_remote_filepath, mock_local_filepath, 60)
-        mocked_requests.assert_called_once()
-        mocked_requests.assert_called_once_with(mock_remote_filepath, mock_local_filepath)
-
-    @patch('streaming.base.storage.download.download_from_databricks_unity_catalog')
-    @pytest.mark.usefixtures('remote_local_file')
-    def test_download_from_databricks_unity_catalog_gets_called(self, mocked_requests: Mock,
-                                                                remote_local_file: Any):
-        mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='dbfs:/Volumes')
-        download_file(mock_remote_filepath, mock_local_filepath, 60)
-        mocked_requests.assert_called_once()
-        mocked_requests.assert_called_once_with(mock_remote_filepath, mock_local_filepath)
-
-    @patch('streaming.base.storage.download.download_from_dbfs')
-    @pytest.mark.usefixtures('remote_local_file')
-    def test_download_from_dbfs_gets_called(self, mocked_requests: Mock, remote_local_file: Any):
-        mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='dbfs:/')
-        download_file(mock_remote_filepath, mock_local_filepath, 60)
-        mocked_requests.assert_called_once()
-        mocked_requests.assert_called_once_with(mock_remote_filepath, mock_local_filepath)
-
-    @patch('streaming.base.storage.download.download_from_alipan')
-    @pytest.mark.usefixtures('remote_local_file')
-    def test_download_from_alipan_gets_called(self, mocked_requests: Mock, remote_local_file: Any):
-        mock_remote_filepath, mock_local_filepath = remote_local_file(cloud_prefix='alipan://')
-        download_file(mock_remote_filepath, mock_local_filepath, 60)
-        mocked_requests.assert_called_once()
-        mocked_requests.assert_called_once_with(mock_remote_filepath, mock_local_filepath)
-
-    @patch('streaming.base.storage.download.download_from_local')
-    @pytest.mark.usefixtures('remote_local_file')
-    def test_download_from_local_gets_called(self, mocked_requests: Mock, remote_local_file: Any):
-        mock_remote_filepath, mock_local_filepath = remote_local_file()
-        download_file(mock_remote_filepath, mock_local_filepath, 60)
-        mocked_requests.assert_called_once()
-        mocked_requests.assert_called_once_with(mock_remote_filepath, mock_local_filepath)
-
-    @pytest.mark.usefixtures('remote_local_file')
-    def test_download_invalid_missing_remote(self, remote_local_file: Any):
+    def test_download_invalid_missing_remote(self):
         with pytest.raises(ValueError):
-            _, mock_local_filepath = remote_local_file()
-            download_file(None, mock_local_filepath, 60)
+            CloudDownloader.get('')
+
+    def test_downloader_without_remote(self):
+        with pytest.raises(ValueError):
+            downloader = CloudDownloader.get('/path/to/local/file')
+            downloader.get('')

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -8,6 +8,7 @@ import time
 import urllib.parse
 from multiprocessing.shared_memory import SharedMemory as BuiltinSharedMemory
 from typing import Optional, Union
+from unittest.mock import Mock
 
 import pytest
 
@@ -309,9 +310,14 @@ def test_merge_index_from_root_local(local_remote_dir: tuple[str, str], n_partit
 def test_retry(with_args: bool):
     num_tries = 0
     return_after = 2
+    clean_up = Mock()
 
     if with_args:
-        decorator = retry(RuntimeError, num_attempts=3, initial_backoff=0.01, max_jitter=0.01)
+        decorator = retry(RuntimeError,
+                          clean_up_fn=clean_up,
+                          num_attempts=3,
+                          initial_backoff=0.01,
+                          max_jitter=0.01)
         return_after = 2
     else:
         decorator = retry
@@ -327,3 +333,6 @@ def test_retry(with_args: bool):
         return "Third time's a charm"
 
     assert flaky_function() == "Third time's a charm"
+
+    if with_args:
+        assert clean_up.call_count == 2

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -13,7 +13,7 @@ import pytest
 
 from streaming.base.constant import RESUME
 from streaming.base.shared.prefix import _get_path
-from streaming.base.storage.download import download_file
+from streaming.base.storage.download import CloudDownloader
 from streaming.base.storage.upload import CloudUploader
 from streaming.base.util import (bytes_to_int, clean_stale_shared_memory, get_list_arg,
                                  merge_index, number_abbrev_to_int, retry)
@@ -151,9 +151,9 @@ def integrity_check(out: Union[str, tuple[str, str]],
 
     with tempfile.TemporaryDirectory() as temp_dir:
         if cu.remote:
-            download_file(os.path.join(cu.remote, 'index.json'),
-                          os.path.join(temp_dir, 'index.json'),
-                          timeout=60)
+            CloudDownloader.direct_download(os.path.join(cu.remote, 'index.json'),
+                                            os.path.join(temp_dir, 'index.json'),
+                                            timeout=60)
             if expected_n_shard_files == -1:
                 expected_n_shard_files = get_expected(cu.remote)
             local_merged_index_path = os.path.join(temp_dir, 'index.json')


### PR DESCRIPTION
## Description of changes:

Refactored the download.py from constantly remaking clients to reusing an existing client for the same object. This should substantially cut down the number of possible active clients which can cause issue with certain cloud providers.

Base run: streaming-oci-socket-testing-f7UHTM
Branch run: streaming-oci-socket-testing-Hq3QSQ

## Issue #, if available:

Fixes https://github.com/mosaicml/streaming/issues/728

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
