### PR TITLE
Add upper bound for prefix_int

### DIFF
--- a/streaming/base/constant.py
+++ b/streaming/base/constant.py
@@ -34,3 +34,6 @@ TICK = 0.007
 
 # Default download timeout
 DEFAULT_TIMEOUT = 60.0
+
+# Maximum prefix integers
+MAX_PREFIX_INT = 1000

--- a/streaming/base/shared/prefix.py
+++ b/streaming/base/shared/prefix.py
@@ -16,7 +16,7 @@ from typing import Iterator, Union
 import numpy as np
 from torch import distributed as dist
 
-from streaming.base.constant import BARRIER_FILELOCK, CACHE_FILELOCK, LOCALS, SHM_TO_CLEAN, TICK
+from streaming.base.constant import BARRIER_FILELOCK, CACHE_FILELOCK, LOCALS, SHM_TO_CLEAN, TICK, MAX_PREFIX_INT
 from streaming.base.shared import SharedMemory
 from streaming.base.world import World
 
@@ -112,6 +112,12 @@ def _check_and_find(streams_local: list[str], streams_remote: list[Union[str, No
     prefix_int = 0
 
     for prefix_int in _each_prefix_int():
+
+        if prefix_int >= MAX_PREFIX_INT:
+            raise ValueError(f"prefix_int exceeds {MAX_PREFIX_INT}. This may happen " +
+                             f"when you mock os.path.exists or os.stat so the filelock " +
+                             f"checks always returns ``True`` " +
+                             f"you need to clean up TMPDIR.")
 
         name = _get_path(prefix_int, shm_name)
 

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -190,3 +190,16 @@ def test_shared_memory_permission_error(mock_shared_memory_class: MagicMock):
     with patch('os.path.exists', return_value=False):
         next_prefix = _check_and_find(['local'], [None], LOCALS)
         assert next_prefix == 1
+
+
+@pytest.mark.usefixtures('local_remote_dir')
+def test_shared_memory_infinity_exception(local_remote_dir: tuple[str, str]):
+    local, remote = local_remote_dir
+    with patch('os.path.exists', return_value=True):
+        with pytest.raises(ValueError, match='prefix_int exceeds .*clean up TMPDIR.'):
+            _, _ = get_shm_prefix(streams_local=[local],
+                                  streams_remote=[remote],
+                                  world=World.detect())
+
+
+


### PR DESCRIPTION
## Description of changes:

prefix_int can go up from 0 to infinity. We want to cap it at a large value before it exhausts the compute resources. 

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
