### PR TITLE
Consistent errors for unused streams in batching methods

### DIFF
--- a/streaming/base/batching/device_per_stream.py
+++ b/streaming/base/batching/device_per_stream.py
@@ -80,6 +80,11 @@ def generate_work_device_per_stream_batching(dataset: StreamingDataset, world: W
                 raise TypeError(f'Dataset `shuffle_block_size` must be an integer. ' +
                                 f'Got {type(dataset.shuffle_block_size)} instead.')
             shuffle_block_portion = int(dataset.shuffle_block_size * stream.proportion)
+            if shuffle_block_portion == 0:
+                raise ValueError(f'Samples from stream {stream_id} are not being used. Please ' +
+                                 f'either increase the `shuffle_block_size` from ' +
+                                 f'{dataset.shuffle_block_size}, or increase the stream ' +
+                                 f'proportion from {stream.proportion}.')
             stream_shuffle = get_shuffle(dataset.shuffle_algo, shuffle_units,
                                          dataset.num_canonical_nodes, dataset.shuffle_seed, epoch,
                                          shuffle_block_portion)

--- a/streaming/base/batching/per_stream.py
+++ b/streaming/base/batching/per_stream.py
@@ -98,9 +98,9 @@ def generate_work_per_stream_batching(dataset: StreamingDataset, world: World, e
         if num_full_batches > 0:
             batches_from_partitions.append(global_batches_inorder[:num_full_batches])
         else:
-            logger.warning(f'Stream with index {stream_idx} does not have an adequate number of ' +
-                           f'samples to construct a complete global batch. Training will occur ' +
-                           f'without any samples from this stream!')
+            raise ValueError(f'Stream with index {stream_idx} does not have an adequate number ' +
+                             f'of samples to construct a complete global batch. Training will ' +
+                             f'occur without any samples from this stream.')
 
     # Combine all global batches from all streams into one array.
     all_partition_batches = np.concatenate(batches_from_partitions)


### PR DESCRIPTION
## Description of changes:

Raise errors consistently for unused streams, as brought up by #816 

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
