### PR TITLE
Change simulator UI help text to refer to directory

### DIFF
--- a/simulation/interfaces/widgets.py
+++ b/simulation/interfaces/widgets.py
@@ -89,9 +89,9 @@ def stream_entry(component: DeltaGenerator,
     on = component.toggle('use `index.json`', key=str(key) + 'toggle') if add_stream else None
     if on or not add_stream:
         path = component.text_input(
-            'path to `index.json`',
-            value='/absolute/path/to/index.json' if defaults is None else defaults['path'],
-            help='path to the `index.json` file for this stream. \
+            'path to directory containing `index.json`',
+            value='/absolute/path/to/dir/' if defaults is None else defaults['path'],
+            help='path to the directory containing the `index.json` file for this stream. \
                                 the `index.json` file contains information about the shards in \
                                 your dataset.',
             key=str(key) + 'path',


### PR DESCRIPTION
When using the mode of the simulator in which you provide an existing `index.json` file, the help text said to provide the absolute path to the `index.json` file. However if you do so, the string `index.json` is then appended to this leading to errors such as:

```
RuntimeError: No `remote` provided, but local file /home/scott/scratch/dummy-mds-dataset/index.json/index.json does not exist either
```

This PR changes the help text to instruct the user to provide the path to the directory containing the `index.json` file, instead of to the file itself.

**Before**:
![](https://github.com/user-attachments/assets/0ef29db9-19de-4d51-b302-b48e4d1b008d)

**After**:
![](https://github.com/user-attachments/assets/77fb39c7-66d3-4f43-9364-73539977140c)


