### PR TITLE
Prevent _s3_client from being serialized

### DIFF
--- a/streaming/base/storage/download.py
+++ b/streaming/base/storage/download.py
@@ -261,6 +261,15 @@ class S3Downloader(CloudDownloader):
                                            config=config,
                                            endpoint_url=os.environ.get('S3_ENDPOINT_URL'))
 
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state['_s3_client'] = None  # Exclude _s3_client from being pickled
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self._s3_client = None  # Ensure _s3_client is reset after unpickling
+
 
 class SFTPDownloader(CloudDownloader):
     """Download files from SFTP to local filesystem."""


### PR DESCRIPTION
## Description of changes:

The latest version (0.10.0) of this library crashes when using S3 as data source with forking as spawn method of the DataLoader, since the S3 session object can not be pickled.

This PR fixes it by excluding the session from being serialized.

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [ ] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
