### PR TITLE
Allow configuring the number of retries for boto3

### DIFF
--- a/streaming/base/storage/download.py
+++ b/streaming/base/storage/download.py
@@ -246,9 +246,11 @@ class S3Downloader(CloudDownloader):
         from botocore import UNSIGNED
         from botocore.config import Config
 
-        retries = {
+        retries: dict[str, Any] = {
             'mode': 'adaptive',
         }
+        if (max_attempts := os.environ.get('MOSAICML_STREAMING_AWS_MAX_ATTEMPTS')) is not None:
+            retries['max_attempts'] = int(max_attempts)
         if unsigned:
             # Client will be using unsigned mode in which public
             # resources can be accessed without credentials


### PR DESCRIPTION
## Description of changes:

<!--
Please briefly describe your change, including what problem the change fixes, and any context
necessary for understanding the change
-->

Users can configure the number of retries that boto3 will use by setting the `MOSAICML_STREAMING_AWS_MAX_ATTEMPTS` envvar.

## Issue #, if available:

<!--
Please include any issues related to this pull request, including 'Fixes' if the issue is resolved
by this pull request.
Example:
- Fixes #42
- Related to #1234
-->

Fixes #852

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
