### PR TITLE
[Bug Fix] HfUploader - use the right local filename path.

### DIFF
--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -665,7 +665,7 @@ class HFUploader(CloudUploader):
 
         @retry(num_attempts=self.retry)
         def _upload_file():
-            local_filename = filename
+            local_filename = os.path.join(self.local, filename)
             local_filename = local_filename.replace('\\', '/')
             remote_filename = os.path.join('datasets', self.dataset_id, filename)
             remote_filename = remote_filename.replace('\\', '/')


### PR DESCRIPTION
## Description of changes:

Fixes the `HfUploader.upload_file` method to use the right path to the local file for uploading.

## Issue #, if available:
#875 

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [ ] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
