### PR TITLE
Allow Spark BinaryType to map to binary-encoded MDS types like PNG, if user specifies so

### DIFF
--- a/streaming/base/converters/dataframe_to_mds.py
+++ b/streaming/base/converters/dataframe_to_mds.py
@@ -137,6 +137,11 @@ def infer_dataframe_schema(dataframe: DataFrame,
                         continue
                     else:
                         raise ValueError(f'{col_name} can not be encoded by MDS JSON.')
+                elif user_dtype in ('pil', 'png', 'jpeg', 'pkl'):
+                    if isinstance(actual_spark_dtype, BinaryType):
+                        continue
+                    else:
+                        raise ValueError(f'Non-binary col {col_name} cannot encode as {user_dtype}.')
                 raise ValueError(f'{user_dtype} is not supported by dataframe_to_mds')
 
             mapped_mds_dtype = map_spark_dtype(actual_spark_dtype)

--- a/streaming/base/converters/dataframe_to_mds.py
+++ b/streaming/base/converters/dataframe_to_mds.py
@@ -141,7 +141,8 @@ def infer_dataframe_schema(dataframe: DataFrame,
                     if isinstance(actual_spark_dtype, BinaryType):
                         continue
                     else:
-                        raise ValueError(f'Non-binary col {col_name} cannot encode as {user_dtype}.')
+                        raise ValueError(
+                            f'Non-binary col {col_name} cannot encode as {user_dtype}.')
                 raise ValueError(f'{user_dtype} is not supported by dataframe_to_mds')
 
             mapped_mds_dtype = map_spark_dtype(actual_spark_dtype)


### PR DESCRIPTION
## Description of changes:

Imagine a user wants to write, for example, PNG or JPEG data with `dataframe_to_mds`. It's possible to put this data in a Spark DataFrame, where it will simply be `BinaryType`. This data is encoded as bytes in MDS anyway.

However, to make sure the MDS files record these as `png` for examples and not `bytes`, it's necessary to specify custom column types in `mds_kwargs`. However, types like `png`, etc are rejected. This simply allows this case, where the user provides `BinaryType` in Spark and wants it to be interpreted as if a binary-encoded type like PNG, JPEG, PIL or pickle.

## Issue #, if available:

N/A

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [X] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [X] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [X] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [ ] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [ ] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.
