### PR TITLE
Fix racing in shared memory creation 

### DIFF
--- a/streaming/base/shared/prefix.py
+++ b/streaming/base/shared/prefix.py
@@ -18,6 +18,7 @@ from torch import distributed as dist
 
 from streaming.base.constant import BARRIER_FILELOCK, CACHE_FILELOCK, LOCALS, SHM_TO_CLEAN, TICK
 from streaming.base.shared import SharedMemory
+from streaming.base.util import retry as retry_decorator
 from streaming.base.world import World
 
 
@@ -230,11 +231,11 @@ def get_shm_prefix(streams_local: list[str],
 
     # Non-local leaders go next, searching for match.
     if not world.is_local_leader:
-        # Import retry locally to avoid circular import
-        from streaming.base.util import retry
 
-        # Retry attaching to shared memory to handle OS-level propagation delays (issue #824)
-        @retry(FileNotFoundError, num_attempts=100, initial_backoff=TICK, max_jitter=0.0)
+        @retry_decorator(exc_class=FileNotFoundError,
+                         num_attempts=100,
+                         initial_backoff=TICK,
+                         max_jitter=0.0)
         def _attach_to_shm() -> SharedMemory:
             """Attach to shared memory created by local leader."""
             name = _get_path(prefix_int, LOCALS)

--- a/streaming/base/shared/prefix.py
+++ b/streaming/base/shared/prefix.py
@@ -230,9 +230,18 @@ def get_shm_prefix(streams_local: list[str],
 
     # Non-local leaders go next, searching for match.
     if not world.is_local_leader:
-        name = _get_path(prefix_int, LOCALS)
+        # Import retry locally to avoid circular import
+        from streaming.base.util import retry
+
+        # Retry attaching to shared memory to handle OS-level propagation delays (issue #824)
+        @retry(FileNotFoundError, num_attempts=100, initial_backoff=TICK, max_jitter=0.0)
+        def _attach_to_shm() -> SharedMemory:
+            """Attach to shared memory created by local leader."""
+            name = _get_path(prefix_int, LOCALS)
+            return SharedMemory(name, False)
+
         try:
-            shm = SharedMemory(name, False)
+            shm = _attach_to_shm()
         except FileNotFoundError:
             raise RuntimeError(f'Internal error: shared memory prefix={prefix_int} was not ' +
                                f'registered by local leader. This may be because you specified ' +

--- a/streaming/base/util.py
+++ b/streaming/base/util.py
@@ -23,7 +23,6 @@ import torch.distributed as dist
 from streaming.base.constant import SHM_TO_CLEAN
 from streaming.base.distributed import get_local_rank, maybe_init_dist
 from streaming.base.format.index import get_index_basename
-from streaming.base.shared.prefix import _get_path
 
 logger = logging.getLogger(__name__)
 
@@ -172,6 +171,8 @@ def clean_stale_shared_memory() -> None:
     In case of a distributed run, clean up happens on local rank 0 while other local ranks wait for
     the local rank 0 to finish.
     """
+    from streaming.base.shared.prefix import _get_path
+
     # Initialize torch.distributed ourselves, if necessary.
     destroy_dist = maybe_init_dist()
 

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -1,17 +1,15 @@
 # Copyright 2022-2024 MosaicML Streaming authors
 # SPDX-License-Identifier: Apache-2.0
 
+import multiprocessing as mp
 import os
 import shutil
-import sys
 import tempfile
+from multiprocessing.shared_memory import SharedMemory as BuiltinSharedMemory
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
-
-import multiprocessing as mp
-from multiprocessing.shared_memory import SharedMemory as BuiltinSharedMemory
 
 from streaming.base import StreamingDataset
 from streaming.base.constant import LOCALS
@@ -197,14 +195,13 @@ def test_shared_memory_permission_error(mock_shared_memory_class: MagicMock):
         assert next_prefix == 1
 
 
-
-
 # Global counter to track attach attempts (per process)
 attach_attempts = 0
 
 
 def patched_shared_memory_init(original_init):
     """Wrapper that fails first 3 attach attempts for non-local leaders."""
+
     def wrapper(self, name, create=False, size=-1):
         global attach_attempts
 
@@ -213,10 +210,11 @@ def patched_shared_memory_init(original_init):
             attach_attempts += 1
             # Fail first 3 attempts to simulate OS propagation delay
             if attach_attempts <= 3:
-                print(f"    [Mock] Attach attempt {attach_attempts} - simulating FileNotFoundError")
-                raise FileNotFoundError(f"[Mock] Simulating OS propagation delay for {name}")
+                print(
+                    f'    [Mock] Attach attempt {attach_attempts} - simulating FileNotFoundError')
+                raise FileNotFoundError(f'[Mock] Simulating OS propagation delay for {name}')
             else:
-                print(f"    [Mock] Attach attempt {attach_attempts} - allowing success")
+                print(f'    [Mock] Attach attempt {attach_attempts} - allowing success')
 
         # Call original init
         return original_init(self, name, create, size)
@@ -234,11 +232,8 @@ def worker_process(rank: int, world_size: int, dataset_path: str):
 
         # Patch SharedMemory BEFORE importing streaming
         # This simulates slow OS propagation
-        with patch.object(
-            BuiltinSharedMemory,
-            '__init__',
-            patched_shared_memory_init(BuiltinSharedMemory.__init__)
-        ):
+        with patch.object(BuiltinSharedMemory, '__init__',
+                          patched_shared_memory_init(BuiltinSharedMemory.__init__)):
             from streaming import StreamingDataset
 
             # Initialize distributed
@@ -247,36 +242,32 @@ def worker_process(rank: int, world_size: int, dataset_path: str):
             os.environ['LOCAL_RANK'] = str(rank)
             os.environ['LOCAL_WORLD_SIZE'] = str(world_size)
 
-            dist.init_process_group(
-                backend='gloo',
-                init_method=os.environ['MASTER_ADDR'],
-                rank=rank,
-                world_size=world_size
-            )
+            dist.init_process_group(backend='gloo',
+                                    init_method=os.environ['MASTER_ADDR'],
+                                    rank=rank,
+                                    world_size=world_size)
 
-            print(f"[Rank {rank}] Creating StreamingDataset...")
+            print(f'[Rank {rank}] Creating StreamingDataset...')
 
             # On MAIN branch (no retry): Will fail immediately on first FileNotFoundError
             # On FIX branch (with retry): Will retry and succeed after 3 attempts
-            dataset = StreamingDataset(
-                local=dataset_path,
-                remote=None,
-                shuffle=False,
-                batch_size=4
-            )
+            dataset = StreamingDataset(local=dataset_path,
+                                       remote=None,
+                                       shuffle=False,
+                                       batch_size=4)
 
-            print(f"[Rank {rank}] ✅ Success! Dataset created with {len(dataset)} samples")
+            print(f'[Rank {rank}] ✅ Success! Dataset created with {len(dataset)} samples')
             dist.destroy_process_group()
             return True
 
     except (FileNotFoundError, RuntimeError) as e:
-        if "shared memory prefix" in str(e) or "FileNotFoundError" in str(e):
-            print(f"[Rank {rank}] ❌ FAILED - Issue #824 (no retry): {e}")
+        if 'shared memory prefix' in str(e) or 'FileNotFoundError' in str(e):
+            print(f'[Rank {rank}] ❌ FAILED - Issue #824 (no retry): {e}')
         else:
-            print(f"[Rank {rank}] ❌ Unexpected error: {e}")
+            print(f'[Rank {rank}] ❌ Unexpected error: {e}')
         return False
     except Exception as e:
-        print(f"[Rank {rank}] ❌ Unexpected error: {e}")
+        print(f'[Rank {rank}] ❌ Unexpected error: {e}')
         import traceback
         traceback.print_exc()
         return False
@@ -298,7 +289,7 @@ def test_forced_race():
             for i in range(100):
                 writer.write({'id': i, 'value': f'sample_{i}'})
 
-        print(f"Created test dataset at {dataset_path}\n")
+        print(f'Created test dataset at {dataset_path}\n')
 
         # Clean stale shared memory
         from streaming.base.util import clean_stale_shared_memory
@@ -317,10 +308,7 @@ def test_forced_race():
         processes = []
 
         for rank in range(2):
-            p = ctx.Process(
-                target=worker_process,
-                args=(rank, 2, dataset_path)
-            )
+            p = ctx.Process(target=worker_process, args=(rank, 2, dataset_path))
             p.start()
             processes.append(p)
 
@@ -337,11 +325,11 @@ def test_forced_race():
                     p.kill()
                     p.join()
                 success = False
-                print(f"Process {p.pid} timed out after {timeout_seconds} seconds")
+                print(f'Process {p.pid} timed out after {timeout_seconds} seconds')
             elif p.exitcode != 0:
                 success = False
 
-        assert success, "Test FAILED - No retry logic to handle the forced race condition"
+        assert success, 'Test FAILED - No retry logic to handle the forced race condition'
 
     finally:
         if os.path.exists(temp_dir):
@@ -351,4 +339,3 @@ def test_forced_race():
             clean_stale_shared_memory()
         except:
             pass
-

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -282,7 +282,6 @@ def worker_process(rank: int, world_size: int, dataset_path: str):
         return False
 
 
-@pytest.mark.timeout(60)
 def test_forced_race():
     """Test with forced race condition."""
 
@@ -325,11 +324,21 @@ def test_forced_race():
             p.start()
             processes.append(p)
 
-        # Wait for completion
+        # Wait for completion with timeout
         success = True
+        timeout_seconds = 60
         for p in processes:
-            p.join()
-            if p.exitcode != 0:
+            p.join(timeout=timeout_seconds)
+            if p.is_alive():
+                # Process hung, terminate it
+                p.terminate()
+                p.join(timeout=5)
+                if p.is_alive():
+                    p.kill()
+                    p.join()
+                success = False
+                print(f"Process {p.pid} timed out after {timeout_seconds} seconds")
+            elif p.exitcode != 0:
                 success = False
 
         assert success, "Test FAILED - No retry logic to handle the forced race condition"

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import tempfile
 from multiprocessing.shared_memory import SharedMemory as BuiltinSharedMemory
+from typing import Any, Callable
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -199,10 +200,10 @@ def test_shared_memory_permission_error(mock_shared_memory_class: MagicMock):
 attach_attempts = 0
 
 
-def patched_shared_memory_init(original_init):
+def patched_shared_memory_init(original_init: Callable):
     """Wrapper that fails first 3 attach attempts for non-local leaders."""
 
-    def wrapper(self, name, create=False, size=-1):
+    def wrapper(self: Any, name: str, create: bool = False, size: int = -1):
         global attach_attempts
 
         # Only interfere with attach (create=False) for specific shared memory names

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -282,6 +282,7 @@ def worker_process(rank: int, world_size: int, dataset_path: str):
         return False
 
 
+@pytest.mark.timeout(60)
 def test_forced_race():
     """Test with forced race condition."""
 

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -2,11 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import shutil
+import sys
 import tempfile
 from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
+
+#import multiprocessing as mp
+#from multiprocessing.shared_memory import SharedMemory as BuiltinSharedMemory
 
 from streaming.base import StreamingDataset
 from streaming.base.constant import LOCALS
@@ -190,3 +195,150 @@ def test_shared_memory_permission_error(mock_shared_memory_class: MagicMock):
     with patch('os.path.exists', return_value=False):
         next_prefix = _check_and_find(['local'], [None], LOCALS)
         assert next_prefix == 1
+
+
+
+
+# Global counter to track attach attempts (per process)
+attach_attempts = 0
+
+
+def patched_shared_memory_init(original_init):
+    """Wrapper that fails first 3 attach attempts for non-local leaders."""
+    def wrapper(self, name, create=False, size=-1):
+        global attach_attempts
+
+        # Only interfere with attach (create=False) for specific shared memory names
+        if not create and name and 'locals' in name:
+            attach_attempts += 1
+            # Fail first 3 attempts to simulate OS propagation delay
+            if attach_attempts <= 3:
+                print(f"    [Mock] Attach attempt {attach_attempts} - simulating FileNotFoundError")
+                raise FileNotFoundError(f"[Mock] Simulating OS propagation delay for {name}")
+            else:
+                print(f"    [Mock] Attach attempt {attach_attempts} - allowing success")
+
+        # Call original init
+        return original_init(self, name, create, size)
+
+    return wrapper
+
+
+def worker_process(rank: int, world_size: int, dataset_path: str):
+    """Worker that creates StreamingDataset with forced race condition."""
+    global attach_attempts
+    attach_attempts = 0  # Reset counter for this process
+
+    try:
+        import torch.distributed as dist
+
+        # Patch SharedMemory BEFORE importing streaming
+        # This simulates slow OS propagation
+        with patch.object(
+            BuiltinSharedMemory,
+            '__init__',
+            patched_shared_memory_init(BuiltinSharedMemory.__init__)
+        ):
+            from streaming import StreamingDataset
+
+            # Initialize distributed
+            os.environ['RANK'] = str(rank)
+            os.environ['WORLD_SIZE'] = str(world_size)
+            os.environ['LOCAL_RANK'] = str(rank)
+            os.environ['LOCAL_WORLD_SIZE'] = str(world_size)
+
+            dist.init_process_group(
+                backend='gloo',
+                init_method=os.environ['MASTER_ADDR'],
+                rank=rank,
+                world_size=world_size
+            )
+
+            print(f"[Rank {rank}] Creating StreamingDataset...")
+
+            # On MAIN branch (no retry): Will fail immediately on first FileNotFoundError
+            # On FIX branch (with retry): Will retry and succeed after 3 attempts
+            dataset = StreamingDataset(
+                local=dataset_path,
+                remote=None,
+                shuffle=False,
+                batch_size=4
+            )
+
+            print(f"[Rank {rank}] ✅ Success! Dataset created with {len(dataset)} samples")
+            dist.destroy_process_group()
+            return True
+
+    except (FileNotFoundError, RuntimeError) as e:
+        if "shared memory prefix" in str(e) or "FileNotFoundError" in str(e):
+            print(f"[Rank {rank}] ❌ FAILED - Issue #824 (no retry): {e}")
+        else:
+            print(f"[Rank {rank}] ❌ Unexpected error: {e}")
+        return False
+    except Exception as e:
+        print(f"[Rank {rank}] ❌ Unexpected error: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_forced_race():
+    """Test with forced race condition."""
+
+    # Create test dataset
+    temp_dir = tempfile.mkdtemp(prefix='forced_race_')
+    dataset_path = os.path.join(temp_dir, 'dataset')
+
+    try:
+        # Create MDS dataset
+        from streaming import MDSWriter
+        os.makedirs(dataset_path, exist_ok=True)
+
+        with MDSWriter(out=dataset_path, columns={'id': 'int', 'value': 'str'}) as writer:
+            for i in range(100):
+                writer.write({'id': i, 'value': f'sample_{i}'})
+
+        print(f"Created test dataset at {dataset_path}\n")
+
+        # Clean stale shared memory
+        from streaming.base.util import clean_stale_shared_memory
+        clean_stale_shared_memory()
+
+        # Setup master address
+        import socket
+        sock = socket.socket()
+        sock.bind(('', 0))
+        port = sock.getsockname()[1]
+        sock.close()
+        os.environ['MASTER_ADDR'] = f'tcp://127.0.0.1:{port}'
+
+        # Launch processes
+        ctx = mp.get_context('spawn')
+        processes = []
+
+        for rank in range(2):
+            p = ctx.Process(
+                target=worker_process,
+                args=(rank, 2, dataset_path)
+            )
+            p.start()
+            processes.append(p)
+
+        # Wait for completion
+        success = True
+        for p in processes:
+            p.join()
+            if p.exitcode != 0:
+                success = False
+
+        assert success, "Test FAILED - No retry logic to handle the forced race condition"
+
+    finally:
+        if os.path.exists(temp_dir):
+            shutil.rmtree(temp_dir)
+        try:
+            from streaming.base.util import clean_stale_shared_memory
+            clean_stale_shared_memory()
+        except:
+            pass
+

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -10,8 +10,8 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 
-#import multiprocessing as mp
-#from multiprocessing.shared_memory import SharedMemory as BuiltinSharedMemory
+import multiprocessing as mp
+from multiprocessing.shared_memory import SharedMemory as BuiltinSharedMemory
 
 from streaming.base import StreamingDataset
 from streaming.base.constant import LOCALS


### PR DESCRIPTION
## Description of changes:

This PR hopefully addresses several issues raised in dataset creation for certain OS. The theory is that certain OS is slow in propagating shared memory across processes, so the non-local leaders need more wait time on the local leader. 

## Issue #, if available:

- Related #824 
- Related #901 
- Related #884 
- Related #767  
- Related #717 


## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [x] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [x] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<!--
Thanks so much for contributing to Streaming! We really appreciate it :)
-->
