### PR TITLE
[HF Datasets] Improve file download

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ extra_deps['alipan'] = [
 ]
 
 extra_deps['hf'] = [
-    'huggingface_hub>=0.23.4,<1.4',
+    'huggingface_hub>=1.2.1,<1.4',
 ]
 
 extra_deps['testing'] = [

--- a/streaming/base/storage/download.py
+++ b/streaming/base/storage/download.py
@@ -502,16 +502,17 @@ class HFDownloader(CloudDownloader):
 
     def _download_file_impl(self, remote: str, local: str, timeout: float) -> None:
         """Implementation of the download function for a file."""
-        from huggingface_hub import hf_hub_download
+        from huggingface_hub import hf_hub_download, hffs
 
-        _, _, _, repo_org, repo_name, path = remote.split('/', 5)
+        resolved_path = hffs.resolve_path(remote)
         local_dirname = os.path.dirname(local)
-        hf_hub_download(repo_id=f'{repo_org}/{repo_name}',
-                        filename=path,
-                        repo_type='dataset',
+        hf_hub_download(repo_id=resolved_path.repo_id,
+                        filename=resolved_path.path_in_repo,
+                        repo_type=resolved_path.repo_type,
+                        revision=resolved_path.revision,
                         local_dir=local_dirname)
 
-        downloaded_name = os.path.join(local_dirname, path)
+        downloaded_name = os.path.join(local_dirname, resolved_path.path_in_repo)
         os.rename(downloaded_name, local)
 
 

--- a/streaming/base/storage/download.py
+++ b/streaming/base/storage/download.py
@@ -502,18 +502,9 @@ class HFDownloader(CloudDownloader):
 
     def _download_file_impl(self, remote: str, local: str, timeout: float) -> None:
         """Implementation of the download function for a file."""
-        from huggingface_hub import hf_hub_download, hffs
+        from huggingface_hub import hffs
 
-        resolved_path = hffs.resolve_path(remote)
-        local_dirname = os.path.dirname(local)
-        hf_hub_download(repo_id=resolved_path.repo_id,
-                        filename=resolved_path.path_in_repo,
-                        repo_type=resolved_path.repo_type,
-                        revision=resolved_path.revision,
-                        local_dir=local_dirname)
-
-        downloaded_name = os.path.join(local_dirname, resolved_path.path_in_repo)
-        os.rename(downloaded_name, local)
+        hffs.download(remote, local)
 
 
 class AzureDownloader(CloudDownloader):


### PR DESCRIPTION
a small improvement to support `hf://`paths that point to any revision or repo_type (current implementation only works for the main branch of dataset repos)