### PR TITLE
Megatron streaming dataset

### DIFF
--- a/streaming/__init__.py
+++ b/streaming/__init__.py
@@ -8,12 +8,14 @@ import streaming.text as text
 import streaming.vision as vision
 from streaming._version import __version__  # noqa: F401
 from streaming.base import (CSVWriter, JSONWriter, LocalDataset, MDSWriter, Stream,
-                            StreamingDataLoader, StreamingDataset, TSVWriter, XSVWriter)
+                            StreamingDataLoader, MegatronStreamingDataLoader, StreamingDataset, MegatronStreamingDataset, TSVWriter, XSVWriter)
 
 __all__ = [
     'StreamingDataLoader',
+    'MegatronStreamingDataLoader',
     'Stream',
     'StreamingDataset',
+    'MegatronStreamingDataset',
     'CSVWriter',
     'JSONWriter',
     'MDSWriter',

--- a/streaming/base/__init__.py
+++ b/streaming/base/__init__.py
@@ -3,13 +3,14 @@
 
 """MosaicML Streaming Datasets for cloud-native model training."""
 
-from streaming.base.dataloader import StreamingDataLoader
+from streaming.base.dataloader import StreamingDataLoader, MegatronStreamingDataLoader
 from streaming.base.dataset import StreamingDataset
+from streaming.base.megatron_dataset import MegatronStreamingDataset
 from streaming.base.format import CSVWriter, JSONWriter, MDSWriter, TSVWriter, XSVWriter
 from streaming.base.local import LocalDataset
 from streaming.base.stream import Stream
 
 __all__ = [
-    'StreamingDataLoader', 'Stream', 'StreamingDataset', 'CSVWriter', 'JSONWriter', 'LocalDataset',
+    'StreamingDataLoader', 'MegatronStreamingDataLoader', 'Stream', 'StreamingDataset', 'MegatronStreamingDataset', 'CSVWriter', 'JSONWriter', 'LocalDataset',
     'MDSWriter', 'TSVWriter', 'XSVWriter'
 ]

--- a/streaming/base/dataloader.py
+++ b/streaming/base/dataloader.py
@@ -11,6 +11,7 @@ from transformers.feature_extraction_utils import BatchFeature
 from transformers.tokenization_utils_base import BatchEncoding
 
 from streaming.base.dataset import StreamingDataset
+from streaming.base.megatron_dataset import MegatronStreamingDataset, DPWorld
 from streaming.base.world import World
 
 
@@ -99,3 +100,26 @@ class StreamingDataLoader(DataLoader):
         """Terminate the workers during cleanup."""
         if self._iterator is not None:
             self._iterator._shutdown_workers()  # type: ignore [reportGeneralTypeIssues]
+
+
+class MegatronStreamingDataLoader(StreamingDataLoader):
+    """A streaming data loader that allows for resumable iteration with MegatronStreamingDataset.
+
+        Args:
+        *args: List arguments.
+        **kwargs: Keyword arguments.
+
+    """
+
+    def __init__(self, *args, **kwargs) -> None:  # pyright: ignore
+        dataset = kwargs.get('dataset', None)
+        dataset = dataset or args[0]
+        if not isinstance(dataset, MegatronStreamingDataset):
+            raise ValueError('MegatronStreamingDataLoader requires a MegatronStreamingDataset.')
+        super().__init__(*args, **kwargs)
+
+    def state_dict(self):
+        world = DPWorld.detect()
+        num_samples = self.num_samples_yielded * world.num_ranks
+
+        return self.dataset.state_dict(num_samples, False)

--- a/streaming/base/dataset.py
+++ b/streaming/base/dataset.py
@@ -28,7 +28,7 @@ from streaming.base.batching import generate_work
 from streaming.base.constant import (BARRIER, BARRIER_FILELOCK, CACHE_FILELOCK, CACHE_USAGE,
                                      DEFAULT_TIMEOUT, EPOCH_DATA, EPOCH_SHAPE, NEXT_EPOCH, RESUME,
                                      SHARD_ACCESS_TIMES, SHARD_STATES, TICK)
-from streaming.base.distributed import maybe_init_dist
+from streaming.base.distributed import maybe_init_dist, barrier
 from streaming.base.format import get_index_basename
 from streaming.base.registry_utils import construct_from_registry
 from streaming.base.sampling import get_sampling
@@ -366,12 +366,8 @@ class StreamingDataset(Array, IterableDataset):
         #   * `parallel_` is who we think we are for iterating purposes, where groups of process
         #     must act the same if `replication` is specified.
         #     This can enable tensor or sequence parallelism.
-        world = World.detect()
-        self._unique_rank_world = world
-        if replication is not None:
-            self._parallel_rank_world = world.replicate(replication)
-        else:
-            self._parallel_rank_world = world.copy()
+        self._unique_rank_world = self._create_unique_rank_world()
+        self._parallel_rank_world = self._create_parallel_rank_world()
         self._unique_worker_world: World
         self._parallel_worker_world: World
 
@@ -538,6 +534,7 @@ class StreamingDataset(Array, IterableDataset):
         streams_remote = [
             os.path.join(x.remote, x.split) if x.remote is not None else None for x in streams
         ]
+        
         self._shm_prefix_int, self._locals_shm = get_shm_prefix(streams_local, streams_remote,
                                                                 self._unique_rank_world)
         self._filelock_root = gettempdir()
@@ -597,8 +594,7 @@ class StreamingDataset(Array, IterableDataset):
                 self._shard_states[shard_id] = _ShardState.LOCAL if size else _ShardState.REMOTE
                 self._shard_access_times[shard_id] = time_ns()
 
-        if dist.is_available() and dist.is_initialized():
-            dist.barrier()
+        barrier()
 
         if destroy_dist:
             dist.destroy_process_group()
@@ -677,6 +673,15 @@ class StreamingDataset(Array, IterableDataset):
             int: Dataset length.
         """
         return self.length
+    
+    def _create_unique_rank_world(self) -> World:
+        return World.detect()
+    
+    def _create_parallel_rank_world(self) -> World:
+        if self.replication is not None:
+            return self._unique_rank_world.replicate(self.replication)
+        else:
+            return self._unique_rank_world.copy()
 
     def _set_shuffle_block_size(self, world: World):
         """Set the shuffle block size value."""
@@ -1499,6 +1504,7 @@ class StreamingDataset(Array, IterableDataset):
 
         # Get this worker's partition of samples to process.
         sample_ids = self._get_work(epoch, sample_in_epoch)
+
         if not len(sample_ids):  # Resumed at end of epoch, out of samples.
             return
 

--- a/streaming/base/distributed.py
+++ b/streaming/base/distributed.py
@@ -14,6 +14,10 @@ import torch
 from torch import Tensor
 from torch import distributed as dist
 
+import logging
+logger = logging.getLogger(__name__)
+
+
 __all__ = [
     'all_gather', 'barrier', 'broadcast', 'get_rank', 'get_local_rank', 'get_local_world_size',
     'get_world_size'
@@ -58,8 +62,22 @@ def get_local_world_size() -> int:
 
 def barrier() -> None:
     """Synchronizes all processes."""
-    if dist.is_available() and dist.is_initialized():
-        dist.barrier()
+    try:
+        from megatron.training import get_dataset_building_group
+        dataset_building_group = get_dataset_building_group()
+    except ImportError:
+        print(f'import error for megatron get_dataset_building_group\n', flush=True)
+        dataset_building_group = None
+    
+    if dataset_building_group is None:
+        logger.warning('dataset_building_group is None, cannot barrier on megatron dataset builder ranks. This would lead to deadlocks if all ranks are not building and iterating datasets at the same time.')
+        if dist.is_available() and dist.is_initialized():
+            print(f'barrier on megatron all ranks\n', flush=True)
+            dist.barrier()    
+    else:
+        print(f'barrier on megatron dataset builder ranks\n', flush=True)
+        dist.barrier(group=dataset_building_group)
+
 
 
 def broadcast(tensor: Tensor, src: int) -> None:

--- a/streaming/base/distributed.py
+++ b/streaming/base/distributed.py
@@ -63,7 +63,7 @@ def get_local_world_size() -> int:
 def barrier() -> None:
     """Synchronizes all processes."""
     try:
-        from megatron.training import get_dataset_building_group
+        from streaming.base.megatron_dataset_utils import get_dataset_building_group
         dataset_building_group = get_dataset_building_group()
     except ImportError:
         print(f'import error for megatron get_dataset_building_group\n', flush=True)

--- a/streaming/base/megatron_dataset.py
+++ b/streaming/base/megatron_dataset.py
@@ -10,7 +10,7 @@ __all__ = ['MegatronStreamingDataset']
 class PerNodeWorld(World):
     @classmethod
     def detect(cls):
-        from megatron.training import get_dataset_builder_ranks_by_node, get_parallel_rank_info
+        from streaming.base.megatron_dataset_utils import get_dataset_builder_ranks_by_node, get_parallel_rank_info
         # global _DATASET_BUILDER_RANKS_BY_NODE
         all_ranks_per_node = get_dataset_builder_ranks_by_node()
         parallel_rank_info = get_parallel_rank_info()

--- a/streaming/base/megatron_dataset.py
+++ b/streaming/base/megatron_dataset.py
@@ -1,0 +1,59 @@
+from streaming.base.dataset import StreamingDataset
+from streaming.base.world import World
+
+import torch
+import os
+
+__all__ = ['MegatronStreamingDataset']
+
+
+class PerNodeWorld(World):
+    @classmethod
+    def detect(cls):
+        from megatron.training import get_dataset_builder_ranks_by_node, get_parallel_rank_info
+        # global _DATASET_BUILDER_RANKS_BY_NODE
+        all_ranks_per_node = get_dataset_builder_ranks_by_node()
+        parallel_rank_info = get_parallel_rank_info()
+        node = torch.distributed.get_rank() // int(os.environ["LOCAL_WORLD_SIZE"])
+        rank = all_ranks_per_node[node][parallel_rank_info]
+        ranks_for_node = len(all_ranks_per_node[node])
+        num_nodes = 1 
+        worker_of_rank, workers_per_rank = cls._get_worker_info()
+        worker = rank * workers_per_rank + worker_of_rank
+        return cls(num_nodes, ranks_for_node, workers_per_rank, worker)
+    
+    def replicate(self, replication):
+        raise NotImplementedError(f'PerNodeWorld does not support replicate()')
+    
+class DPWorld(World):
+    @classmethod
+    def detect(cls):
+        from megatron.core import mpu
+        rank = mpu.get_data_parallel_rank()
+        ranks_per_node = mpu.get_data_parallel_world_size()
+        num_nodes = 1
+        worker_of_rank, workers_per_rank = cls._get_worker_info()
+        worker = rank * workers_per_rank + worker_of_rank
+        return cls(num_nodes, ranks_per_node, workers_per_rank, worker)
+    
+    def replicate(self, replication):
+        raise NotImplementedError(f'DPWorld does not support replicate()')
+    
+
+class MegatronStreamingDataset(StreamingDataset):
+    """A dataset class compatible with Megatron-LM's data loading. This dataset can be used in place of Megatron's BlendedMegatronDataset
+
+    This class extends the base StreamingDataset class to ensure compatibility with Megatron-LM's distributed data loading policies for N-D parallelisms.
+    """
+
+    def __init__(self, *args, **kwargs):
+        replication = kwargs.pop('replication', None)
+        assert replication is None, 'MegatronStreamingDataset does not support replication. Please remove the `replication` argument.'
+        super().__init__(*args, **kwargs)
+        print(f'Initialized MegatronStreamingDataset\n', flush=True)
+
+    def _create_unique_rank_world(self) -> World:
+        return PerNodeWorld.detect()
+    
+    def _create_parallel_rank_world(self) -> World:
+        return DPWorld.detect()

--- a/streaming/base/megatron_dataset_demo.py
+++ b/streaming/base/megatron_dataset_demo.py
@@ -1,0 +1,373 @@
+import json
+import glob
+import os
+import shutil
+
+from typing import Callable, Optional, Dict, List, Iterable, Any
+from argparse import Namespace
+import torch
+from torch.utils.data._utils.collate import default_collate
+from megatron.training.global_vars import _GLOBAL_ARGS, _ensure_var_is_not_initialized, set_args
+
+def set_global_variables(args: Namespace, build_tokenizer: bool = False):
+    assert args is not None
+
+    _ensure_var_is_not_initialized(_GLOBAL_ARGS, 'args')
+    set_args(args)
+
+def _compile_dependencies():
+    return
+
+def validate_args(args: Namespace, defaults: Dict ={}):
+    """Validate arguments for this demo."""
+
+    if args.pipeline_model_parallel_size != 1:
+        raise ValueError("This demo only supports pipeline_model_parallel_size=1")
+
+    assert args.world_size %  args.tensor_model_parallel_size * args.pipeline_model_parallel_size * args.context_parallel_size *args.expert_model_parallel_size == 0, \
+        "The world size must divide the product of tensor_model_parallel_size, pipeline_model_parallel_size, context_parallel_size and expert_model_parallel_size"
+
+    args.data_parallel_size = args.world_size // (args.tensor_model_parallel_size * args.pipeline_model_parallel_size * args.context_parallel_size *args.expert_model_parallel_size)
+    args.virtual_pipeline_model_parallel_size = None
+
+    print_rank_0(f"Data parallel size: {args.data_parallel_size}")
+
+    print_rank_0(f"Tensor parallel size: {args.tensor_model_parallel_size}")
+
+    print_rank_0(f"Context parallel size: {args.context_parallel_size}")
+
+    print_rank_0(f"Expert parallel size: {args.expert_model_parallel_size}")
+
+    print_rank_0(f"micro batch size: {args.micro_batch_size}")
+
+
+
+
+from megatron.training import initialize
+
+# override validate_args with the simpler check we need for this demo
+initialize.validate_args = validate_args
+
+# override to do nothing for this demo
+initialize.set_global_variables = set_global_variables
+
+initialize._compile_dependencies = _compile_dependencies
+
+from megatron.training import get_args
+from megatron.core import mpu
+from megatron.training.initialize import initialize_megatron
+
+from megatron.training.utils import print_rank_0
+
+from streaming.base import MegatronStreamingDataset, MegatronStreamingDataLoader
+from streaming.base.megatron_dataset_utils import build_dataset_builder_ranks_by_node, get_parallel_rank_info
+from tests.common.utils import convert_to_mds
+
+all_batch_info: Optional[Dict[str, List[int]]] = None
+save_path = '/tmp/streaming_dataset_demo'
+
+
+def init_all_batch_info():
+    from dataclasses import asdict
+
+    global all_batch_info
+    world = get_parallel_rank_info()
+
+    all_batch_info = asdict(world)
+
+    all_batch_info['idxs'] = []
+
+def load_all_batch_info(load_dir: str):
+    node = torch.distributed.get_rank() // int(os.environ["LOCAL_WORLD_SIZE"])
+    rank = torch.distributed.get_rank()
+    
+
+    with open(os.path.join(load_dir, f'node_{node}_rank_{rank}.json'), 'r') as f:
+        data = json.load(f)
+    
+    global all_batch_info
+    all_batch_info = data
+
+def update_all_batch_info(batch: Dict[str, Any]):
+    global all_batch_info
+    if all_batch_info is None:
+        init_all_batch_info()
+    all_batch_info['idxs'].extend(batch['idx'].cpu().numpy().tolist())
+
+def save_batch_info(save_dir: str):
+    global all_batch_info
+    rank = torch.distributed.get_rank()
+    local_world_size = int(os.environ["LOCAL_WORLD_SIZE"])
+    node = rank // local_world_size
+
+    with open(os.path.join(save_dir, f'node_{node}_rank_{rank}.json'), 'w') as f:
+        json.dump(all_batch_info, f)
+
+def validate_batch_info(save_dir: str, expected_num_samples: int):
+    all_idxs = []
+
+    idxs_per_dp_rank = {}
+
+    for filepath in glob.glob(os.path.join(save_dir, f'node_*_rank_*.json')):
+        with open(filepath, 'r') as f:
+            data = json.load(f)
+            idxs_per_dp_rank.setdefault(data['data_parallel_rank'], []).append(data['idxs'])
+
+    # Check that all dp_ranks see the same indices
+
+    for dp_rank, idxs_list in idxs_per_dp_rank.items():
+        for i in range(len(idxs_list)):
+            for j in range(i + 1, len(idxs_list)):
+                if idxs_list[i] != idxs_list[j]:
+                    print(f'Error: Data parallel rank {dp_rank} has inconsistent indices across its ranks.\n', flush=True)
+                    return
+        all_idxs.extend(idxs_list[0])
+        
+                
+    print('All data parallel ranks have consistent indices across their ranks.\n', flush=True)
+
+
+    # Check for missing or duplicate indices
+    all_idxs_set = set(all_idxs)
+    if len(all_idxs) != expected_num_samples:
+        print(f'Error: Expected {expected_num_samples} samples, but got {len(all_idxs)} samples.\n', flush=True)
+    elif len(all_idxs_set) != expected_num_samples:
+        print(f'Error: Found duplicate indices in the collected samples.\n', flush=True)
+    else:
+        print('All samples unique and all the data is streamed correctly\n', flush=True)
+
+
+def is_dataset_built_on_rank():
+    """We define a simple policy here that only ranks with tp_rank == 0 will build the dataset. 
+    The corresponding Megatron function considers vp_stage and mtp_on_this_rank but for simplicity we ignore these in this demo.
+    """
+    return mpu.get_tensor_model_parallel_rank() == 0
+
+def _get_iterator(dataloader: Optional[MegatronStreamingDataLoader]) -> Optional[Iterable]:
+    if dataloader is None:
+        return None
+    else:
+        return iter(dataloader)
+    
+
+def build_train_valid_test_datasets(build_train_valid_test_datasets_provider: Callable):
+    return build_train_valid_test_datasets_provider()
+
+        
+def build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider: Callable):
+    args = get_args()
+
+    # We define a policy here that only ranks with tp_rank == 0 will build the dataset
+    if is_dataset_built_on_rank():
+        # Build datasets.
+        train_ds, _, _ = build_train_valid_test_datasets(
+            build_train_valid_test_datasets_provider)
+        return MegatronStreamingDataLoader(
+            train_ds,
+            batch_size=args.micro_batch_size,
+            num_workers=args.num_workers, 
+            pin_memory=True,
+            drop_last=True,
+            collate_fn=default_collate
+        ), None, None
+    else:
+        return None, None, None
+    
+def train_valid_test_datasets_provider():
+    remote_dir, local_dir = os.path.join(save_path, 'remote'), os.path.join(save_path, 'local')
+
+    args = get_args()
+
+    dataset = MegatronStreamingDataset(
+        local=local_dir,
+        remote=remote_dir,
+        shuffle=True,
+        num_canonical_nodes=1,
+        batch_size=args.micro_batch_size,
+    )
+
+    return dataset, None, None
+
+    
+def build_train_valid_test_data_iterators(build_train_valid_test_datasets_provider: Callable):
+    train_dataloader, valid_dataloader, test_dataloader = build_train_valid_test_data_loaders(build_train_valid_test_datasets_provider)
+    train_data_iterator = _get_iterator(train_dataloader)
+    valid_data_iterator = _get_iterator(valid_dataloader)
+    test_data_iterator = _get_iterator(test_dataloader)
+    return train_data_iterator, valid_data_iterator, test_data_iterator
+
+
+def iterate_dataset(
+    train_valid_test_dataset_provider: Callable,
+    get_batch: Callable,
+    is_dataset_built_on_rank_func: Callable,
+    args_defaults: Dict[str, Any]={},
+
+):
+    """Data iteration loop.
+
+    This function will run the followings in the order provided:
+        1) initialize Megatron.
+        3) call train_val_test_data_provider to get train/val/test datasets.
+        4) Iterate train data.
+
+    Args:
+        train_valid_test_dataset_provider: a function that returns the
+            train/valid/test dataset and returns `train, valid, test` datasets.
+        is_dataset_built_on_rank_func: a function that returns True if dataset is built on a rank and False otherwise
+    """
+
+    assert is_dataset_built_on_rank_func is not None, \
+        "is_dataset_built_on_rank_func must be provided to iterate_data."
+    
+    # Initalize and get arguments, timers, and Tensorboard writer.
+    initialize_megatron(
+        args_defaults=args_defaults,
+    )
+
+    global save_path
+
+    remote_dir = os.path.join(save_path, 'remote')
+
+    if torch.distributed.get_rank() == 0:
+        if os.path.exists(save_path):
+            shutil.rmtree(save_path)
+            print(f"Directory '{save_path}' has been removed.")
+        else:
+            print(f"Directory '{save_path}' does not exist or is not a directory.")
+            
+        os.makedirs(save_path)
+        
+        convert_to_mds(out_root=remote_dir,
+                    dataset_name='sequencedatasetint',
+                    num_samples=1024,
+                    size_limit=1 << 8)
+    
+    torch.distributed.barrier()
+
+    args = get_args()
+
+
+    print_rank_0(f"Starting job with local world size: {os.environ['LOCAL_WORLD_SIZE']}")
+
+    # Essential to call this function, which initializes all the info that StreamingDataset needs to know about the Megatron parallel environment (e.g. which ranks build the dataset, how to share data across ranks, etc.)
+    build_dataset_builder_ranks_by_node(is_dataset_built_on_rank_func)
+
+
+    iter = 0
+
+    train_data_iterator, _, _  = build_train_valid_test_data_iterators(train_valid_test_dataset_provider)
+
+    print_freq = 10
+
+    while iter < args.train_iters:
+        batch = get_batch(train_data_iterator)
+        if batch is None:
+            break
+        iter += 1
+        if iter % print_freq == 0:
+            print(f'Processing batch {iter} on rank {torch.distributed.get_rank()} with keys: {list(batch.keys())}\n', flush=True)
+
+        update_all_batch_info(batch)
+
+    print(f'Finished iterating through data on rank {torch.distributed.get_rank()}. Saving batch info...', flush=True)
+    save_batch_info(save_path)
+
+    torch.distributed.barrier()
+    validate_batch_info(save_path, expected_num_samples=args.micro_batch_size * mpu.get_data_parallel_world_size() * iter)
+
+    torch.distributed.destroy_process_group()
+
+def get_batch_on_this_cp_rank(batch: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """In a real implementation with token sequences, we would slice batch input along sequence dimension into multiple chunks,
+        which are parallelized across GPUs in a context parallel group.
+    """
+    return batch
+
+def get_batch_on_this_tp_rank(data_iterator: Iterable) -> Optional[Dict[str, Any]]:
+    """Broadcast from tp_rank=0 to other ranks in the same tp group"""
+    args = get_args()
+
+    device = torch.cuda.current_device()
+    tp_group = mpu.get_tensor_model_parallel_group()
+    tp_rank = mpu.get_tensor_model_parallel_rank()
+    tp_src = mpu.get_tensor_model_parallel_src_rank()
+
+    mbs = args.micro_batch_size
+
+    # ------------------------------------------------------------------
+    # 1. Pre-allocate tensors on ALL TP ranks (fixed shapes)
+    # ------------------------------------------------------------------
+    batch = {
+        "idx": torch.empty((mbs,), dtype=torch.int64, device=device),
+    }
+
+    # Scalar "is valid batch" flag
+    flag = torch.zeros((), dtype=torch.int8, device=device)
+
+    # ------------------------------------------------------------------
+    # 2. Only TP src rank touches the iterator
+    # ------------------------------------------------------------------
+    if tp_rank == 0:
+        try:
+            src_batch = next(data_iterator)
+            flag.fill_(1)
+            actual_bs = src_batch["idx"].shape[0]
+
+            # ------------------------------------------------------------------------------------
+            # 2a. Pad last batch if needed. This can be avoided with drop_last=True in DataLoader
+            # ------------------------------------------------------------------------------------
+            if actual_bs < mbs:
+                pad = mbs - actual_bs
+                for k, v in src_batch.items():
+                    pad_shape = (pad, *v.shape[1:])
+                    pad_tensor = torch.zeros(
+                        pad_shape, dtype=v.dtype, device=v.device
+                    )
+                    src_batch[k] = torch.cat([v, pad_tensor], dim=0)
+
+            # ----------------------------------------------------------
+            # 2b. Copy into fixed-shape buffers
+            # ----------------------------------------------------------
+            for k in batch:
+                batch[k].copy_(src_batch[k], non_blocking=True)
+
+        except StopIteration:
+            flag.fill_(0)
+
+    # ------------------------------------------------------------------
+    # 3. Broadcast flag (ALWAYS)
+    # ------------------------------------------------------------------
+    torch.distributed.broadcast(flag, tp_src, group=tp_group)
+
+    # ------------------------------------------------------------------
+    # 4. Broadcast tensors (ALWAYS, even if flag == 0)
+    # In PP/VP the broadcast depends on PP/VP stage but we do not worry about such oprimizations here
+    # ------------------------------------------------------------------
+    for v in batch.values():
+        torch.distributed.broadcast(v, tp_src, group=tp_group)
+
+    # ------------------------------------------------------------------
+    # 5. Consume flag
+    # ------------------------------------------------------------------
+    if flag.item() == 0:
+        return None
+
+    return batch
+
+
+def get_batch(data_iterator: Optional[Iterable]) -> Optional[Dict[str, Any]]:
+    """Generate a batch."""
+    # get batches based on the TP rank you are on
+    batch = get_batch_on_this_tp_rank(data_iterator)
+
+    # slice batch along sequence dimension for context parallelism
+    batch = get_batch_on_this_cp_rank(batch)
+
+    return batch
+
+if __name__ == "__main__":
+    iterate_dataset(train_valid_test_dataset_provider=train_valid_test_datasets_provider, 
+                    get_batch=get_batch, 
+                    is_dataset_built_on_rank_func=is_dataset_built_on_rank,
+                )

--- a/streaming/base/megatron_dataset_utils.py
+++ b/streaming/base/megatron_dataset_utils.py
@@ -1,0 +1,138 @@
+from dataclasses import dataclass
+import os
+from typing import Callable
+import torch
+import torch.distributed as dist
+from megatron.core import mpu
+
+_DATASET_BUILDER_RANKS_BY_NODE = None
+_DATASET_BUILDING_GROUP = None
+
+@dataclass(frozen=True)
+class ParallelRankInfo:
+    rank: int   
+    tensor_model_parallel_rank: int
+    context_parallel_rank: int
+    pipeline_model_parallel_rank: int
+    expert_parallel_rank: int
+    data_parallel_rank: int
+
+def get_parallel_rank_info():
+    return ParallelRankInfo(
+        rank=torch.distributed.get_rank(),
+        tensor_model_parallel_rank=mpu.get_tensor_model_parallel_rank(),
+        context_parallel_rank=mpu.get_context_parallel_rank(),
+        pipeline_model_parallel_rank=mpu.get_pipeline_model_parallel_rank(),
+        expert_parallel_rank=mpu.get_expert_model_parallel_rank(),
+        data_parallel_rank=mpu.get_data_parallel_rank(),
+    )
+
+def build_dataset_builder_ranks_by_node(is_dataset_built_on_rank_func: Callable):
+    """
+    Returns:
+        dict[int, list[tuple]]:
+            {
+              node_id: [
+                (global_rank, tp_rank, cp_rank, pp_rank, ep_rank, dp_rank),
+                ...
+              ],
+              ...
+            }
+    Only includes ranks for which is_dataset_built_on_rank_func() == True.
+    """
+
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_world_size = int(os.environ["LOCAL_WORLD_SIZE"])
+    node_id = rank // local_world_size
+
+    tp_rank = mpu.get_tensor_model_parallel_rank()
+    cp_rank = mpu.get_context_parallel_rank()
+    pp_rank = mpu.get_pipeline_model_parallel_rank()
+    ep_rank = mpu.get_expert_model_parallel_rank()
+    dp_rank = mpu.get_data_parallel_rank()
+
+    builds_dataset = is_dataset_built_on_rank_func()
+
+    local_payload = torch.tensor(
+        [
+            node_id, 
+            rank,
+            tp_rank,
+            cp_rank,
+            pp_rank,
+            ep_rank,
+            dp_rank,
+            int(builds_dataset),
+        ],
+        device="cuda",
+        dtype=torch.int64,
+    )
+
+    gathered = [
+        torch.empty_like(local_payload) for _ in range(world_size)
+    ]
+    dist.all_gather(gathered, local_payload)
+
+    dataset_building_group = []
+
+    result = {}
+
+    for entry in gathered:
+        (
+            entry_node_id,
+            entry_rank,
+            entry_tp,
+            entry_cp,
+            entry_pp,
+            entry_ep,
+            entry_dp,
+            entry_builds,
+        ) = entry.tolist()
+
+        if not entry_builds:
+            continue
+    
+        dataset_building_group.append(entry_rank)
+
+        result.setdefault(entry_node_id, []).append(
+            (entry_rank, entry_tp, entry_cp, entry_pp, entry_ep, entry_dp)
+        )
+
+    p_results = {}
+    for node_id, rank_tuples in result.items():
+        p_results[node_id] = {
+            ParallelRankInfo(
+                rank=r,
+                tensor_model_parallel_rank=tp,
+                context_parallel_rank=cp,
+                pipeline_model_parallel_rank=pp,
+                expert_parallel_rank=ep,
+                data_parallel_rank=dp,
+            ) : i
+            for i, (r, tp, cp, pp, ep, dp) in enumerate(rank_tuples)
+        }
+
+    global _DATASET_BUILDER_RANKS_BY_NODE
+    _DATASET_BUILDER_RANKS_BY_NODE = p_results
+
+    global _DATASET_BUILDING_GROUP
+    _DATASET_BUILDING_GROUP = dist.new_group(ranks=dataset_building_group)
+
+    print(f'dataset_building_ranks: {dataset_building_group}\n', flush=True)
+
+
+
+    print(f"Built dataset builder ranks by node: {_DATASET_BUILDER_RANKS_BY_NODE}\n", flush=True)
+
+def get_dataset_builder_ranks_by_node():
+    if _DATASET_BUILDER_RANKS_BY_NODE is None:
+        raise ValueError("Dataset builder ranks by node not built yet. Call build_dataset_builder_ranks_by_node() first.")
+    
+    return _DATASET_BUILDER_RANKS_BY_NODE
+
+def get_dataset_building_group():
+    if _DATASET_BUILDING_GROUP is None:
+        raise ValueError("Dataset building group not built yet. Call build_dataset_builder_ranks_by_node() first.")
+    
+    return _DATASET_BUILDING_GROUP

--- a/streaming/base/shared/prefix.py
+++ b/streaming/base/shared/prefix.py
@@ -216,7 +216,6 @@ def get_shm_prefix(streams_local: list[str],
         for shm_name in SHM_TO_CLEAN
     ])
 
-    print(f'barrier\n', flush=True)
     barrier()
 
     # First, the local leader registers the first available shm prefix, recording its locals.

--- a/streaming/base/shared/prefix.py
+++ b/streaming/base/shared/prefix.py
@@ -14,12 +14,12 @@ from time import sleep
 from typing import Iterator, Union
 
 import numpy as np
-from torch import distributed as dist
 
 from streaming.base.constant import BARRIER_FILELOCK, CACHE_FILELOCK, LOCALS, SHM_TO_CLEAN, TICK
 from streaming.base.shared import SharedMemory
 from streaming.base.util import retry as retry_decorator
 from streaming.base.world import World
+from streaming.base.distributed import barrier
 
 
 def _each_prefix_int() -> Iterator[int]:
@@ -216,8 +216,8 @@ def get_shm_prefix(streams_local: list[str],
         for shm_name in SHM_TO_CLEAN
     ])
 
-    if dist.is_available() and dist.is_initialized():
-        dist.barrier()
+    print(f'barrier\n', flush=True)
+    barrier()
 
     # First, the local leader registers the first available shm prefix, recording its locals.
     if world.is_local_leader:
@@ -226,8 +226,7 @@ def get_shm_prefix(streams_local: list[str],
         shm = SharedMemory(name, True, len(data))
         shm.buf[:len(data)] = data
 
-    if dist.is_available() and dist.is_initialized():
-        dist.barrier()
+    barrier()
 
     # Non-local leaders go next, searching for match.
     if not world.is_local_leader:

--- a/streaming/base/util.py
+++ b/streaming/base/util.py
@@ -21,7 +21,7 @@ from typing import Any, Callable, Optional, Sequence, TypeVar, Union, cast, over
 import torch.distributed as dist
 
 from streaming.base.constant import SHM_TO_CLEAN
-from streaming.base.distributed import get_local_rank, maybe_init_dist
+from streaming.base.distributed import get_local_rank, maybe_init_dist, barrier
 from streaming.base.format.index import get_index_basename
 
 logger = logging.getLogger(__name__)
@@ -198,8 +198,7 @@ def clean_stale_shared_memory() -> None:
                 break
 
     # Sync all ranks
-    if dist.is_available() and dist.is_initialized():
-        dist.barrier()
+    barrier()
 
     # Delete the process group if Streaming initialized it.
     if destroy_dist:

--- a/tests/common/datasets.py
+++ b/tests/common/datasets.py
@@ -61,6 +61,29 @@ class SequenceDataset:
         sample[self.column_names[1]] = np.int64(sample[self.column_names[1]]).tobytes()
         return sample
 
+class SequenceDatasetInt(SequenceDataset):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.column_encodings = ['int', 'int']
+        self.column_names = ['idx', 'sample']
+        self.column_sizes = [8, 8]
+
+    def __next__(self) -> dict[str, Any]:
+        if self._index >= self.size:
+            raise StopIteration
+        id = self._index
+        data = (3 * self._index) + self.offset
+        self._index += 1
+        return {
+            self.column_names[0]: id,
+            self.column_names[1]: data,
+        }
+
+    def get_sample_in_bytes(self, index: int) -> dict[str, Any]:
+        sample = self.__getitem__(index)
+        sample[self.column_names[0]] = sample[self.column_names[0]].tobytes()
+        sample[self.column_names[1]] = np.int64(sample[self.column_names[1]]).tobytes()
+        return sample
 
 class NumberAndSayDataset:
     """Generate a synthetic number-saying dataset, i.e. converting a numbers from digits to words,

--- a/tests/common/utils.py
+++ b/tests/common/utils.py
@@ -12,7 +12,7 @@ import pytest
 
 from streaming import MDSWriter
 
-from .datasets import NumberAndSayDataset, SequenceDataset
+from .datasets import NumberAndSayDataset, SequenceDataset, SequenceDatasetInt
 
 
 @pytest.fixture(scope='function')
@@ -45,6 +45,7 @@ def convert_to_mds(**kwargs: Any):
     dataset_mapping = {
         'sequencedataset': SequenceDataset,
         'numberandsaydataset': NumberAndSayDataset,
+        'sequencedatasetint': SequenceDatasetInt
     }
     dataset_name = kwargs['dataset_name'].lower()
     out_root = kwargs['out_root']


### PR DESCRIPTION
## Description of changes

PR that addresses this issue #827 and #397 more generally for Megatron and also a framework for arbitrary N-D parallelisms


**At a very high level `StreamingDataset` with multiple workers via `StreamingDataloader`:**

1. Assumes all ranks in a multinode-multigpu setup need to iterate through a potentially remote data stream
2. Sets up a local leader per node to handle downloading index.json and setting up resources like shms. This is the essence of unique_rank_world and unique_worker world for the single worker and multiworker case respectively. 
3. During initialization i.e when `StreamingDataset.__init__` is called `dist.barrier()` is used for synchronization
4. At the beginning of `StreamingDataset.__iter__` parallel_worker_world is set up based on `parallel_rank world` and `num_workers` to determine how the data stream is sharded among dataloader workers

The above setup is valid for data parallelisms like vanilla DP, Zero, FSDP, HSDP etc.

Now two assumptions in the above setup can break down for general N-D parallelisms. These are:

1. All ranks participate in dataloader instantiation and iteration
2. All ranks iterate through different shards of the data stream

Without loss of generality we can assume that a rank initializes the dataloader iff it also iterates through it.

The `replicate` argument is an attempt to address issue 2, however it is not general enough since it assumes contiguous gpus stream the same data shards in the same order.

A bigger issue is that replicate does not address issue 1 since vanilla `dist.barrier()` waits for all ranks. 

**The solutions to the above issues:**

1. Let the distrubuted trainer supply a policy of which ranks actually need to instantiate the dataloader. Let's call the corresponding process group of such ranks the `dl_group`,
then we construct the `unique_rank_world` based on this info, assigning one process in the `dl_group` per node to be a local leader and replace all `dist.barrier()` calls with
`dist.barrier(dl_group)`

2. For each rank in the dl_group we use only the `dp_rank` and `dp_world_size` to construct the `parallel_rank_world`


In some cases the N-D parallelism policy might also require that certain ranks iterate through multiple copies of identical data streams, for example
in virtual pipeline parallelism in Megatron. In this case the training code can simply instantiate multiple StreamingDataset instances with identical arguments
but with different local_caches. Ditto `StreamingDataloader `instances.

**Tests**

Currently model independent demo and tests is in `megatron_dataset_demo.py` and can be ran with torchrun in a single-node or multi-node setting. This requires installing Megatron-LM.