### PR TITLE
Fix merge_index dropping nested directories from shard paths

### DIFF
--- a/streaming/base/util.py
+++ b/streaming/base/util.py
@@ -327,12 +327,16 @@ def _merge_index_from_list(index_file_urls: Sequence[Union[str, tuple[str, str]]
             if not os.path.exists(dest):
                 raise FileNotFoundError(f'Index file {dest} does not exist or not accessible.')
 
-            partitions.append(dest)
+            partitions.append((dest, _get_partition_dirname(url, out)))
 
         # merge shards from all index files
         shards = []
-        for partition_index in partitions:
+        for partition_index, partition_dirname in partitions:
             p = Path(partition_index)
+            if partition_dirname is None:
+                # The partition does not reside under ``out``, so its path relative to ``out``
+                # cannot be determined. Fall back to the partition's parent directory name.
+                partition_dirname = os.path.basename(p.parent)
             obj = json.load(open(partition_index))
             for i in range(len(obj['shards'])):
                 shard = obj['shards'][i]
@@ -340,7 +344,7 @@ def _merge_index_from_list(index_file_urls: Sequence[Union[str, tuple[str, str]]
                     if shard.get(key):
                         basename = shard[key]['basename']
                         obj['shards'][i][key]['basename'] = os.path.join(
-                            os.path.basename(p.parent), basename)
+                            partition_dirname, basename)
             shards += obj['shards']
 
         # Save merged index locally
@@ -361,6 +365,46 @@ def _merge_index_from_list(index_file_urls: Sequence[Union[str, tuple[str, str]]
         # Clean up
         if not keep_local:
             shutil.rmtree(cu.local, ignore_errors=True)
+
+
+def _get_partition_dirname(index_file_url: Union[str, tuple[str, str]],
+                           out: Union[str, tuple[str, str]]) -> Optional[str]:
+    """Get the directory of a partition index file relative to the merge root ``out``.
+
+    Args:
+        index_file_url (Union[str, Tuple[str,str]]): a partition index file url, either a single
+            path string or a (local, remote) tuple.
+        out (Union[str, Tuple[str,str]]): the merge root, either a single path string or a
+            (local, remote) tuple.
+
+    Returns:
+        Optional[str]: the partition directory relative to ``out``, e.g. ``group1/subdir2`` for
+            an index file at ``<out>/group1/subdir2/index.json``. ``None`` if the partition does
+            not reside under ``out``.
+    """
+    urls = index_file_url if isinstance(index_file_url, tuple) else (index_file_url,)
+    roots = out if isinstance(out, tuple) else (out,)
+    for url in urls:
+        url_obj = urllib.parse.urlparse(url)
+        for root in roots:
+            root_obj = urllib.parse.urlparse(root)
+            # Only compare urls that live in the same place, e.g. the same bucket or the local
+            # filesystem.
+            if (url_obj.scheme, url_obj.netloc) != (root_obj.scheme, root_obj.netloc):
+                continue
+            root_path = root_obj.path
+            if root_obj.scheme and not root_path:
+                root_path = '/'
+            try:
+                rel = os.path.relpath(os.path.dirname(url_obj.path), root_path)
+            except ValueError:
+                continue
+            if rel == os.curdir:
+                # The partition index sits directly at the root, so do not prefix basenames.
+                return ''
+            if rel != os.pardir and not rel.startswith(os.pardir + os.sep):
+                return rel
+    return None
 
 
 def _not_merged_index(index_file_path: str, out: str):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -199,6 +199,64 @@ def test_format_remote_index_files(scheme: str):
         assert obj.scheme == scheme
 
 
+@pytest.mark.parametrize(('index_file_url', 'out', 'expected'), [
+    ('/foo/group1/subdir2/index.json', '/foo', os.path.join('group1', 'subdir2')),
+    ('/foo/subdir1/index.json', '/foo', 'subdir1'),
+    ('/foo/index.json', '/foo', ''),
+    ('/elsewhere/subdir1/index.json', '/foo', None),
+    ('s3://bucket/foo/group1/subdir2/index.json', 's3://bucket/foo',
+     os.path.join('group1', 'subdir2')),
+    ('s3://bucket/foo/subdir1/index.json', 's3://bucket', os.path.join('foo', 'subdir1')),
+    ('s3://bucket/foo/subdir1/index.json', 'gs://bucket/foo', None),
+    ('s3://other/foo/subdir1/index.json', 's3://bucket/foo', None),
+    (('/foo/subdir1/index.json', 's3://bucket/foo/subdir1/index.json'),
+     ('/foo', 's3://bucket/foo'), 'subdir1'),
+    (('/elsewhere/subdir1/index.json', 's3://bucket/foo/group1/subdir1/index.json'),
+     's3://bucket/foo', os.path.join('group1', 'subdir1')),
+])
+def test_get_partition_dirname(index_file_url: Union[str, tuple[str, str]],
+                               out: Union[str, tuple[str, str]], expected: Optional[str]):
+    """Validate partition directories are resolved relative to the merge root."""
+    from streaming.base.util import _get_partition_dirname
+
+    assert _get_partition_dirname(index_file_url, out) == expected
+
+
+@pytest.mark.parametrize('keep_local', [True, False])
+def test_merge_index_from_root_local_nested(local_remote_dir: tuple[str, str], keep_local: bool):
+    """Validate the merged index keeps full relative paths for nested partitions."""
+    from streaming import MDSWriter, StreamingDataset
+
+    out, _ = local_remote_dir
+    n_samples = 0
+    for group in ('group1', 'group2'):
+        for subdir in ('subdir1', 'subdir2'):
+            with MDSWriter(out=os.path.join(out, group, subdir),
+                           columns={'id': 'int'},
+                           keep_local=True) as writer:
+                for _ in range(3):
+                    writer.write({'id': n_samples})
+                    n_samples += 1
+
+    merge_index(out, keep_local=keep_local)
+    integrity_check(out, keep_local=keep_local, expected_n_shard_files=4)
+
+    if not keep_local:
+        return
+
+    merged_index = json.load(open(os.path.join(out, 'index.json')))
+    basenames = sorted(shard['raw_data']['basename'] for shard in merged_index['shards'])
+    assert basenames == [
+        os.path.join('group1', 'subdir1', 'shard.00000.mds'),
+        os.path.join('group1', 'subdir2', 'shard.00000.mds'),
+        os.path.join('group2', 'subdir1', 'shard.00000.mds'),
+        os.path.join('group2', 'subdir2', 'shard.00000.mds'),
+    ]
+
+    dataset = StreamingDataset(local=out, batch_size=1)
+    assert sorted(sample['id'] for sample in dataset) == list(range(n_samples))
+
+
 @pytest.mark.parametrize('index_file_urls_pattern', [1, 2, 3])
 @pytest.mark.parametrize('keep_local', [True, False])
 @pytest.mark.parametrize('scheme', ['gs://', 's3://', 'oci://'])


### PR DESCRIPTION
## Description of changes:

`merge_index` drops intermediate directories from shard paths in the merged `index.json` when
partitions are nested more than one level under the root. Root cause: `_merge_index_from_list`
(`streaming/base/util.py`) rebuilds each merged basename as
`os.path.join(os.path.basename(p.parent), basename)` — exactly one directory level of the
partition index's path — so anything between the merge root and the partition is silently
dropped.

This PR resolves each partition's directory relative to the merge root instead, via a new
`_get_partition_dirname` helper that compares the partition index url against `out` (local part
against local root, remote against remote, same bucket only) and takes `os.path.relpath` on the
url paths. Partitions that don't reside under `out` (arbitrary `index_file_urls`) fall back to
the previous single-level behavior, so existing one-level layouts are unaffected.

Testing:
- New `test_merge_index_from_root_local_nested` writes 4 MDS partitions at
  `out/group{1,2}/subdir{1,2}`, merges, and asserts the merged basenames keep the full relative
  paths and that a `StreamingDataset` on the merged root iterates all samples. It fails on main
  ("expected 4 shard files but got 2") and passes with this change.
- New `test_get_partition_dirname` covers local, remote, tuple, root-level, cross-bucket, and
  outside-root fallback cases.
- All pre-existing `tests/test_util.py` tests (incl. the spark-based
  `test_merge_index_from_list_local` / `test_merge_index_from_root_local` matrices) and
  `tests/base/converters/test_dataframe_to_mds.py` pass locally.

## Issue #, if available:

- Fixes #959

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.
