### PR TITLE
Fix dataframe_to_mds for non-nullable ArrayType columns

### DIFF
--- a/streaming/base/converters/dataframe_to_mds.py
+++ b/streaming/base/converters/dataframe_to_mds.py
@@ -108,6 +108,10 @@ def infer_dataframe_schema(dataframe: DataFrame,
         """
         if issubclass(type(spark_data_type), DecimalType):
             mds_type = SPARK_TO_MDS.get(DecimalType(), None)
+        elif isinstance(spark_data_type, ArrayType):
+            # Look up arrays by element type only, since ArrayType equality includes
+            # ``containsNull`` but the MDS encoding does not depend on it.
+            mds_type = SPARK_TO_MDS.get(ArrayType(spark_data_type.elementType), None)
         else:
             mds_type = SPARK_TO_MDS.get(spark_data_type, None)
 

--- a/tests/base/converters/test_dataframe_to_mds.py
+++ b/tests/base/converters/test_dataframe_to_mds.py
@@ -104,6 +104,20 @@ class TestDataFrameToMDS:
         df = spark.createDataFrame(data=data, schema=schema).repartition(3)
         yield df
 
+    @pytest.fixture
+    def non_nullable_array_dataframe(self):
+        spark = SparkSession.builder.getOrCreate()  # pyright: ignore
+
+        data = [([1.0, 2.0, 3.0],), ([4.0, 5.0, 6.0],), ([7.0, 8.0, 9.0],)]
+
+        # Spark marks array columns built from non-null inputs (e.g. ``array`` or ``concat`` of
+        # non-nullable columns) with ``containsNull=False``.
+        schema = StructType(
+            [StructField('vals', ArrayType(DoubleType(), containsNull=False), True)])
+
+        df = spark.createDataFrame(data=data, schema=schema).repartition(3)
+        yield df
+
     @pytest.mark.parametrize('keep_local', [True, False])
     @pytest.mark.parametrize('merge_index', [True, False])
     def test_end_to_end_conversion_local_nocolumns(self, dataframe: Any, keep_local: bool,
@@ -318,6 +332,26 @@ class TestDataFrameToMDS:
         else:
             assert not os.path.exists(os.path.join(
                 out, 'index.json')), 'merged index is created when merge_index=False'
+
+    def test_non_nullable_array_type_mapping(self, non_nullable_array_dataframe: Any):
+        assert infer_dataframe_schema(non_nullable_array_dataframe) == {'vals': 'ndarray:float64'}
+
+    @pytest.mark.parametrize('use_columns', [True, False])
+    def test_non_nullable_array_end_to_end_conversion_local(self,
+                                                            non_nullable_array_dataframe: Any,
+                                                            use_columns: bool,
+                                                            local_remote_dir: tuple[str, str]):
+        out, _ = local_remote_dir
+        mds_kwargs: dict[str, Any] = {'out': out, 'keep_local': True}
+
+        if use_columns:
+            mds_kwargs['columns'] = {'vals': 'ndarray:float64'}
+
+        _ = dataframe_to_mds(non_nullable_array_dataframe, merge_index=True, mds_kwargs=mds_kwargs)
+
+        assert os.path.exists(os.path.join(out, 'index.json')), 'No merged index.json found'
+        mgi = json.load(open(os.path.join(out, 'index.json'), 'r'))
+        assert sum([a['samples'] for a in mgi['shards']]) == 3
 
     def test_array_udf_correct_columns(self,
                                        array_dataframe: Any,


### PR DESCRIPTION
## Description of changes:

`dataframe_to_mds` rejects array columns declared with `containsNull=False`, as reported in the issue.

This PR implements the element-type lookup suggested there: `map_spark_dtype` now normalizes arrays to `ArrayType(elementType)` before the `SPARK_TO_MDS` lookup, mirroring the existing `DecimalType` normalization directly above. Both call sites are covered (user-defined-columns validation and automatic schema inference), and the change is safe because the MDS `ndarray:*` encodings don't depend on array nullability.

Added regression tests: schema inference on a `containsNull=False` array column, plus end-to-end conversion with both auto-inferred and user-defined columns. They fail without the source change; with it, `tests/base/converters/test_dataframe_to_mds.py` passes locally (24 passed).

## Issue #, if available:

- Fixes #870

## Merge Checklist:
_Put an `x` without space in the boxes that apply. If you are unsure about any checklist, please don't hesitate to ask. We are here to help! This is simply a reminder of what we are going to look for before merging your pull request._

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [x] I ran `pre-commit` on my change. (check out the `pre-commit` section of [prerequisites](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#prerequisites))
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass. (check out [testing](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md#submitting-a-contribution))
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.

<sub>Authored with the help of Claude Code.</sub>
