### PR TITLE
Fix Windows drive-letter paths misparsed as cloud schemes

### DIFF
--- a/streaming/base/storage/upload.py
+++ b/streaming/base/storage/upload.py
@@ -48,6 +48,26 @@ UPLOADERS = {
 }
 
 
+def _provider_prefix(uri: str) -> str:
+    """Return the cloud provider scheme for ``uri``, or ``''`` for local paths.
+
+    ``urllib.parse.urlparse`` treats Windows drive letters as URL schemes
+    (``D:/path`` → ``scheme='d'``). Those are local filesystem paths, not cloud
+    providers, so map single alphabetic schemes to the local uploader.
+    """
+    obj = urllib.parse.urlparse(uri)
+    scheme = obj.scheme
+    if len(scheme) == 1 and scheme.isalpha():
+        return ''
+    if scheme == 'dbfs':
+        path = pathlib.Path(uri)
+        if len(path.parts) >= 2:
+            prefix = os.path.join(path.parts[0], path.parts[1])
+            if prefix == 'dbfs:/Volumes':
+                return prefix
+    return scheme
+
+
 class GCSAuthentication(Enum):
     HMAC = 1
     SERVICE_ACCOUNT = 2
@@ -86,13 +106,7 @@ class CloudUploader:
             CloudUploader: An instance of sub-class.
         """
         cls._validate(cls, out)
-        obj = urllib.parse.urlparse(out) if isinstance(out, str) else urllib.parse.urlparse(out[1])
-        provider_prefix = obj.scheme
-        if obj.scheme == 'dbfs':
-            path = pathlib.Path(out) if isinstance(out, str) else pathlib.Path(out[1])
-            prefix = os.path.join(path.parts[0], path.parts[1])
-            if prefix == 'dbfs:/Volumes':
-                provider_prefix = prefix
+        provider_prefix = _provider_prefix(out if isinstance(out, str) else out[1])
         return getattr(sys.modules[__name__],
                        UPLOADERS[provider_prefix])(out, keep_local, progress_bar, retry, exist_ok)
 
@@ -114,15 +128,15 @@ class CloudUploader:
             ValueError: Invalid Cloud provider prefix.
         """
         if isinstance(out, str):
-            obj = urllib.parse.urlparse(out)
+            provider_prefix = _provider_prefix(out)
         else:
             if len(out) != 2:
                 raise ValueError(f'Invalid `out` argument. It is either a string of ' +
                                  f'local/remote directory or a list of two strings with ' +
                                  f'[local, remote].')
-            obj = urllib.parse.urlparse(out[1])
-        if obj.scheme not in UPLOADERS:
-            raise ValueError(f'Invalid Cloud provider prefix: {obj.scheme}.')
+            provider_prefix = _provider_prefix(out[1])
+        if provider_prefix not in UPLOADERS:
+            raise ValueError(f'Invalid Cloud provider prefix: {provider_prefix}.')
 
     def __init__(self,
                  out: Union[str, tuple[str, str]],
@@ -158,8 +172,8 @@ class CloudUploader:
         self.retry = retry
 
         if isinstance(out, str):
-            # It is a remote directory
-            if urllib.parse.urlparse(out).scheme != '':
+            # It is a remote directory (cloud scheme). Windows drive letters are local.
+            if _provider_prefix(out) != '':
                 self.local = mkdtemp()
                 self.remote = out
             # It is a local directory

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -49,6 +49,9 @@ class TestCloudUploader:
             [None, 'gs://bucket/dir/file', GCSUploader],
             ['/tmp/dir/filepath', LocalUploader],
             ['./relative/dir/filepath', LocalUploader],
+            # Windows absolute paths parse as scheme='d' / 'c' — must stay local (#960).
+            ['D:/datasets/train', LocalUploader],
+            ['C:/Users/data/out', LocalUploader],
         ],
     )
     @pytest.mark.usefixtures('gcs_hmac_credentials')
@@ -69,6 +72,20 @@ class TestCloudUploader:
             out_root = (mapping[0], mapping[1])
             cw = CloudUploader.get(out_root)
         assert isinstance(cw, mapping[-1])
+
+    def test_windows_drive_letter_not_cloud_scheme(self, tmp_path: Any):
+        """MDSWriter-style absolute Windows paths must not raise Invalid Cloud provider (#960)."""
+        from streaming.base.storage.upload import _provider_prefix
+        assert _provider_prefix('D:/test') == ''
+        assert _provider_prefix('C:\\train\\out') == ''
+        assert _provider_prefix('s3://bucket/key') == 's3'
+        assert _provider_prefix('/unix/abs') == ''
+        # Instantiation uses a real temp dir so LocalUploader can mkdir.
+        win_style = str(tmp_path / 'win_out')
+        # Simulate urlparse drive-letter behavior without requiring Windows.
+        with patch('streaming.base.storage.upload._provider_prefix', return_value=''):
+            cw = CloudUploader.get(out=win_style)
+        assert isinstance(cw, LocalUploader)
 
     @pytest.mark.parametrize('out', [(), ('s3://bucket/dir',), ('./dir1', './dir2', './dir3')])
     def test_invalid_out_parameter_length(self, out: Any):


### PR DESCRIPTION
## Description of changes:

On Windows, absolute paths like `D:/test` are rejected by `CloudUploader` with `ValueError: Invalid Cloud provider prefix: d.` because `urllib.parse.urlparse` treats the drive letter as a URL scheme (`scheme='d'`). That breaks `MDSWriter(out=r'D:/...')` (issue #960).

Root cause: `CloudUploader.get` / `_validate` / `__init__` used `urlparse(...).scheme` directly and looked it up in `UPLOADERS`.

This PR adds `_provider_prefix(uri)` which:
- maps single alphabetic schemes (Windows drive letters) to `''` → `LocalUploader`
- preserves existing `dbfs:/Volumes` handling
- leaves real cloud schemes (`s3`, `gs`, …) unchanged

`get`, `_validate`, and `__init__` all use the helper so drive-letter paths are not treated as remote.

Testing:
- Extended `test_instantiation_type` with `D:/...` and `C:/...` local cases
- New `test_windows_drive_letter_not_cloud_scheme` asserts `_provider_prefix` behavior + LocalUploader instantiation
- `pytest -vv tests/test_upload.py::TestCloudUploader --no-cov` — 9 related tests passed locally

## Issue #, if available:

- Fixes #960

## Merge Checklist:

### General
- [x] I have read the [contributor guidelines](https://github.com/mosaicml/streaming/blob/main/CONTRIBUTING.md)
- [ ] This is a documentation change or typo fix. If so, skip the rest of this checklist.
- [x] I certify that the changes I am introducing will be backward compatible, and I have discussed concerns about this, if any, with the MosaicML team.
- [ ] I have updated any necessary documentation, including [README](https://github.com/mosaicml/streaming/blob/main/README.md) and [API docs](https://github.com/mosaicml/streaming/tree/main/docs) (if appropriate).

### Tests
- [ ] I ran `pre-commit` on my change.
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate).
- [x] I ran the tests locally to make sure it pass.
- [x] I have added unit and/or integration tests as appropriate to ensure backward compatibility of the changes.